### PR TITLE
chore(slo-tla): populate tools.toml SHA-256

### DIFF
--- a/skills/slo-tla/tools.toml
+++ b/skills/slo-tla/tools.toml
@@ -16,11 +16,11 @@
 [tlc]
 version = "1.8.0"
 url = "https://github.com/tlaplus/tlaplus/releases/download/v1.8.0/tla2tools.jar"
-sha256 = "UNSET"
+sha256 = "d5d07d5dab38ddb840c91ec48fa02f28b37a608d5af9a73570018591dbc8ef7f"
 
 # Apalache is fetched lazily only when TLC reports state explosion.
 # This entry exists so the lazy-download helper has a pinned reference.
 [apalache]
 version = "0.44.11"
 url = "https://github.com/apalache-mc/apalache/releases/download/v0.44.11/apalache.tgz"
-sha256 = "UNSET"
+sha256 = "5fe31cbc5708747bde654f6e2bc5100ac4e8e846e9fb540293e0b919e3bda0c8"


### PR DESCRIPTION
## Summary

Populates the two `sha256 = "UNSET"` placeholders in `skills/slo-tla/tools.toml` with values computed by `sldo-tla-sha` (the M1/M2 helper from the tla-sha-autopop runbook).

| Section | Version | SHA-256 |
|---|---|---|
| `[tlc]` | v1.8.0 | `d5d07d5dab38ddb840c91ec48fa02f28b37a608d5af9a73570018591dbc8ef7f` |
| `[apalache]` | v0.44.11 | `5fe31cbc5708747bde654f6e2bc5100ac4e8e846e9fb540293e0b919e3bda0c8` |

Both hashes were re-fetched after commit and verified with `sldo-tla-sha --verify` — round-tripped green.

## Why

Unblocks `/slo-tla` from running end-to-end. On a fresh machine the skill's prereq cascade can now:

1. `which java` → user installs if missing, exits cleanly.
2. Look for `~/.sldo/tla/tla2tools.jar` → not found on first run.
3. Read `tools.toml`, fetch the URL, SHA-256-verify the bytes → **now passes** with the pinned hash above.
4. Install the shim, proceed to TLC.

Previously step 3 always failed with "SHA-256 mismatch (expected UNSET)" — intentional by design, so we'd never ship a hash we hadn't personally computed. This PR does that computation.

## Test plan

- [x] `sldo-tla-sha` computed the hashes against the pinned URLs.
- [x] `sldo-tla-sha --verify` re-fetched and confirmed both match after commit.
- [x] Reviewer: sanity-check the SHAs against `shasum -a 256` on a locally-downloaded copy of each URL if paranoid.

## Provenance

- Computed on macOS arm64, 2026-04-24.
- Final-URL host check passed for both (both resolved through `objects.githubusercontent.com`, on the allow-list).
- No redirects outside the allow-list.
- Max-bytes cap (500 MB) not hit (TLC jar ~8 MB, Apalache tgz ~80 MB).

🤖 Generated with /slo-ship methodology