### PR TITLE
[codex] Rework agent-host onboarding, docs, and research flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,8 +25,9 @@ docs/legal
 # Research dossier output directory
 output/
 
-# User-local Claude Code state in this repo (scheduled_tasks.lock, settings.local.json)
+# User-local host-agent state in this repo (scheduled_tasks.lock, settings.local.json)
 .claude/
+.copilot/
 
 # TLA+ tool cache location if a user accidentally symlinks it into the repo
 .sldo/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ Sprint flow: Think → Plan → Build → Review → Test → Ship → Reflect.
 | Stage | Skill | Purpose |
 |---|---|---|
 | Ideate | `/slo-ideate` | YC-style product interrogation before any code |
-| Research | `/slo-research` | Wraps `sldo-research` Rust backend for sourced dossiers |
+| Research | `/slo-research` | Host-native research first; optional Claude batch backend via `sldo-research` |
 | Architect | `/slo-architect` | Stack + ARCHITECTURE.md + interfaces lock-in + `tla_required` flag |
 | Verify design | `/slo-tla` | TLC model-check the design (when `tla_required: true`) |
 | Plan | `/slo-plan` | Interactive v3 runbook authoring, one milestone at a time |
@@ -73,7 +73,7 @@ Every feature runbook lives at `docs/RUNBOOK-<FEATURE>.md` and follows [docs/run
 cargo test -p sldo-common -p sldo-install -p sldo-research
 ```
 
-The workspace contains four crates: `sldo-common` (shared library), `sldo-research` (Rust backend driven by `/slo-research`), `sldo-install` (skill installer), and `xtasks/sast-verify` (Semgrep rule gate driven by `/slo-rulegen` + `/slo-ruleverify`). All other Rust code (the legacy `sldo-plan` / `sldo-run` CLIs, the parked `sldo-tauri` desktop UI, the `sldo-tla-sha` maintenance utility) was removed in the 2026-04 cleanup — the skills are the canonical interface now.
+The workspace contains four crates: `sldo-common` (shared library), `sldo-research` (optional Claude batch backend for `/slo-research`), `sldo-install` (skill installer), and `xtasks/sast-verify` (Semgrep rule gate driven by `/slo-rulegen` + `/slo-ruleverify`). All other Rust code (the legacy `sldo-plan` / `sldo-run` CLIs, the parked `sldo-tauri` desktop UI, the `sldo-tla-sha` maintenance utility) was removed in the 2026-04 cleanup — the skills are the canonical interface now.
 
 ## Installing the pack on this machine
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
-# SunLitOrchestrate — Claude Code project notes
+# SunLitOrchestrate — Claude Code overlay
 
-This repo hosts the SunLitOrchestrate (SLO) skill pack for Claude Code. When you are working in this repo, the skills below are available via `sldo-install`.
+This file is the Claude Code overlay for the canonical living catalog at [docs/skill-pack-catalog.md](docs/skill-pack-catalog.md). Use it when you are working in Claude Code and need Claude-specific session notes. For the host-neutral list of shipped skills, read the catalog first. For GitHub Copilot-specific notes, read [copilot-instructions.md](copilot-instructions.md).
 
 ## Skill pack — first-party `/slo-*` skills
 
@@ -70,7 +70,7 @@ Every feature runbook lives at `docs/RUNBOOK-<FEATURE>.md` and follows [docs/run
 ## Baseline test command (this repo)
 
 ```bash
-cargo test --workspace
+cargo test -p sldo-common -p sldo-install -p sldo-research
 ```
 
 The workspace contains four crates: `sldo-common` (shared library), `sldo-research` (Rust backend driven by `/slo-research`), `sldo-install` (skill installer), and `xtasks/sast-verify` (Semgrep rule gate driven by `/slo-rulegen` + `/slo-ruleverify`). All other Rust code (the legacy `sldo-plan` / `sldo-run` CLIs, the parked `sldo-tauri` desktop UI, the `sldo-tla-sha` maintenance utility) was removed in the 2026-04 cleanup — the skills are the canonical interface now.
@@ -87,3 +87,7 @@ cargo build -p sldo-install --release
 ```
 
 Manifest: `~/.sldo/install.toml`.
+
+If you are using GitHub Copilot instead of Claude Code, use [copilot-instructions.md](copilot-instructions.md) for the matching host overlay.
+
+If you are completely new to the repo, start with [docs/getting-started.md](docs/getting-started.md) before using this overlay.

--- a/README.md
+++ b/README.md
@@ -1,37 +1,51 @@
 # SunLitOrchestrate
 
-> An AI-driven software-development workflow that adds the missing guardrails: idea → research → architecture → plan → critique → execute → verify → ship → reflect. Each step is a slash-command skill backed by file-based contracts (runbooks, threat models, lessons) so the work survives across sessions and reviewers.
+> An AI-first workflow that turns "build this" into scoped, reviewable, testable work. SunLitOrchestrate adds durable guardrails around LLM execution: idea → research → architecture → plan → critique → execute → verify → ship → reflect.
 
 **License:** [Apache-2.0 OR MIT](LICENSE) (dual; pick either) — explicitly NOT AGPL.
 **Status:** active development. The skill pack and Rust CLIs are stable; the Tauri desktop UI is parked.
 
-## What problem this solves
+## Why SunLitOrchestrate
 
-Sit a senior engineer next to an LLM and the LLM will happily write 5,000 lines of beautiful code that solves the wrong problem, skips the important risks, and leaves no record of *why* anything happened. SunLitOrchestrate fixes that with three things:
+SunLitOrchestrate is for teams who like fast LLM output but dislike silent scope drift, missing rationale, and lessons that die in chat history.
 
-1. **A v3 milestone-runbook contract.** Every feature lives in a `docs/RUNBOOK-<feature>.md` with explicit Contract Blocks (allowed files, forbidden shortcuts, BDD scenarios, abuse cases, regression tests). The LLM can't "silently widen scope" because the scope is checked against this file at every step.
-2. **A sequence of focused skills**, each doing one thing: `/slo-ideate` interrogates the idea, `/slo-research` produces a sourced dossier, `/slo-architect` commits to a stack + emits a threat model, `/slo-plan` writes the runbook one milestone at a time, `/slo-critique` rotates four adversarial reviewers (CEO, eng-lead, security, designer), `/slo-execute M<N>` drives one milestone with allow-list enforcement, `/slo-verify M<N>` runs the runtime QA, `/slo-retro M<N>` writes lessons + completion summaries.
-3. **A SAST rule pack** (`/slo-rulegen`) generating Semgrep rules for the top-10 CWE classes idiomatic Rust + popular crates are most susceptible to. Variation-template-driven, gated by `cargo xtask sast-verify`, never copies AGPL upstream YAML.
+- **Stop silent scope widening**: every feature lives in a `docs/RUNBOOK-<feature>.md` with allowed files, forbidden shortcuts, BDD scenarios, abuse cases, and regression tests.
+- **Preserve the why**: research dossiers, threat models, runbooks, lessons, and completion summaries survive across sessions and reviewers.
+- **Add formal rigor where it matters**: `/slo-tla` gives the workflow an explicit TLA+ step for designs with real concurrency, ordering, or protocol risk, so the system can be challenged as a spec before it is implemented as code.
+- **Keep follow-ups alive**: `/slo-retro` captures what was learned, and `/slo-resume` is the "what next?" entrypoint when work gets interrupted.
+- **Default to reviewability**: the pack prefers explicit contracts, adversarial critique, and verification over "the model will probably remember".
 
-The raw `SKILL.md` contract is agent-neutral. The canonical living catalog lives in [docs/skill-pack-catalog.md](docs/skill-pack-catalog.md). Host-specific session notes live in [CLAUDE.md](CLAUDE.md) and [copilot-instructions.md](copilot-instructions.md). If this is your first time here, start with [docs/getting-started.md](docs/getting-started.md).
+If this is your first time here, start with [docs/getting-started.md](docs/getting-started.md).
 
-## Highlights
+## What ships here
 
-- **Sprint-flow skill pack** — 11 first-party `/slo-*` skills covering ideate → research → architect → tla → plan → critique → execute → verify → retro → ship, plus power tools (`/slo-second-opinion`, `/slo-freeze`, `/slo-resume`).
-- **UK biz-pack** — 4 advisor skills (`/slo-legal`, `/slo-accounting`, `/slo-equity`, `/slo-fundraise`) and 11 generator skills (`/slo-talk-to-users`, `/slo-gtm`, `/slo-product`, `/slo-marketing`, `/slo-launch`, `/slo-sales-funnel`, `/slo-pricing`, `/slo-metrics`, `/slo-cofounder`, `/slo-hire`, `/slo-founder-check`) for the company-around-the-product side. Hard-block gates for regulated domains, deals over £5,000, counterparty-with-lawyer, and GDPR documents. JPP Law / SeedLegals public pricing as the cost baseline.
-- **SAST rule generator** — `/slo-rulegen` produces a 10/10 CWE-class Semgrep rule pack from variation templates; `/slo-ruleverify` re-gates the pack on demand. Trail-of-Bits-AGPL-clean-room policy is enforced by code review.
-- **Threat-model-by-default** — `/slo-architect` emits a `docs/design/<slug>-threat-model.md` (STRIDE × component, abuse cases, compliance mapping) for every project. `/slo-plan` cites threat-model rows as BDD abuse-case scenarios.
-- **No agentic shortcuts** — every skill *refuses* to run when its inputs aren't present (no idea doc → refuse `/slo-research`; no research dossier → refuse `/slo-architect`; non-`done` tracker rows → refuse `/slo-ship`). Slow is smooth, smooth is fast.
+| Pack | What it is for | Main entrypoints |
+|---|---|---|
+| Core sprint flow | Turning an idea or change request into a runbook-driven delivery loop | `/slo-ideate`, `/slo-research`, `/slo-architect`, `/slo-tla`, `/slo-plan`, `/slo-execute`, `/slo-verify`, `/slo-retro`, `/slo-ship` |
+| Security + SAST | Threat-model-by-default design and Semgrep rule-pack generation | `/slo-sast`, `/slo-rulegen`, `/slo-ruleverify` |
+| UK biz pack (v1) | Founder, GTM, pricing, legal, accounting, equity, and hiring artifacts for UK-only workflows | `/slo-legal`, `/slo-accounting`, `/slo-equity`, `/slo-fundraise`, `/slo-talk-to-users`, `/slo-gtm`, `/slo-product`, `/slo-marketing`, `/slo-launch`, `/slo-sales-funnel`, `/slo-pricing`, `/slo-metrics`, `/slo-cofounder`, `/slo-hire`, `/slo-founder-check` |
+
+The raw `SKILL.md` contract is agent-neutral. The canonical skill list lives in [docs/skill-pack-catalog.md](docs/skill-pack-catalog.md). Host-specific overlays live in [CLAUDE.md](CLAUDE.md) and [copilot-instructions.md](copilot-instructions.md).
+
+The workflow is intentionally more technical-contract-driven than a typical prompt stack. The v3 runbook contract at [docs/runbook-template_v_3_template.md](docs/runbook-template_v_3_template.md) gives every milestone explicit scope, interfaces, abuse cases, compatibility expectations, and verification gates. For designs with real protocol complexity, `/slo-tla` adds a formal-spec step so the design can be checked with TLA+ before implementation.
+
+## Pick a starting point
+
+- **New feature or product idea**: run `/slo-ideate` and expect `docs/idea/<slug>.md` as the first artifact.
+- **Existing idea doc or known problem**: start at `/slo-research` or `/slo-architect`, depending on whether you still need external evidence.
+- **Interrupted runbook**: run `/slo-resume`. It reads the tracker and suggests the next move without starting work for you.
+- **Security-only adoption**: jump straight to `/slo-rulegen` or `/slo-sast`.
+- **Business-only adoption**: use the UK biz-pack skills without adopting the entire sprint-flow path.
 
 ## Quick start
 
-If you want the step-by-step first-run path, read [docs/getting-started.md](docs/getting-started.md) first. The short version is below.
+If you want the step-by-step first-run path, read [docs/getting-started.md](docs/getting-started.md). The short version is below.
 
 ### Prerequisites
 
 - **Rust toolchain** (stable). `rustup install stable` if you don't have one.
 - **A supported host agent**: Claude Code or GitHub Copilot. Claude Code remains the default target if you do not pass `--host`.
-- **Semgrep** (`brew install semgrep` or `pip install semgrep`). Required for the SAST rule pack only.
+- **Semgrep** (`brew install semgrep` or `pip install semgrep`). Required only for the SAST rule-pack path.
 
 ### Install the skill pack
 
@@ -39,47 +53,58 @@ If you want the step-by-step first-run path, read [docs/getting-started.md](docs
 git clone https://github.com/kerberosmansour/SunLitOrchestrate.git
 cd SunLitOrchestrate
 
-# Build the installer
 cargo build -p sldo-install --release
 
-# Claude Code is still the default host
+# Claude Code (default host)
 ./target/release/sldo-install
+./target/release/sldo-install status
+./target/release/sldo-install verify
 
-# Install into GitHub Copilot instead
+# GitHub Copilot
 ./target/release/sldo-install --host github-copilot
+./target/release/sldo-install --host github-copilot status
+./target/release/sldo-install --host github-copilot verify
 
-# Project-local installs write into ./.claude/skills/ or ./.copilot/skills/
+# Project-local installs
 ./target/release/sldo-install --local
 ./target/release/sldo-install --host github-copilot --local
 ```
 
-After install, every `/slo-*` skill is available from the host you selected. If you omit `--host`, `sldo-install` uses `claude-code`.
+What success looks like:
 
-For the first-use path, expected output files, and troubleshooting, continue with [docs/getting-started.md](docs/getting-started.md).
+- `sldo-install` prints the selected target root.
+- `status` lists the installed skills for the host you chose.
+- Global installs land in `~/.claude/skills/` or `~/.copilot/skills/`.
+- Local installs land in `./.claude/skills/` or `./.copilot/skills/` if you add `--local`.
 
-### Drive a feature end-to-end
+`/slo-research` now uses host-native research first in both Claude Code and GitHub Copilot. `sldo-research` remains an optional Claude batch backend when you explicitly want that automation path.
+
+### Typical flow
 
 ```text
-/slo-ideate          # YC-style product interrogation
-/slo-research        # Sourced dossier (wraps sldo-research)
-/slo-architect       # Stack + ARCHITECTURE.md + threat model
-/slo-plan            # v3 runbook, one milestone at a time
-/slo-critique        # 4-persona adversarial review
-/slo-execute M1      # Drive M1 with allow-list enforcement
-/slo-verify M1       # Runtime QA + Playwright if UI
-/slo-retro M1        # Lessons + completion + tracker update
+/slo-ideate          # interrogate the problem before code exists
+/slo-research        # produce a sourced dossier
+/slo-architect       # commit to a stack + threat model
+/slo-tla             # optional: model-check the design when concurrency or ordering risk is real
+/slo-plan            # write the v3 runbook one milestone at a time
+/slo-critique        # run the adversarial review pass
+/slo-execute M1      # drive one milestone within the allow-list
+/slo-verify M1       # runtime QA + Playwright if UI
+/slo-retro M1        # lessons + completion + tracker update
 # ... repeat /slo-execute / /slo-verify / /slo-retro per milestone ...
-/slo-ship            # Open PR with runbook-aware description
+/slo-ship            # open a runbook-aware PR
 ```
 
-### Generate a SAST rule pack
+If you step away mid-runbook, use `/slo-resume`. It is the pack's read-only orientation path: it reads the tracker and suggests the next action.
+
+### Security-only quick path
 
 ```bash
 # In a Rust workspace where you want the rules:
-/slo-rulegen                                    # generates 10 rule pairs at .semgrep/rust/
-/slo-ruleverify                                 # confirms every rule passes gate
+/slo-rulegen
+/slo-ruleverify
 
-# Run a specific rule's gate locally:
+# Run a specific gate locally:
 cargo xtask sast-verify gate .semgrep/rust/cwe-755-panic-on-result-fn.yaml
 
 # Extend the pack from a real bug + fix:
@@ -91,63 +116,25 @@ cargo xtask sast-verify gate .semgrep/rust/cwe-755-panic-on-result-fn.yaml
 
 CI wiring is documented in [`references/sast/CI-WIRING.md`](references/sast/CI-WIRING.md).
 
-## Skill reference
+## Host reality
 
-### Sprint flow
+- Claude Code and GitHub Copilot can both install and use the `SKILL.md` pack interactively.
+- Claude Code remains the default host if you omit `--host`.
+- Headless runtime automation is still host-specific today.
+- `sldo-research` as a batch backend and the live business judgment runtime harness are still Claude-only today.
+- For exact boundaries, read [docs/design/agent-host-capabilities.md](docs/design/agent-host-capabilities.md).
 
-| Stage | Skill | Purpose |
-|---|---|---|
-| Ideate | `/slo-ideate` | YC-style product interrogation before any code |
-| Research | `/slo-research` | Wraps `sldo-research` Rust backend for sourced dossiers |
-| Architect | `/slo-architect` | Stack + `ARCHITECTURE.md` + interfaces lock-in + `tla_required` flag + threat model |
-| Verify design | `/slo-tla` | TLC model-check the design (when `tla_required: true`) |
-| Plan | `/slo-plan` | Interactive v3 runbook authoring, one milestone at a time |
-| Critique | `/slo-critique` | Four-persona adversarial review (CEO, eng-lead, security, designer) |
-| Execute | `/slo-execute M<N>` | Per-milestone driver with allow-list enforcement |
-| Verify | `/slo-verify M<N>` | Runtime QA with Playwright for UI surfaces |
-| Close | `/slo-retro M<N>` | Lessons + completion + tracker update |
-| Ship | `/slo-ship` | Open PR with runbook-aware description |
+## Full skill map
 
-Power tools: `/slo-second-opinion` (cross-model disagreement surfacer), `/slo-freeze <path>` (lock edits to one directory for the session), `/slo-resume` (read tracker, suggest next step).
+The README is the orientation page. For the full host-neutral skill list, output paths, and current support boundaries, use:
 
-### Biz pack (UK only, v1)
-
-Four advisor skills with `draft | translate | triage | prepare` modes; eleven generator skills producing one artifact each. See [docs/design/biz-skill-pack-overview.md](docs/design/biz-skill-pack-overview.md) for the full design.
-
-| Skill | Domain |
-|---|---|
-| `/slo-legal` | NDA, contractor SOW, IP assignment, T&Cs |
-| `/slo-accounting` | Bookkeeping, VAT, R&D credit, MTD |
-| `/slo-equity` | Cofounder split, vesting, cap-table snapshot |
-| `/slo-fundraise` | SAFE math, pitch narrative, term-sheet redline brief |
-| `/slo-talk-to-users` | Mom-test interviews + post-call extraction |
-| `/slo-gtm` | ICP / motion choice / channel strategy / KPI alignment |
-| `/slo-product` | Roadmap / metrics / OKRs |
-| `/slo-marketing` | B2B / B2C tactics with PECR routing |
-| `/slo-launch` | 4-stage launch sequence + readiness gates |
-| `/slo-sales-funnel` | Outbound funnel math + cold email templates |
-| `/slo-pricing` | Value-equation pricing + 3-tier-max model |
-| `/slo-metrics` | Financial KPI dashboard (consumer / B2B) |
-| `/slo-cofounder` | Cofounder evaluation + 4-week paid trial framing |
-| `/slo-hire` | IR35-aware hiring with mandatory CEST triage gate |
-| `/slo-founder-check` | 12-question self-assessment + worst-case-runway worksheet |
-
-### SAST pack
-
-| Skill | Purpose |
-|---|---|
-| `/slo-rulegen` | Generate or extend a Semgrep rule pack from variation templates |
-| `/slo-ruleverify` | Re-gate the rule pack |
-
-The xtask `cargo xtask sast-verify` exposes `validate`, `test`, `check-coverage`, `check-clean`, `gate`, `detect-tier`, and `validate-file-paths` subcommands. `gate` is the single deterministic entry point that `/slo-rulegen` shells out to before authorising any rule write.
-
-### Vendored
-
-| Skill | Purpose | Prereq |
-|---|---|---|
-| `/get-api-docs` | Fetch current third-party API docs via `chub` | `npm install -g @aisuite/chub` |
-
-See [skills/get-api-docs/UPSTREAM.md](skills/get-api-docs/UPSTREAM.md) for attribution.
+- [docs/skill-pack-catalog.md](docs/skill-pack-catalog.md) — canonical living catalog of shipped skills
+- [docs/getting-started.md](docs/getting-started.md) — first-run path with exact commands and expected results
+- [docs/design/agent-host-capabilities.md](docs/design/agent-host-capabilities.md) — what works in Claude Code, GitHub Copilot, or both
+- [CLAUDE.md](CLAUDE.md) — Claude Code overlay
+- [copilot-instructions.md](copilot-instructions.md) — GitHub Copilot overlay
+- [docs/PARADIGM-OVER-ENGINEERING-FOR-SIMPLICITY.md](docs/PARADIGM-OVER-ENGINEERING-FOR-SIMPLICITY.md) — design philosophy: more internal discipline, less user-visible ceremony
+- [skills/get-api-docs/UPSTREAM.md](skills/get-api-docs/UPSTREAM.md) — attribution for the vendored `/get-api-docs` helper
 
 ## Project structure
 
@@ -155,8 +142,8 @@ See [skills/get-api-docs/UPSTREAM.md](skills/get-api-docs/UPSTREAM.md) for attri
 .
 ├── skills/                       # Skill pack (slo-* + get-api-docs)
 ├── crates/
-│   ├── sldo-common/              # Shared library (used by sldo-research)
-│   ├── sldo-research/            # Backend driven by /slo-research skill
+│   ├── sldo-common/              # Shared library (used by the remaining Rust tooling)
+│   ├── sldo-research/            # Optional Claude batch backend for /slo-research
 │   └── sldo-install/             # Skill installer (symlinks skills/* into the selected host root)
 ├── xtasks/sast-verify/           # cargo xtask sast-verify (Semgrep rule gate; driven by /slo-rulegen + /slo-ruleverify)
 ├── .semgrep/rust/                # 10/10 CWE rule pack (M1 + M1.5 + M1.6)
@@ -170,20 +157,23 @@ See [skills/get-api-docs/UPSTREAM.md](skills/get-api-docs/UPSTREAM.md) for attri
 ### Baseline test command
 
 ```bash
-cargo test --workspace
+cargo test -p sldo-common -p sldo-install -p sldo-research
 ```
 
 ## Documentation
+
+Docs live in-repo today.
 
 Start here:
 
 - [docs/getting-started.md](docs/getting-started.md) — first-run guide with exact commands and expected results
 - [docs/skill-pack-catalog.md](docs/skill-pack-catalog.md) — canonical living catalog of shipped skills
-- [CLAUDE.md](CLAUDE.md) — Claude Code overlay for the catalog
-- [copilot-instructions.md](copilot-instructions.md) — GitHub Copilot overlay for the catalog
-- [docs/design/agent-host-capabilities.md](docs/design/agent-host-capabilities.md) — capability matrix for install, interactive use, and headless automation
-- [SECURITY.md](SECURITY.md) — project-wide security defaults
 - [docs/runbook-template_v_3_template.md](docs/runbook-template_v_3_template.md) — the v3 runbook contract `/slo-plan` produces
+- [docs/design/agent-host-capabilities.md](docs/design/agent-host-capabilities.md) — capability matrix for install, interactive use, and headless automation
+- [docs/PARADIGM-OVER-ENGINEERING-FOR-SIMPLICITY.md](docs/PARADIGM-OVER-ENGINEERING-FOR-SIMPLICITY.md) — why the pack prefers more internal discipline with less user-visible ceremony
+- [SECURITY.md](SECURITY.md) — project-wide security defaults
+- [CLAUDE.md](CLAUDE.md) — Claude Code overlay
+- [copilot-instructions.md](copilot-instructions.md) — GitHub Copilot overlay
 
 Skill-pack design:
 
@@ -239,5 +229,8 @@ Unless you explicitly state otherwise, any contribution intentionally submitted 
 ## Acknowledgements
 
 - Trail of Bits' [`semgrep-rules`](https://github.com/trailofbits/semgrep-rules) (AGPL) for the structural shape inspiration on the panic-DoS / CWE-755 rule. The SunLitOrchestrate rule pack is independently re-authored from variation templates per the AGPL clean-room policy in [references/sast/AUTHORING.md](references/sast/AUTHORING.md).
+- The [BMad Method](https://github.com/bmad-code-org/BMAD-METHOD) for helping popularize structured, lifecycle-aware AI-assisted development. SunLitOrchestrate arrives at a more contract-heavy, security-first shape, but it shares the belief that better outcomes come from explicit workflow rather than one-shot prompting.
+- [TLA+](https://github.com/tlaplus/tlaplus), and the broader formal-methods tradition around it, for reinforcing the idea that some designs should be challenged as specifications before they are implemented as code. SunLit carries that idea through `/slo-tla` when concurrency, ordering, or protocol risk is real.
+- Jim Manico's talk [*Securing Claude Code: Guardrails for AI-Assisted Development*](https://youtu.be/thsdAsgIsFc?si=FvxYtdHyus7DQTe7) for sharpening the guardrail-first mindset behind the project's threat-modeling, verification, and "no agentic shortcuts" posture.
 - The [oneNDA](https://www.onenda.org/) consortium (CC BY-ND 4.0) for the canonical UK NDA template the biz-pack `/slo-legal draft nda` flow defers to.
 - The [SeedLegals](https://seedlegals.com/) public pricing page as the v1 cost baseline anchor for biz-pack ROI claims, alongside JPP Law's fixed-fee public pricing.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Sit a senior engineer next to an LLM and the LLM will happily write 5,000 lines 
 2. **A sequence of focused skills**, each doing one thing: `/slo-ideate` interrogates the idea, `/slo-research` produces a sourced dossier, `/slo-architect` commits to a stack + emits a threat model, `/slo-plan` writes the runbook one milestone at a time, `/slo-critique` rotates four adversarial reviewers (CEO, eng-lead, security, designer), `/slo-execute M<N>` drives one milestone with allow-list enforcement, `/slo-verify M<N>` runs the runtime QA, `/slo-retro M<N>` writes lessons + completion summaries.
 3. **A SAST rule pack** (`/slo-rulegen`) generating Semgrep rules for the top-10 CWE classes idiomatic Rust + popular crates are most susceptible to. Variation-template-driven, gated by `cargo xtask sast-verify`, never copies AGPL upstream YAML.
 
-The skills run inside [Claude Code](https://claude.com/claude-code). The Rust CLIs (`sldo-plan`, `sldo-run`, `sldo-research`) implement the same orchestration without Claude Code (they shell out to GitHub Copilot CLI or Claude Code CLI directly).
+The skills can now be installed into [Claude Code](https://claude.com/claude-code) or GitHub Copilot. `sldo-install` still defaults to Claude Code for backward compatibility, and this milestone only changes installer support — broader host-specific docs and runtime capability notes are tracked separately.
 
 ## Highlights
 
@@ -28,7 +28,7 @@ The skills run inside [Claude Code](https://claude.com/claude-code). The Rust CL
 ### Prerequisites
 
 - **Rust toolchain** (stable). `rustup install stable` if you don't have one.
-- **Claude Code** ([install instructions](https://docs.claude.com/en/docs/claude-code/quickstart)). Required for the `/slo-*` skills.
+- **A supported host agent**: Claude Code or GitHub Copilot. Claude Code remains the default target if you do not pass `--host`.
 - **Semgrep** (`brew install semgrep` or `pip install semgrep`). Required for the SAST rule pack only.
 
 ### Install the skill pack
@@ -37,14 +37,21 @@ The skills run inside [Claude Code](https://claude.com/claude-code). The Rust CL
 git clone https://github.com/kerberosmansour/SunLitOrchestrate.git
 cd SunLitOrchestrate
 
-# Build the installer + the SAST verifier
-cargo build -p sldo-install -p sast-verify --release
+# Build the installer
+cargo build -p sldo-install --release
 
-# Symlink skills/* into ~/.claude/skills/
+# Claude Code is still the default host
 ./target/release/sldo-install
+
+# Install into GitHub Copilot instead
+./target/release/sldo-install --host github-copilot
+
+# Project-local installs write into ./.claude/skills/ or ./.copilot/skills/
+./target/release/sldo-install --local
+./target/release/sldo-install --host github-copilot --local
 ```
 
-After install, every `/slo-*` skill is invocable from any Claude Code session.
+After install, every `/slo-*` skill is available from the host you selected. If you omit `--host`, `sldo-install` uses `claude-code`.
 
 ### Drive a feature end-to-end
 
@@ -142,11 +149,11 @@ See [skills/get-api-docs/UPSTREAM.md](skills/get-api-docs/UPSTREAM.md) for attri
 
 ```
 .
-├── skills/                       # Claude Code skill pack (slo-*  + get-api-docs)
+├── skills/                       # Skill pack (slo-* + get-api-docs)
 ├── crates/
 │   ├── sldo-common/              # Shared library (used by sldo-research)
 │   ├── sldo-research/            # Backend driven by /slo-research skill
-│   └── sldo-install/             # Skill installer (symlinks skills/* to ~/.claude/skills/)
+│   └── sldo-install/             # Skill installer (symlinks skills/* into the selected host root)
 ├── xtasks/sast-verify/           # cargo xtask sast-verify (Semgrep rule gate; driven by /slo-rulegen + /slo-ruleverify)
 ├── .semgrep/rust/                # 10/10 CWE rule pack (M1 + M1.5 + M1.6)
 ├── references/                   # Shared scaffolding read by skills (biz/, sast/)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SunLitOrchestrate
 
-> An AI-driven software-development workflow that adds the missing guardrails: idea → research → architecture → plan → critique → execute → verify → ship → reflect. Each step is a slash-command skill for Claude Code, backed by file-based contracts (runbooks, threat models, lessons) so the work survives across sessions and reviewers.
+> An AI-driven software-development workflow that adds the missing guardrails: idea → research → architecture → plan → critique → execute → verify → ship → reflect. Each step is a slash-command skill backed by file-based contracts (runbooks, threat models, lessons) so the work survives across sessions and reviewers.
 
 **License:** [Apache-2.0 OR MIT](LICENSE) (dual; pick either) — explicitly NOT AGPL.
 **Status:** active development. The skill pack and Rust CLIs are stable; the Tauri desktop UI is parked.
@@ -13,7 +13,7 @@ Sit a senior engineer next to an LLM and the LLM will happily write 5,000 lines 
 2. **A sequence of focused skills**, each doing one thing: `/slo-ideate` interrogates the idea, `/slo-research` produces a sourced dossier, `/slo-architect` commits to a stack + emits a threat model, `/slo-plan` writes the runbook one milestone at a time, `/slo-critique` rotates four adversarial reviewers (CEO, eng-lead, security, designer), `/slo-execute M<N>` drives one milestone with allow-list enforcement, `/slo-verify M<N>` runs the runtime QA, `/slo-retro M<N>` writes lessons + completion summaries.
 3. **A SAST rule pack** (`/slo-rulegen`) generating Semgrep rules for the top-10 CWE classes idiomatic Rust + popular crates are most susceptible to. Variation-template-driven, gated by `cargo xtask sast-verify`, never copies AGPL upstream YAML.
 
-The skills can now be installed into [Claude Code](https://claude.com/claude-code) or GitHub Copilot. `sldo-install` still defaults to Claude Code for backward compatibility, and this milestone only changes installer support — broader host-specific docs and runtime capability notes are tracked separately.
+The raw `SKILL.md` contract is agent-neutral. The canonical living catalog lives in [docs/skill-pack-catalog.md](docs/skill-pack-catalog.md). Host-specific session notes live in [CLAUDE.md](CLAUDE.md) and [copilot-instructions.md](copilot-instructions.md). If this is your first time here, start with [docs/getting-started.md](docs/getting-started.md).
 
 ## Highlights
 
@@ -24,6 +24,8 @@ The skills can now be installed into [Claude Code](https://claude.com/claude-cod
 - **No agentic shortcuts** — every skill *refuses* to run when its inputs aren't present (no idea doc → refuse `/slo-research`; no research dossier → refuse `/slo-architect`; non-`done` tracker rows → refuse `/slo-ship`). Slow is smooth, smooth is fast.
 
 ## Quick start
+
+If you want the step-by-step first-run path, read [docs/getting-started.md](docs/getting-started.md) first. The short version is below.
 
 ### Prerequisites
 
@@ -52,6 +54,8 @@ cargo build -p sldo-install --release
 ```
 
 After install, every `/slo-*` skill is available from the host you selected. If you omit `--host`, `sldo-install` uses `claude-code`.
+
+For the first-use path, expected output files, and troubleshooting, continue with [docs/getting-started.md](docs/getting-started.md).
 
 ### Drive a feature end-to-end
 
@@ -158,7 +162,8 @@ See [skills/get-api-docs/UPSTREAM.md](skills/get-api-docs/UPSTREAM.md) for attri
 ├── .semgrep/rust/                # 10/10 CWE rule pack (M1 + M1.5 + M1.6)
 ├── references/                   # Shared scaffolding read by skills (biz/, sast/)
 ├── docs/                         # Runbooks, design docs, lessons, completions
-├── CLAUDE.md                     # Project guidance for Claude Code
+├── CLAUDE.md                     # Claude Code overlay for the canonical skill catalog
+├── copilot-instructions.md       # GitHub Copilot overlay for the same skill pack
 └── SECURITY.md                   # Project-wide security defaults
 ```
 
@@ -172,7 +177,11 @@ cargo test --workspace
 
 Start here:
 
-- [CLAUDE.md](CLAUDE.md) — project guidance read by Claude Code on every session
+- [docs/getting-started.md](docs/getting-started.md) — first-run guide with exact commands and expected results
+- [docs/skill-pack-catalog.md](docs/skill-pack-catalog.md) — canonical living catalog of shipped skills
+- [CLAUDE.md](CLAUDE.md) — Claude Code overlay for the catalog
+- [copilot-instructions.md](copilot-instructions.md) — GitHub Copilot overlay for the catalog
+- [docs/design/agent-host-capabilities.md](docs/design/agent-host-capabilities.md) — capability matrix for install, interactive use, and headless automation
 - [SECURITY.md](SECURITY.md) — project-wide security defaults
 - [docs/runbook-template_v_3_template.md](docs/runbook-template_v_3_template.md) — the v3 runbook contract `/slo-plan` produces
 
@@ -197,7 +206,7 @@ Contributions are welcome. The recommended workflow:
 1. **Fork + clone.** `git clone <your-fork>` and `cd SunLitOrchestrate`.
 2. **Open an issue first** for non-trivial work — the v3 runbook discipline only pays off when the work is scoped before code is written.
 3. **Use the skills on yourself.** `/slo-ideate` → `/slo-research` → `/slo-architect` → `/slo-plan` produces a runbook the maintainers can review without any code yet. This is the lowest-friction path to merging.
-4. **Pass the baseline.** `cargo test -p sldo-common -p sldo-plan -p sldo-run -p sldo-research -p sldo-install -p sast-verify` must be green.
+4. **Pass the baseline.** `cargo test -p sldo-common -p sldo-install -p sldo-research` must be green.
 5. **Open a PR.** The PR description should link to the runbook + the closed milestone's completion summary.
 
 What's currently most welcome:

--- a/copilot-instructions.md
+++ b/copilot-instructions.md
@@ -1,0 +1,49 @@
+# SunLitOrchestrate — GitHub Copilot overlay
+
+This file is the GitHub Copilot overlay for the canonical living catalog at [docs/skill-pack-catalog.md](docs/skill-pack-catalog.md). Use it when you are working in GitHub Copilot and want the Copilot-specific install path, reading order, and limitations.
+
+If you are new to the repo, start with [docs/getting-started.md](docs/getting-started.md). If you want the Claude-specific version of this file, read [CLAUDE.md](CLAUDE.md).
+
+## Read this first
+
+1. [docs/getting-started.md](docs/getting-started.md) — first-run path
+2. [docs/skill-pack-catalog.md](docs/skill-pack-catalog.md) — canonical living catalog
+3. [docs/design/agent-host-capabilities.md](docs/design/agent-host-capabilities.md) — what works today and what is still host-specific
+
+## Install into GitHub Copilot
+
+From the repo root:
+
+```bash
+cargo build -p sldo-install --release
+./target/release/sldo-install --host github-copilot
+./target/release/sldo-install --host github-copilot status
+./target/release/sldo-install --host github-copilot verify
+```
+
+Project-local install:
+
+```bash
+./target/release/sldo-install --host github-copilot --local
+```
+
+Global installs land in `~/.copilot/skills/`. Local installs land in `./.copilot/skills/`.
+
+## What works today
+
+- The installed skill contract is the same `SKILL.md` format used by Claude Code.
+- `sldo-install` can install, list, verify, and uninstall Copilot-targeted skills.
+- The canonical skill list stays in [docs/skill-pack-catalog.md](docs/skill-pack-catalog.md), so this file only needs to explain Copilot-specific details.
+
+## Current limitations
+
+- Headless runtime automation in GitHub Copilot is **not supported yet**. Do not assume there is a Copilot CLI runtime equivalent to the Claude-only test harnesses.
+- `/slo-research` still has a Claude-specific batch backend behind the scenes today. Treat that as a documented limitation until the host-neutral interactive rewrite lands.
+- The live business judgment runtime harness remains Claude-only today because it shells out to `claude -p`.
+
+## First session checklist
+
+1. Confirm the install target is Copilot by running `./target/release/sldo-install --host github-copilot status`.
+2. Read [docs/getting-started.md](docs/getting-started.md) for the first-run path.
+3. Use [docs/skill-pack-catalog.md](docs/skill-pack-catalog.md) to pick the skill you want.
+4. Check [docs/design/agent-host-capabilities.md](docs/design/agent-host-capabilities.md) before assuming a runtime or automation surface exists.

--- a/copilot-instructions.md
+++ b/copilot-instructions.md
@@ -38,7 +38,7 @@ Global installs land in `~/.copilot/skills/`. Local installs land in `./.copilot
 ## Current limitations
 
 - Headless runtime automation in GitHub Copilot is **not supported yet**. Do not assume there is a Copilot CLI runtime equivalent to the Claude-only test harnesses.
-- `/slo-research` still has a Claude-specific batch backend behind the scenes today. Treat that as a documented limitation until the host-neutral interactive rewrite lands.
+- `/slo-research` now supports host-native interactive research without installing Claude. The separate `sldo-research` path remains an optional Claude batch backend when a user explicitly wants batch automation.
 - The live business judgment runtime harness remains Claude-only today because it shells out to `claude -p`.
 
 ## First session checklist

--- a/crates/sldo-install/src/host.rs
+++ b/crates/sldo-install/src/host.rs
@@ -1,0 +1,58 @@
+use clap::ValueEnum;
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq, ValueEnum)]
+pub enum Host {
+    ClaudeCode,
+    GithubCopilot,
+}
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub struct HostDescriptor {
+    pub id: &'static str,
+    pub display_name: &'static str,
+    pub config_dir: &'static str,
+}
+
+const CLAUDE_CODE: HostDescriptor = HostDescriptor {
+    id: "claude-code",
+    display_name: "Claude Code",
+    config_dir: ".claude",
+};
+
+const GITHUB_COPILOT: HostDescriptor = HostDescriptor {
+    id: "github-copilot",
+    display_name: "GitHub Copilot",
+    config_dir: ".copilot",
+};
+
+impl Host {
+    pub fn descriptor(self) -> &'static HostDescriptor {
+        match self {
+            Self::ClaudeCode => &CLAUDE_CODE,
+            Self::GithubCopilot => &GITHUB_COPILOT,
+        }
+    }
+
+    pub fn id(self) -> &'static str {
+        self.descriptor().id
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn claude_code_descriptor_matches_expected_paths() {
+        let descriptor = Host::ClaudeCode.descriptor();
+        assert_eq!(descriptor.id, "claude-code");
+        assert_eq!(descriptor.config_dir, ".claude");
+    }
+
+    #[test]
+    fn github_copilot_descriptor_matches_expected_paths() {
+        let descriptor = Host::GithubCopilot.descriptor();
+        assert_eq!(descriptor.id, "github-copilot");
+        assert_eq!(descriptor.config_dir, ".copilot");
+    }
+}

--- a/crates/sldo-install/src/install.rs
+++ b/crates/sldo-install/src/install.rs
@@ -14,11 +14,13 @@ use colored::Colorize;
 use std::fs;
 use std::path::{Path, PathBuf};
 
+use crate::host::Host;
 use crate::manifest::{Entry, Manifest};
 use crate::paths;
 
 pub struct Options {
     pub skills_dir: PathBuf,
+    pub host: Host,
     pub local: bool,
     pub force: bool,
     pub dry_run: bool,
@@ -73,10 +75,16 @@ fn discover_skills(skills_dir: &Path) -> Result<Vec<(String, PathBuf)>> {
 fn compute_root_and_manifest(opts: &Options) -> Result<(PathBuf, PathBuf)> {
     if opts.local {
         let cwd = std::env::current_dir().context("Failed to read current directory")?;
-        Ok((paths::local_skills_root(&cwd), paths::local_manifest_path(&cwd)))
+        Ok((
+            paths::local_skills_root(&cwd, opts.host),
+            paths::local_manifest_path(&cwd, opts.host),
+        ))
     } else {
         let home = paths::home_dir()?;
-        Ok((paths::global_skills_root(&home), paths::global_manifest_path(&home)))
+        Ok((
+            paths::global_skills_root(&home, opts.host),
+            paths::global_manifest_path(&home),
+        ))
     }
 }
 
@@ -185,7 +193,12 @@ pub fn install(opts: &Options) -> Result<()> {
                 item.source.display()
             )
         })?;
-        manifest.upsert(item.name.clone(), item.target.clone(), item.source.clone());
+        manifest.upsert(
+            opts.host,
+            item.name.clone(),
+            item.target.clone(),
+            item.source.clone(),
+        );
         println!(
             "  {} {} {} {}",
             "+".green().bold(),
@@ -197,8 +210,13 @@ pub fn install(opts: &Options) -> Result<()> {
 
     for item in &plan.up_to_date {
         // Still ensure it's in the manifest (e.g., after manifest loss).
-        if manifest.find(&item.name).is_none() {
-            manifest.upsert(item.name.clone(), item.target.clone(), item.source.clone());
+        if manifest.find(&item.name, opts.host).is_none() {
+            manifest.upsert(
+                opts.host,
+                item.name.clone(),
+                item.target.clone(),
+                item.source.clone(),
+            );
         }
         println!("  {} {} (already installed)", "=".dimmed(), item.name);
     }
@@ -218,29 +236,40 @@ pub fn install(opts: &Options) -> Result<()> {
 }
 
 pub fn uninstall(opts: &Options) -> Result<()> {
-    let (_root, manifest_path) = compute_root_and_manifest(opts)?;
+    let (root, manifest_path) = compute_root_and_manifest(opts)?;
     let mut manifest = Manifest::load(&manifest_path)?;
+    let host_entries: Vec<Entry> = manifest
+        .entries_for_host(opts.host)
+        .into_iter()
+        .cloned()
+        .collect();
 
-    if manifest.entries.is_empty() {
-        println!("nothing to uninstall (manifest is empty or missing).");
+    if host_entries.is_empty() {
+        println!("nothing to uninstall for {}.", opts.host.id());
         return Ok(());
     }
 
     if opts.dry_run {
-        println!("would remove:");
-        for entry in &manifest.entries {
+        println!("would remove for {}:", opts.host.id());
+        for entry in &host_entries {
             println!("  - {}", entry.target.display());
         }
         println!("  manifest: {}", manifest_path.display());
         return Ok(());
     }
 
-    let to_remove: Vec<Entry> = manifest.entries.clone();
+    let to_remove = host_entries;
+    let mut bad = 0usize;
     for entry in to_remove {
+        if let Err(error) = validate_entry_target_in_host_root(&entry, &root) {
+            eprintln!("  {} {}: {}", "x".red().bold(), entry.name, error);
+            bad += 1;
+            continue;
+        }
         match remove_managed_symlink(&entry) {
             Ok(true) => {
                 println!("  {} {}", "-".yellow().bold(), entry.name);
-                manifest.remove(&entry.name);
+                manifest.remove(&entry.name, opts.host);
             }
             Ok(false) => {
                 eprintln!(
@@ -251,6 +280,7 @@ pub fn uninstall(opts: &Options) -> Result<()> {
             }
             Err(e) => {
                 eprintln!("  {} {}: {}", "x".red().bold(), entry.name, e);
+                bad += 1;
             }
         }
     }
@@ -260,33 +290,49 @@ pub fn uninstall(opts: &Options) -> Result<()> {
     } else {
         manifest.save(&manifest_path)?;
     }
+
+    if bad > 0 {
+        bail!("{} skill(s) were rejected or failed uninstall", bad);
+    }
     Ok(())
 }
 
 pub fn status(opts: &Options) -> Result<()> {
     let (_root, manifest_path) = compute_root_and_manifest(opts)?;
     let manifest = Manifest::load(&manifest_path)?;
-    if manifest.entries.is_empty() {
-        println!("no skills installed.");
+    let host_entries = manifest.entries_for_host(opts.host);
+    if host_entries.is_empty() {
+        println!("no skills installed for {}.", opts.host.id());
         return Ok(());
     }
-    println!("installed skills ({}):", manifest.entries.len());
-    for e in &manifest.entries {
+    println!(
+        "installed skills for {} ({}):",
+        opts.host.id(),
+        host_entries.len()
+    );
+    for e in host_entries {
         println!("  {} -> {}  [installed {}]", e.name, e.source.display(), e.installed_at);
     }
     Ok(())
 }
 
 pub fn verify(opts: &Options) -> Result<()> {
-    let (_root, manifest_path) = compute_root_and_manifest(opts)?;
+    let (root, manifest_path) = compute_root_and_manifest(opts)?;
     let manifest = Manifest::load(&manifest_path)?;
-    if manifest.entries.is_empty() {
-        println!("manifest is empty — nothing to verify.");
+    let host_entries = manifest.entries_for_host(opts.host);
+    if host_entries.is_empty() {
+        println!("manifest is empty for {} — nothing to verify.", opts.host.id());
         return Ok(());
     }
 
+    println!("verifying {} entries for {}:", host_entries.len(), opts.host.id());
     let mut bad = 0usize;
-    for entry in &manifest.entries {
+    for entry in host_entries {
+        if let Err(error) = validate_entry_target_in_host_root(entry, &root) {
+            eprintln!("  {} {}: {}", "x".red(), entry.name, error);
+            bad += 1;
+            continue;
+        }
         if !entry.target.is_symlink() {
             eprintln!("  {} {}: target is not a symlink", "x".red(), entry.name);
             bad += 1;
@@ -366,6 +412,18 @@ fn remove_managed_symlink(entry: &Entry) -> Result<bool> {
     }
     fs::remove_file(&entry.target)?;
     Ok(true)
+}
+
+fn validate_entry_target_in_host_root(entry: &Entry, root: &Path) -> Result<()> {
+    if entry.target.starts_with(root) {
+        return Ok(());
+    }
+
+    bail!(
+        "target {} is outside the selected host root {}",
+        entry.target.display(),
+        root.display()
+    )
 }
 
 fn print_plan(plan: &Plan, root: &Path) {

--- a/crates/sldo-install/src/main.rs
+++ b/crates/sldo-install/src/main.rs
@@ -1,19 +1,23 @@
 //! `sldo-install` — install, update, and uninstall the SunLitOrchestrate skill pack.
 //!
 //! Symlinks the skill directories under `skills/` in this repo into the
-//! host agent's skills directory (default: `~/.claude/skills/`), or into a
-//! project-local `.claude/skills/` when `--local` is passed.
+//! selected host agent's skills directory (default: `~/.claude/skills/`), or
+//! into a project-local host directory such as `./.claude/skills/` or
+//! `./.copilot/skills/` when `--local` is passed.
 //!
 //! The installer is idempotent: running it twice leaves the same state as
 //! running it once. Uninstall reverses every change recorded in the manifest.
 
 use anyhow::{bail, Context, Result};
-use clap::{Parser, Subcommand, ValueEnum};
+use clap::{Parser, Subcommand};
 use std::path::PathBuf;
 
+mod host;
 mod install;
 mod manifest;
 mod paths;
+
+use host::Host;
 
 #[derive(Parser, Debug)]
 #[command(
@@ -30,11 +34,11 @@ struct Cli {
     #[arg(long, global = true)]
     skills_dir: Option<PathBuf>,
 
-    /// Install into the project-local `.claude/skills/` instead of `~/.claude/skills/`.
+    /// Install into the project-local host skills directory instead of the global host root.
     #[arg(long, global = true)]
     local: bool,
 
-    /// Target host agent. Only `claude-code` is implemented in M1.
+    /// Target host agent. Defaults to `claude-code` for backward compatibility.
     #[arg(long, value_enum, default_value_t = Host::ClaudeCode, global = true)]
     host: Host,
 
@@ -59,17 +63,13 @@ enum Command {
     Verify,
 }
 
-#[derive(Copy, Clone, Debug, ValueEnum)]
-enum Host {
-    ClaudeCode,
-}
-
 fn main() -> Result<()> {
     let cli = Cli::parse();
     let command = cli.command.unwrap_or(Command::Install);
 
     let opts = install::Options {
         skills_dir: resolve_skills_dir(cli.skills_dir)?,
+        host: cli.host,
         local: cli.local,
         force: cli.force,
         dry_run: cli.dry_run,

--- a/crates/sldo-install/src/manifest.rs
+++ b/crates/sldo-install/src/manifest.rs
@@ -7,11 +7,16 @@ use serde::{Deserialize, Serialize};
 use std::fs;
 use std::path::{Path, PathBuf};
 
+use crate::host::Host;
+
 /// A single installed skill entry.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Entry {
     /// Skill directory name (e.g. `slo-ideate`, `get-api-docs`).
     pub name: String,
+    /// Host id that owns this install (for example `claude-code`).
+    #[serde(default = "default_host_id")]
+    pub host: String,
     /// Absolute path to the symlink we created.
     pub target: PathBuf,
     /// Absolute path to the source skill directory the symlink points at.
@@ -21,7 +26,7 @@ pub struct Entry {
 }
 
 /// The full manifest file.
-#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Manifest {
     /// Manifest schema version for forward compat.
     #[serde(default = "default_schema_version")]
@@ -31,23 +36,38 @@ pub struct Manifest {
     pub entries: Vec<Entry>,
 }
 
+const CURRENT_SCHEMA_VERSION: u32 = 2;
+
 fn default_schema_version() -> u32 {
-    1
+    CURRENT_SCHEMA_VERSION
+}
+
+fn default_host_id() -> String {
+    Host::ClaudeCode.id().to_string()
+}
+
+impl Default for Manifest {
+    fn default() -> Self {
+        Self {
+            schema_version: CURRENT_SCHEMA_VERSION,
+            entries: Vec::new(),
+        }
+    }
 }
 
 impl Manifest {
     /// Load a manifest from disk, returning an empty manifest when the file does not exist.
     pub fn load(path: &Path) -> Result<Self> {
         if !path.exists() {
-            return Ok(Self {
-                schema_version: 1,
-                entries: Vec::new(),
-            });
+            return Ok(Self::default());
         }
         let content = fs::read_to_string(path)
             .with_context(|| format!("Failed to read manifest: {}", path.display()))?;
-        let m: Self = toml::from_str(&content)
+        let mut m: Self = toml::from_str(&content)
             .with_context(|| format!("Failed to parse manifest: {}", path.display()))?;
+        if m.schema_version < CURRENT_SCHEMA_VERSION {
+            m.schema_version = CURRENT_SCHEMA_VERSION;
+        }
         Ok(m)
     }
 
@@ -64,29 +84,49 @@ impl Manifest {
         Ok(())
     }
 
-    /// Find an entry by skill name.
-    pub fn find(&self, name: &str) -> Option<&Entry> {
-        self.entries.iter().find(|e| e.name == name)
+    /// Find an entry by skill name and host.
+    pub fn find(&self, name: &str, host: Host) -> Option<&Entry> {
+        self.entries
+            .iter()
+            .find(|entry| entry.name == name && entry.host == host.id())
     }
 
-    /// Add or replace an entry, keyed by name. Timestamp is set now.
-    pub fn upsert(&mut self, name: String, target: PathBuf, source: PathBuf) {
+    /// Return the entries owned by a specific host.
+    pub fn entries_for_host(&self, host: Host) -> Vec<&Entry> {
+        self.entries
+            .iter()
+            .filter(|entry| entry.host == host.id())
+            .collect()
+    }
+
+    /// Add or replace an entry, keyed by skill name + host. Timestamp is set now.
+    pub fn upsert(&mut self, host: Host, name: String, target: PathBuf, source: PathBuf) {
+        self.schema_version = CURRENT_SCHEMA_VERSION;
         let entry = Entry {
             name: name.clone(),
+            host: host.id().to_string(),
             target,
             source,
             installed_at: Utc::now().to_rfc3339(),
         };
-        if let Some(existing) = self.entries.iter_mut().find(|e| e.name == name) {
+        if let Some(existing) = self
+            .entries
+            .iter_mut()
+            .find(|existing| existing.name == name && existing.host == host.id())
+        {
             *existing = entry;
         } else {
             self.entries.push(entry);
         }
     }
 
-    /// Remove an entry by name. Returns the removed entry if present.
-    pub fn remove(&mut self, name: &str) -> Option<Entry> {
-        if let Some(idx) = self.entries.iter().position(|e| e.name == name) {
+    /// Remove an entry by name + host. Returns the removed entry if present.
+    pub fn remove(&mut self, name: &str, host: Host) -> Option<Entry> {
+        if let Some(idx) = self
+            .entries
+            .iter()
+            .position(|entry| entry.name == name && entry.host == host.id())
+        {
             Some(self.entries.remove(idx))
         } else {
             None
@@ -105,7 +145,7 @@ mod tests {
         let path = tmp.path().join("nope.toml");
         let m = Manifest::load(&path).unwrap();
         assert!(m.entries.is_empty());
-        assert_eq!(m.schema_version, 1);
+        assert_eq!(m.schema_version, CURRENT_SCHEMA_VERSION);
     }
 
     #[test]
@@ -113,8 +153,8 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let path = tmp.path().join("sub").join("install.toml");
         let mut m = Manifest::default();
-        m.schema_version = 1;
         m.upsert(
+            Host::ClaudeCode,
             "slo-ideate".into(),
             PathBuf::from("/home/u/.claude/skills/slo-ideate"),
             PathBuf::from("/repo/skills/slo-ideate"),
@@ -124,24 +164,86 @@ mod tests {
         let loaded = Manifest::load(&path).unwrap();
         assert_eq!(loaded.entries.len(), 1);
         assert_eq!(loaded.entries[0].name, "slo-ideate");
+        assert_eq!(loaded.entries[0].host, "claude-code");
+        assert_eq!(loaded.schema_version, CURRENT_SCHEMA_VERSION);
     }
 
     #[test]
-    fn upsert_replaces_existing() {
+    fn upsert_replaces_existing_for_same_host_only() {
         let mut m = Manifest::default();
-        m.upsert("a".into(), PathBuf::from("/t1"), PathBuf::from("/s1"));
-        m.upsert("a".into(), PathBuf::from("/t2"), PathBuf::from("/s2"));
-        assert_eq!(m.entries.len(), 1);
-        assert_eq!(m.entries[0].target, PathBuf::from("/t2"));
+        m.upsert(
+            Host::ClaudeCode,
+            "a".into(),
+            PathBuf::from("/t1"),
+            PathBuf::from("/s1"),
+        );
+        m.upsert(
+            Host::GithubCopilot,
+            "a".into(),
+            PathBuf::from("/t2"),
+            PathBuf::from("/s2"),
+        );
+        m.upsert(
+            Host::ClaudeCode,
+            "a".into(),
+            PathBuf::from("/t3"),
+            PathBuf::from("/s3"),
+        );
+
+        assert_eq!(m.entries.len(), 2);
+        assert_eq!(
+            m.find("a", Host::ClaudeCode).unwrap().target,
+            PathBuf::from("/t3")
+        );
+        assert_eq!(
+            m.find("a", Host::GithubCopilot).unwrap().target,
+            PathBuf::from("/t2")
+        );
     }
 
     #[test]
-    fn remove_returns_entry_and_deletes() {
+    fn remove_returns_entry_and_deletes_only_selected_host() {
         let mut m = Manifest::default();
-        m.upsert("a".into(), PathBuf::from("/t"), PathBuf::from("/s"));
-        let removed = m.remove("a");
+        m.upsert(
+            Host::ClaudeCode,
+            "a".into(),
+            PathBuf::from("/claude"),
+            PathBuf::from("/s1"),
+        );
+        m.upsert(
+            Host::GithubCopilot,
+            "a".into(),
+            PathBuf::from("/copilot"),
+            PathBuf::from("/s2"),
+        );
+
+        let removed = m.remove("a", Host::GithubCopilot);
         assert!(removed.is_some());
-        assert!(m.entries.is_empty());
-        assert!(m.remove("a").is_none());
+        assert_eq!(m.entries.len(), 1);
+        assert!(m.find("a", Host::ClaudeCode).is_some());
+        assert!(m.remove("a", Host::GithubCopilot).is_none());
+    }
+
+    #[test]
+    fn load_v1_manifest_defaults_entries_to_claude_code() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("install.toml");
+        fs::write(
+            &path,
+            r#"schema_version = 1
+
+[[entries]]
+name = "slo-ideate"
+target = "/home/u/.claude/skills/slo-ideate"
+source = "/repo/skills/slo-ideate"
+installed_at = "2026-01-01T00:00:00Z"
+"#,
+        )
+        .unwrap();
+
+        let loaded = Manifest::load(&path).unwrap();
+        assert_eq!(loaded.schema_version, CURRENT_SCHEMA_VERSION);
+        assert_eq!(loaded.entries.len(), 1);
+        assert_eq!(loaded.entries[0].host, "claude-code");
     }
 }

--- a/crates/sldo-install/src/paths.rs
+++ b/crates/sldo-install/src/paths.rs
@@ -6,6 +6,8 @@
 use anyhow::{Context, Result};
 use std::path::{Path, PathBuf};
 
+use crate::host::Host;
+
 /// Resolve the user's home directory, honoring `$HOME` (which `tempfile`-backed
 /// tests override). Falls back to `dirs`-style fallback not implemented here —
 /// we require `$HOME` to be set because every test and production environment
@@ -18,14 +20,14 @@ pub fn home_dir() -> Result<PathBuf> {
     Ok(PathBuf::from(home))
 }
 
-/// Where global installs land: `~/.claude/skills/`.
-pub fn global_skills_root(home: &Path) -> PathBuf {
-    home.join(".claude").join("skills")
+/// Where global installs land: `~/.claude/skills/` or `~/.copilot/skills/`.
+pub fn global_skills_root(home: &Path, host: Host) -> PathBuf {
+    home.join(host.descriptor().config_dir).join("skills")
 }
 
-/// Where local installs land, relative to the given CWD: `<cwd>/.claude/skills/`.
-pub fn local_skills_root(cwd: &Path) -> PathBuf {
-    cwd.join(".claude").join("skills")
+/// Where local installs land, relative to the given CWD.
+pub fn local_skills_root(cwd: &Path, host: Host) -> PathBuf {
+    cwd.join(host.descriptor().config_dir).join("skills")
 }
 
 /// Where the global manifest lives: `~/.sldo/install.toml`.
@@ -33,9 +35,9 @@ pub fn global_manifest_path(home: &Path) -> PathBuf {
     home.join(".sldo").join("install.toml")
 }
 
-/// Where the local manifest lives: `<cwd>/.claude/slo-install.toml`.
-pub fn local_manifest_path(cwd: &Path) -> PathBuf {
-    cwd.join(".claude").join("slo-install.toml")
+/// Where the local manifest lives: `<cwd>/<host>/slo-install.toml`.
+pub fn local_manifest_path(cwd: &Path, host: Host) -> PathBuf {
+    cwd.join(host.descriptor().config_dir).join("slo-install.toml")
 }
 
 #[cfg(test)]
@@ -46,7 +48,7 @@ mod tests {
     fn global_skills_root_under_home() {
         let home = Path::new("/tmp/fakehome");
         assert_eq!(
-            global_skills_root(home),
+            global_skills_root(home, Host::ClaudeCode),
             PathBuf::from("/tmp/fakehome/.claude/skills")
         );
     }
@@ -55,8 +57,23 @@ mod tests {
     fn local_skills_root_under_cwd() {
         let cwd = Path::new("/tmp/fake-repo");
         assert_eq!(
-            local_skills_root(cwd),
+            local_skills_root(cwd, Host::ClaudeCode),
             PathBuf::from("/tmp/fake-repo/.claude/skills")
+        );
+    }
+
+    #[test]
+    fn github_copilot_roots_use_copilot_config_dir() {
+        let base = Path::new("/tmp/fakehome");
+        assert_eq!(
+            global_skills_root(base, Host::GithubCopilot),
+            PathBuf::from("/tmp/fakehome/.copilot/skills")
+        );
+
+        let cwd = Path::new("/tmp/fake-repo");
+        assert_eq!(
+            local_manifest_path(cwd, Host::GithubCopilot),
+            PathBuf::from("/tmp/fake-repo/.copilot/slo-install.toml")
         );
     }
 }

--- a/crates/sldo-install/tests/e2e_agent_host_m1.rs
+++ b/crates/sldo-install/tests/e2e_agent_host_m1.rs
@@ -1,0 +1,231 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use tempfile::TempDir;
+
+fn binary_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_sldo-install"))
+}
+
+fn make_skill(skills_dir: &Path, name: &str) {
+    let dir = skills_dir.join(name);
+    fs::create_dir_all(&dir).unwrap();
+    fs::write(
+        dir.join("SKILL.md"),
+        format!("---\nname: {}\ndescription: test\n---\nbody", name),
+    )
+    .unwrap();
+}
+
+fn sldo_install(home: &Path, skills_dir: &Path, extra: &[&str]) -> std::process::Output {
+    let mut cmd = Command::new(binary_path());
+    cmd.env("HOME", home)
+        .arg("--skills-dir")
+        .arg(skills_dir);
+    for arg in extra {
+        cmd.arg(arg);
+    }
+    cmd.output().expect("failed to exec sldo-install")
+}
+
+fn manifest_path(home: &Path) -> PathBuf {
+    home.join(".sldo/install.toml")
+}
+
+#[test]
+fn test_claude_and_copilot_roots_are_distinct() {
+    let home = TempDir::new().unwrap();
+    let src = TempDir::new().unwrap();
+    make_skill(src.path(), "slo-ideate");
+
+    let claude = sldo_install(home.path(), src.path(), &["install"]);
+    assert!(
+        claude.status.success(),
+        "claude install failed: {}",
+        String::from_utf8_lossy(&claude.stderr)
+    );
+
+    let copilot = sldo_install(
+        home.path(),
+        src.path(),
+        &["--host", "github-copilot", "install"],
+    );
+    assert!(
+        copilot.status.success(),
+        "copilot install failed: {}",
+        String::from_utf8_lossy(&copilot.stderr)
+    );
+
+    assert!(home.path().join(".claude/skills/slo-ideate").is_symlink());
+    assert!(home.path().join(".copilot/skills/slo-ideate").is_symlink());
+
+    let manifest = fs::read_to_string(home.path().join(".sldo/install.toml")).unwrap();
+    assert!(manifest.contains("host = \"claude-code\""));
+    assert!(manifest.contains("host = \"github-copilot\""));
+}
+
+#[test]
+fn test_uninstall_only_removes_selected_host_entries() {
+    let home = TempDir::new().unwrap();
+    let src = TempDir::new().unwrap();
+    make_skill(src.path(), "slo-ideate");
+
+    assert!(sldo_install(home.path(), src.path(), &["install"]).status.success());
+    assert!(
+        sldo_install(
+            home.path(),
+            src.path(),
+            &["--host", "github-copilot", "install"],
+        )
+        .status
+        .success()
+    );
+
+    let uninstall = sldo_install(
+        home.path(),
+        src.path(),
+        &["--host", "github-copilot", "uninstall"],
+    );
+    assert!(
+        uninstall.status.success(),
+        "copilot uninstall failed: {}",
+        String::from_utf8_lossy(&uninstall.stderr)
+    );
+
+    assert!(home.path().join(".claude/skills/slo-ideate").is_symlink());
+    assert!(!home.path().join(".copilot/skills/slo-ideate").exists());
+
+    let manifest_path = home.path().join(".sldo/install.toml");
+    let manifest = fs::read_to_string(&manifest_path).expect("manifest should keep claude entries");
+    assert!(manifest.contains("host = \"claude-code\""));
+    assert!(!manifest.contains("host = \"github-copilot\""));
+}
+
+#[test]
+fn test_status_and_verify_report_selected_host() {
+    let home = TempDir::new().unwrap();
+    let src = TempDir::new().unwrap();
+    make_skill(src.path(), "slo-ideate");
+
+    let install = sldo_install(
+        home.path(),
+        src.path(),
+        &["--host", "github-copilot", "install"],
+    );
+    assert!(install.status.success());
+
+    let status = sldo_install(
+        home.path(),
+        src.path(),
+        &["--host", "github-copilot", "status"],
+    );
+    assert!(status.status.success());
+    let status_stdout = String::from_utf8_lossy(&status.stdout);
+    assert!(status_stdout.contains("github-copilot"));
+
+    let verify = sldo_install(
+        home.path(),
+        src.path(),
+        &["--host", "github-copilot", "verify"],
+    );
+    assert!(verify.status.success());
+    let verify_stdout = String::from_utf8_lossy(&verify.stdout);
+    assert!(verify_stdout.contains("github-copilot"));
+}
+
+#[test]
+fn test_github_copilot_local_install_uses_repo_state() {
+    let home = TempDir::new().unwrap();
+    let src = TempDir::new().unwrap();
+    make_skill(src.path(), "slo-local");
+
+    let project = TempDir::new().unwrap();
+    let out = Command::new(binary_path())
+        .current_dir(project.path())
+        .env("HOME", home.path())
+        .arg("--skills-dir")
+        .arg(src.path())
+        .arg("--host")
+        .arg("github-copilot")
+        .arg("--local")
+        .arg("install")
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "local copilot install failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    assert!(project.path().join(".copilot/skills/slo-local").is_symlink());
+    assert!(project.path().join(".copilot/slo-install.toml").exists());
+    assert!(!home.path().join(".copilot/skills/slo-local").exists());
+}
+
+#[test]
+fn test_unknown_host_fails_loud() {
+    let home = TempDir::new().unwrap();
+    let src = TempDir::new().unwrap();
+    make_skill(src.path(), "slo-ideate");
+
+    let out = sldo_install(home.path(), src.path(), &["--host", "not-a-host", "install"]);
+    assert!(!out.status.success(), "unknown host should fail");
+
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("claude-code"));
+    assert!(stderr.contains("github-copilot"));
+}
+
+#[test]
+fn test_legacy_manifest_upgrades_without_breaking_uninstall() {
+    let home = TempDir::new().unwrap();
+    let src = TempDir::new().unwrap();
+    make_skill(src.path(), "slo-ideate");
+
+    let install = sldo_install(home.path(), src.path(), &["install"]);
+    assert!(install.status.success());
+
+    let manifest_path = manifest_path(home.path());
+    let legacy_manifest = fs::read_to_string(&manifest_path)
+        .unwrap()
+        .replace("schema_version = 2", "schema_version = 1")
+        .replace("host = \"claude-code\"\n", "");
+    fs::write(&manifest_path, legacy_manifest).unwrap();
+
+    let uninstall = sldo_install(home.path(), src.path(), &["uninstall"]);
+    assert!(
+        uninstall.status.success(),
+        "legacy uninstall failed: {}",
+        String::from_utf8_lossy(&uninstall.stderr)
+    );
+
+    assert!(!home.path().join(".claude/skills/slo-ideate").exists());
+    assert!(!manifest_path.exists());
+}
+
+#[test]
+fn test_install_root_escape_refused_on_verify() {
+    let home = TempDir::new().unwrap();
+    let src = TempDir::new().unwrap();
+    make_skill(src.path(), "slo-ideate");
+
+    let install = sldo_install(home.path(), src.path(), &["install"]);
+    assert!(install.status.success());
+
+    let manifest_path = manifest_path(home.path());
+    let mismatched_manifest = fs::read_to_string(&manifest_path)
+        .unwrap()
+        .replace("host = \"claude-code\"", "host = \"github-copilot\"");
+    fs::write(&manifest_path, mismatched_manifest).unwrap();
+
+    let verify = sldo_install(
+        home.path(),
+        src.path(),
+        &["--host", "github-copilot", "verify"],
+    );
+    assert!(!verify.status.success(), "verify should reject escaped roots");
+
+    let stderr = String::from_utf8_lossy(&verify.stderr);
+    assert!(stderr.contains("outside the selected host root"));
+    assert!(home.path().join(".claude/skills/slo-ideate").is_symlink());
+}

--- a/crates/sldo-install/tests/e2e_agent_host_m2.rs
+++ b/crates/sldo-install/tests/e2e_agent_host_m2.rs
@@ -1,0 +1,107 @@
+use std::fs;
+use std::path::PathBuf;
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .to_path_buf()
+}
+
+fn read(rel_path: &str) -> String {
+    fs::read_to_string(repo_root().join(rel_path))
+        .unwrap_or_else(|_| panic!("missing required file: {rel_path}"))
+}
+
+#[test]
+fn test_living_docs_distinguish_catalog_from_overlays() {
+    let catalog = read("docs/skill-pack-catalog.md");
+    let claude = read("CLAUDE.md");
+    let copilot = read("copilot-instructions.md");
+
+    assert!(
+        catalog.contains("canonical living catalog"),
+        "catalog must identify itself as the canonical living catalog"
+    );
+    assert!(
+        catalog.contains("CLAUDE.md") && catalog.contains("copilot-instructions.md"),
+        "catalog must point readers to both host overlays"
+    );
+    assert!(
+        claude.contains("Claude Code overlay") && claude.contains("docs/skill-pack-catalog.md"),
+        "CLAUDE.md must identify itself as the Claude overlay and point back to the canonical catalog"
+    );
+    assert!(
+        copilot.contains("GitHub Copilot overlay")
+            && copilot.contains("docs/skill-pack-catalog.md"),
+        "copilot overlay must identify itself as an overlay and point back to the canonical catalog"
+    );
+}
+
+#[test]
+fn test_capability_matrix_marks_headless_copilot_as_unsupported() {
+    let capability = read("docs/design/agent-host-capabilities.md");
+
+    assert!(
+        capability.contains("Headless runtime automation"),
+        "capability matrix must cover headless runtime automation"
+    );
+    assert!(
+        capability.contains("GitHub Copilot") && capability.contains("Not supported yet"),
+        "capability matrix must say headless GitHub Copilot automation is not supported yet"
+    );
+    assert!(
+        capability.contains("interactive") || capability.contains("Interactive"),
+        "capability matrix should distinguish interactive support from headless automation"
+    );
+}
+
+#[test]
+fn test_readme_links_to_getting_started_and_getting_started_has_first_run_sections() {
+    let readme = read("README.md");
+    let guide = read("docs/getting-started.md");
+
+    assert!(
+        readme.contains("docs/getting-started.md"),
+        "README must link to the getting-started guide"
+    );
+
+    for heading in [
+        "## Prerequisites",
+        "## Install the skill pack",
+        "## Run your first skill",
+        "## Troubleshooting",
+    ] {
+        assert!(
+            guide.contains(heading),
+            "getting-started guide must contain heading: {heading}"
+        );
+    }
+}
+
+#[test]
+fn test_architecture_doc_matches_surviving_workspace_members() {
+    let readme = read("README.md");
+    let architecture = read("docs/ARCHITECTURE.md");
+
+    assert!(
+        readme.contains("sldo-common")
+            && readme.contains("sldo-research")
+            && readme.contains("sldo-install")
+            && readme.contains("xtasks/sast-verify"),
+        "README must describe the surviving workspace members"
+    );
+    assert!(
+        architecture.contains("sldo-common")
+            && architecture.contains("sldo-research")
+            && architecture.contains("sldo-install")
+            && architecture.contains("xtasks/sast-verify"),
+        "ARCHITECTURE.md must describe the surviving workspace members"
+    );
+    assert!(
+        !readme.contains("CLI tools -- `sldo-plan`") && !architecture.contains("CLI tools -- `sldo-plan`"),
+        "living docs must not describe removed CLI tools as active interfaces"
+    );
+}

--- a/crates/sldo-install/tests/e2e_agent_host_m3.rs
+++ b/crates/sldo-install/tests/e2e_agent_host_m3.rs
@@ -1,0 +1,75 @@
+use std::fs;
+use std::path::PathBuf;
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .to_path_buf()
+}
+
+fn read(rel_path: &str) -> String {
+    fs::read_to_string(repo_root().join(rel_path))
+        .unwrap_or_else(|_| panic!("missing required file: {rel_path}"))
+}
+
+#[test]
+fn test_slo_research_skill_no_longer_requires_batch_backend_for_interactive_flow() {
+    let skill = read("skills/slo-research/SKILL.md");
+
+    assert!(
+        skill.contains("host-native research tools"),
+        "interactive /slo-research guidance must describe a host-native research path"
+    );
+    assert!(
+        skill.contains("optional Claude batch backend"),
+        "skill must separate the optional Claude batch backend from the interactive path"
+    );
+    assert!(
+        !skill.contains("You have one tool: the existing `sldo-research` Rust binary."),
+        "interactive skill must not claim that sldo-research is the only tool"
+    );
+    assert!(
+        !skill.contains("Shell out: `sldo-research"),
+        "interactive skill must not mandate shelling out to sldo-research"
+    );
+}
+
+#[test]
+fn test_batch_backend_is_marked_optional_and_claude_specific() {
+    let readme = read("README.md");
+    let claude = read("CLAUDE.md");
+    let copilot = read("copilot-instructions.md");
+    let catalog = read("docs/skill-pack-catalog.md");
+    let architecture = read("docs/ARCHITECTURE.md");
+
+    for (label, contents) in [
+        ("README", readme.as_str()),
+        ("CLAUDE", claude.as_str()),
+        ("Copilot overlay", copilot.as_str()),
+        ("catalog", catalog.as_str()),
+        ("architecture", architecture.as_str()),
+    ] {
+        assert!(
+            contents.contains("optional Claude batch backend"),
+            "{label} must call sldo-research an optional Claude batch backend"
+        );
+    }
+
+    assert!(
+        readme.contains("host-native research"),
+        "README must describe /slo-research as host-native first"
+    );
+    assert!(
+        catalog
+            .to_lowercase()
+            .contains("host-native interactive research"),
+        "catalog must describe the interactive path as host-native first"
+    );
+    assert!(
+        copilot.contains("without installing Claude"),
+        "Copilot overlay must make the no-hidden-Claude interactive path explicit"
+    );
+}

--- a/crates/sldo-research/src/main.rs
+++ b/crates/sldo-research/src/main.rs
@@ -17,14 +17,15 @@ mod research;
 /// recover between calls.
 const COOLDOWN_SECS: u64 = 5;
 
-/// Generate a research dossier using Claude Code CLI.
+/// Generate a research dossier using the optional Claude batch backend.
 ///
 /// Takes a research prompt (via file or inline arg), explores the topic using
-/// Claude Code, and produces a structured dossier ready for use with sldo-plan.
+/// the optional Claude batch backend, and produces a structured dossier ready
+/// for use with sldo-plan.
 #[derive(Parser, Debug)]
 #[command(
     name = "sldo-research",
-    about = "Generate a research dossier using Claude Code CLI."
+    about = "Generate a research dossier using the optional Claude batch backend."
 )]
 struct Cli {
     /// Path to a file containing the research prompt.
@@ -70,7 +71,7 @@ fn run() -> Result<()> {
         _ => {}
     }
 
-    header("Research Dossier Generator");
+    header("Research Dossier Generator (Claude batch backend)");
     info(&format!("Output:         {}", cli.output.display()));
     info(&format!("Model:          {}", cli.model));
     info(&format!("Max iterations: {}", cli.max_iterations));

--- a/crates/sldo-research/src/research.rs
+++ b/crates/sldo-research/src/research.rs
@@ -1,6 +1,6 @@
 //! Research loop orchestration for sldo-research.
 //!
-//! Drives the multi-phase Claude Code pipeline:
+//! Drives the optional multi-phase Claude batch pipeline:
 //!   1. Optional repo-context invocation when `--repo-dir` is supplied.
 //!   2. Exploration invocation (iteration 1).
 //!   3. Web-search invocations (1..=`max_searches`) between exploration and

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -13,11 +13,11 @@ SunLitOrchestrate is an AI-driven software development toolkit with two interfac
 
 Both interfaces share `sldo-common`, a library of reusable modules.
 
-A third, first-class surface ships alongside the CLIs and desktop app: the `/slo-*` **skill pack** (see [Skill Pack](#skill-pack) below). Skills are Markdown `SKILL.md` files consumed by Claude Code; they are not compiled Rust. The CLI tools (`sldo-plan`, `sldo-run`) were the original interface; the skill pack is the active direction (the `sldo-tauri` desktop app is parked).
+A third, first-class surface ships alongside the CLIs and desktop app: the `/slo-*` **skill pack** (see [Skill Pack](#skill-pack) below). Skills are Markdown `SKILL.md` files consumed by skill-capable coding agents; they are not compiled Rust. `sldo-install` currently supports installing them into Claude Code and GitHub Copilot, with Claude Code still the default host for backward compatibility. The CLI tools (`sldo-plan`, `sldo-run`) were the original interface; the skill pack is the active direction (the `sldo-tauri` desktop app is parked).
 
 ## Skill Pack
 
-The skill pack lives at `skills/slo-*/` and is installed to `~/.claude/skills/` by `sldo-install`. Each skill is a directory with a single `SKILL.md` plus optional support files (`personas/`, `examples/`, `references/`). Skills are invoked by the user as `/<skill-name>` in Claude Code; the loader reads `SKILL.md` frontmatter (`name:`, `description:`) and exposes the skill.
+The skill pack lives at `skills/slo-*/` and is installed by `sldo-install`. Global installs land in `~/.claude/skills/` by default or `~/.copilot/skills/` when `--host github-copilot` is selected; local installs land in `./.claude/skills/` or `./.copilot/skills/`. Global installs share `~/.sldo/install.toml`, and each manifest entry records its owning host so `status`, `verify`, and `uninstall` stay host-specific. Each skill is a directory with a single `SKILL.md` plus optional support files (`personas/`, `examples/`, `references/`).
 
 | Stage | Skill | Purpose |
 |---|---|---|

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -64,7 +64,7 @@ The current workspace has four active members:
 | Member | Role |
 |---|---|
 | `crates/sldo-common` | Shared library used by the remaining Rust tools |
-| `crates/sldo-research` | Research backend for sourced dossier generation |
+| `crates/sldo-research` | Optional Claude batch backend for sourced dossier generation |
 | `crates/sldo-install` | Host-aware installer for the skill pack |
 | `xtasks/sast-verify` | Deterministic Semgrep validation, coverage, and gate runner |
 
@@ -96,7 +96,7 @@ The root package `sunlit-orchestrate-tests` hosts workspace-level integration te
 | `prompt.rs` | Prompt construction |
 | `dossier.rs` | Dossier assembly and related helpers |
 
-The installed skill is host-neutral. The automated batch backend behind it is still Claude-specific today, which is why the capability matrix calls that boundary out explicitly.
+The installed skill is host-neutral for interactive use. `sldo-research` is the optional Claude batch backend for users who explicitly want automated dossier generation from a Claude-backed CLI flow.
 
 ## Installer: `sldo-install`
 
@@ -135,6 +135,7 @@ The current host line is simple:
 - The catalog and the `SKILL.md` contract are host-neutral.
 - Interactive skill use is supported in Claude Code and GitHub Copilot.
 - Headless runtime automation is still Claude-specific where it exists today.
-- `/slo-research` automated batch execution and the live business judgment runtime harness are the main remaining Claude-only paths.
+- `/slo-research` interactive use is multi-host today; `sldo-research` remains an optional Claude batch backend.
+- The live business judgment runtime harness remains a Claude-only path.
 
 Read `docs/design/agent-host-capabilities.md` before making any stronger host-compatibility promise than that.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,789 +1,140 @@
-# Architecture — SunLitOrchestrate
+# SunLitOrchestrate Architecture
 
-> This document describes the architecture of SunLitOrchestrate, including both the CLI tools and the Tauri desktop application.
-
----
+> **Reality-first orientation doc**: this file describes what is implemented at HEAD. Planned work belongs in `docs/design/*.md` and in feature runbooks.
 
 ## Overview
 
-SunLitOrchestrate is an AI-driven software development toolkit with two interfaces:
+SunLitOrchestrate ships three cooperating layers:
 
-1. **CLI tools** — `sldo-plan` (runbook generation) and `sldo-run` (milestone execution)
-2. **Tauri desktop app** — A graphical interface wrapping the same backend logic
+1. A Markdown skill pack under `skills/`.
+2. A host-aware installer in `crates/sldo-install/`.
+3. Supporting Rust tooling in `crates/sldo-common/`, `crates/sldo-research/`, and `xtasks/sast-verify/`.
 
-Both interfaces share `sldo-common`, a library of reusable modules.
+The repo no longer ships `sldo-plan`, `sldo-run`, or `sldo-tauri` as active workspace members. The living surfaces at HEAD are the skill pack, the installer, and the remaining support crates listed above.
 
-A third, first-class surface ships alongside the CLIs and desktop app: the `/slo-*` **skill pack** (see [Skill Pack](#skill-pack) below). Skills are Markdown `SKILL.md` files consumed by skill-capable coding agents; they are not compiled Rust. `sldo-install` currently supports installing them into Claude Code and GitHub Copilot, with Claude Code still the default host for backward compatibility. The CLI tools (`sldo-plan`, `sldo-run`) were the original interface; the skill pack is the active direction (the `sldo-tauri` desktop app is parked).
+## Living docs
 
-## Skill Pack
-
-The skill pack lives at `skills/slo-*/` and is installed by `sldo-install`. Global installs land in `~/.claude/skills/` by default or `~/.copilot/skills/` when `--host github-copilot` is selected; local installs land in `./.claude/skills/` or `./.copilot/skills/`. Global installs share `~/.sldo/install.toml`, and each manifest entry records its owning host so `status`, `verify`, and `uninstall` stay host-specific. Each skill is a directory with a single `SKILL.md` plus optional support files (`personas/`, `examples/`, `references/`).
-
-| Stage | Skill | Purpose |
-|---|---|---|
-| Ideate | `slo-ideate` | YC-style interrogation before code |
-| Research | `slo-research` | Wraps the `sldo-research` Rust binary for sourced dossiers |
-| Architect | `slo-architect` | Emits `ARCHITECTURE.md` / `docs/design/*.md`, decides `tla_required` |
-| Verify design | `slo-tla` | TLC model-check when the architect flags concurrency risk |
-| Plan | `slo-plan` | Interactive v3 runbook authoring, one milestone at a time |
-| Critique | `slo-critique` | Four-persona adversarial review (CEO, eng, security, design) |
-| Execute | `slo-execute` | Per-milestone driver with allow-list enforcement |
-| Verify | `slo-verify` | Runtime QA in four passes (happy / degraded / partial failure / **security — supply-chain + variant-analysis + conditional DAST**); Playwright for UI surfaces |
-| Close | `slo-retro` | Lessons + completion + tracker update |
-| Ship | `slo-ship` | Open PR with runbook-aware description |
-| Power tools | `slo-freeze`, `slo-resume`, `slo-second-opinion`, `get-api-docs` | Auxiliary disciplines |
-| Business advisor (M1 of biz pack Runbook A) | `slo-legal` | UK-only legal advisor with `draft\|translate\|triage\|prepare` modes; cites `references/biz/triage-gate.md` for the four hard-block predicates (regulated / >£5,000 / counterparty-with-lawyer / GDPR) |
-| Business advisor (M2 of biz pack Runbook A) | `slo-accounting` | UK-only accounting advisor; same four-mode contract; default professional routing for HMRC matters is the accountant (per-skill override of gate-1-regulated default); cites M2-tier shared references (`artifact-schema`, `jurisdiction-uk`, `ico-duaa-index`, `ico-enforcement-reality`, `open-template-anchors`) |
-| Business advisor (M3 of biz pack Runbook A) | `slo-equity` | UK-only equity advisor for cofounder-split / vesting / cap-table-snapshot drafts; runs the four-question SEIS / EIS pre-check from `references/biz/hmrc-vcm-index.md` (VCM34080 control / VCM3000 excluded activities / VCM31000 SEIS relief / Abingdon Health preferential-rights line) before any draft; routes to lawyer + accountant (dual review) on every draft |
-| Business advisor (M4 of biz pack Runbook A) | `slo-fundraise` | UK-only fundraise advisor for SAFE math / pitch narrative / investor update / term-sheet redline brief; runs the SEIS / EIS Advance Assurance pre-check on every interaction and refuses term-sheet drafting without AA ≥ 6 weeks ahead of any signature; cites `references/biz/ir35-cest-factors.md` for qualifying-employee context that affects SEIS / EIS thresholds |
-| Business generator (M1 of biz pack Runbook B1) | `slo-talk-to-users` | UK-only user-interview generator with `pre-interview` / `post-interview` mode arg; cites Mom Test discipline; outputs to `docs/biz/users/<date>-<name>.md` (confidential — interview transcripts contain PII). M1 also lands the deferred `/slo-verify` Pass 4 PII-pattern scan over `docs/biz-public/` (email / UK NI / sort code / capitalised-bigram regex set with `pii_scan_override` frontmatter override) |
-| Business generator (M2 of biz pack Runbook B1) | `slo-gtm` | UK-only GTM strategy generator (single-mode, no arg); ICP definition + 3-segment cap + motion choice (PLG / sales-led / community-led / hybrid) + channel strategy + KPI alignment; routes direct-marketing channels to `/slo-legal triage` for PECR considerations before strategy doc is written; output `docs/biz-public/gtm/strategy.md` (public tier, no real PII) |
-| Business generator (M3 of biz pack Runbook B1) | `slo-product` | UK-only PM artifact generator with mode arg `roadmap` \| `metrics` \| `okrs`; outputs to `docs/biz-public/product/{roadmap,metrics,okrs}.md`; PM-side metrics only (DAU / activation / retention / feature adoption); explicit redirect to `/slo-metrics` (B2) for financial KPIs (CAC / LTV / NDR / burn multiple); 3-objective cap on OKRs |
-| Business generator (M4 of biz pack Runbook B1) | `slo-marketing` | UK-only marketing tactics generator with mode arg `b2b` \| `b2c`; outputs to `docs/biz-public/marketing/{b2b,b2c}-plan.md`; brand voice + 90-day content calendar + channel mix + demand gen; routes ALL direct-marketing implementation to `/slo-legal triage` for DUAA 2025 PECR considerations (£17.5M ceiling); B2C also flags ASA / CAP Code disclosure + CRA 2015 routing |
-| Business generator (M1 of biz pack Runbook B2) | `slo-launch` | UK-only launch sequence generator (single-mode); pitch validator + 4-stage launch (silent → F&F → communities → press) with kill / delay rules + readiness checklist; output `docs/biz-public/launch-<slug>.md` |
-| Business generator (M2 of biz pack Runbook B2) | `slo-sales-funnel` | UK-only outbound funnel generator; funnel math worksheet + cold-email template (7 principles) + deal structure (paid trial → recurring → opt-out); routes cold email to `/slo-legal triage` for PECR; output `docs/biz-public/sales/funnel-<segment>.md` |
-| Business generator (M3 of biz pack Runbook B2) | `slo-pricing` | UK-only pricing strategy generator; value equation (25-33% of delivered value) + 3-tier-max model + canonical "increase by 50%" experiment framing; output `docs/biz-public/pricing.md`; routes SEIS/EIS revenue-mix considerations to `/slo-fundraise triage` |
-| Business generator (M4 of biz pack Runbook B2) | `slo-metrics` | UK-only financial KPI dashboard with mode arg `consumer` \| `b2b`; CAC / LTV / NDR / MoM revenue / burn multiple / gross margin / runway / ARR; B2B targets NDR ≥ 110%; consumer ≥ 15% MoM; burn multiple ≤ 2 (Bessemer); output `docs/biz-public/metrics.md`; redirects PM-side metrics to `/slo-product metrics` (B1) |
-| Business generator (M1 of biz pack Runbook C) | `slo-cofounder` | UK-only cofounder evaluation + 4-week paid trial framing + monthly 1:1 agenda; output `docs/biz/cofounder/<name>.md` (confidential); routes equity-split to `/slo-equity` (A M3); routes active disputes to mediator + `/slo-legal triage` |
-| Business generator (M2 of biz pack Runbook C) | `slo-hire` | UK-only hiring artifact with mode_arg = role-shape `swe \| ae \| designer \| ops`; sourcing + interview rubric + offer cadence + onboarding; output `docs/biz/hires/<role>-<name>.md` (confidential); MANDATORY IR35 triage gate per `references/biz/ir35-cest-factors.md` (seven hard-block triggers run BEFORE offer); rejects "call them a contractor for tax efficiency" framing |
-| Business generator (M3 of biz pack Runbook C) | `slo-founder-check` | UK-only self-assessment — 12-question check + worst-case-runway worksheet (4 cost-cut tiers) + optional YC application prep; output `docs/biz/founder-check.md` (confidential); routes mental-health / personal-finance / wind-down concerns to professional support |
-| SAST rule-gen (M1 of sast pack Runbook A — DESIGN, not yet implemented) | `slo-rulegen` | Bootstrap mode emits a Semgrep rule pack covering the top-10 Rust CWE classes from a 2-hop RustSec → GHSA → OSV `cwe_ids` join (CWE-755 panic-DoS, CWE-416 UAF, CWE-697 incorrect-comparison, CWE-125 OOB-read, CWE-787 OOB-write, CWE-190 integer-overflow, CWE-295 cert-validation, CWE-672 expired-resource, CWE-20 input-validation, CWE-79 webapp-XSS) into `.semgrep/rust/`. Extend mode (M2) takes `(bug_summary, fix_diff, file_paths)` from a Claude-found bug and outputs 3-5 variation rules with auto-derived corpus, appending to the existing pack. `rulegen_*` toolflags DENY WebFetch / WebSearch — CWE map is pre-baked in `references/sast/`. See [docs/design/sast-rulegen-skill-pack-overview.md](design/sast-rulegen-skill-pack-overview.md). |
-| SAST rule-gen verify (M1 of sast pack Runbook A — DESIGN, not yet implemented) | `slo-ruleverify` | Read-only skill that invokes `cargo xtask sast-verify gate <rule-path>`; composes `validate` (Semgrep YAML/syntax via exit codes 5/7/4), `test` (fire-on-bad / silent-on-good per `// ruleid:` / `// ok:` annotations — Semgrep upstream convention), `check-coverage` (≥ N `pattern-either` arms per CWE template), `check-clean` (zero false positives on the host crate's `src/` after fix is applied). `ruleverify_*` toolflags DENY Write/Edit/WebFetch/WebSearch. |
-| SAST orchestration (M1+ of scanner-orchestration runbook — DESIGN, not yet implemented) | `slo-sast` | Markdown-only orchestrator that reads `docs/design/<slug>-threat-model.md` for `CWE-\d+` references, detects target stack from manifest files (`Cargo.toml`, `package.json`, `requirements.txt`, `go.mod`, `pom.xml`, etc.), clones `github.com/semgrep/semgrep-rules` at a pinned SHA into `~/.cache/sldo/semgrep-rules/<SHA>/`, filters by `metadata.cwe ∧ metadata.technology`, and emits four artifacts into the target repo: `.semgrep/rules/<rule-id>.yaml` (selected rules committed), `.semgrep.yml` (config), `.github/workflows/sast.yml` (safe template — `on: pull_request`, never `pull_request_target`, `permissions: {}`, SHA-pinned actions, `fetch-depth: 0`, `SEMGREP_RULES` env var not `--config`), and `.semgrep/manifest.json` (audit-defense: `cwes_claimed` vs `cwes_actually_covered`, threat-model SHA, `semgrep_rules_sha`, Semgrep version, per-rule `source_sha`). Re-derives ruleset on threat-model edit, surfacing the diff as a PR. Hard ban on `pull_request_target` survives the 2025-12-08 GitHub default-branch mitigation (full secret access remains the issue). PCI compliance citations target **6.2.3 (v4.0.1)**, NOT 6.3.2 v3.2.1. Integrates with `/slo-rulegen`: rulegen authors project-specific rules to `.semgrep/rules/`, sast deploys them alongside registry-selected rules. See [docs/design/scanner-orchestration-overview.md](design/scanner-orchestration-overview.md). |
-
-### Skill pack invariants (reality at HEAD)
-
-- **Markdown-only skill contract.** No compiled code in `skills/slo-*/`. Shell-outs are the extension mechanism — skills invoke `sldo-research`, `gh`, `cargo test`, or any CLI the host has available.
-- **Canonical planning artifact.** Every feature runbook is `docs/RUNBOOK-<feature>.md` and follows `docs/runbook-template_v_3_template.md`. The template is the output contract of `/slo-plan`.
-- **Reality-first ARCHITECTURE.md.** This file describes implemented code at HEAD. Planned work for a feature lives in `docs/design/<slug>-overview.md` and in that feature's runbook Target Architecture section.
-- **Baseline test command.** `cargo test -p sldo-common -p sldo-plan -p sldo-run -p sldo-research -p sldo-install` (not `--workspace`; the parked `sldo-tauri` crate breaks that on macOS arm64).
-- **Shared scaffolding for the biz skill pack lives at `references/biz/`** (NOT under `skills/`). `crates/sldo-install/src/install.rs:44-71`'s `discover_skills()` walker requires `<skills_dir>/<name>/SKILL.md` to discover, so a sibling `references/biz/` directory has zero installer interaction. The `references/biz/` directory holds the four hard-block predicate definitions (`triage-gate.md`), the JPP Law cost baseline (`cost-baseline-jpp-law-2026.md`), the oneNDA template placeholder (`templates/onenda-uk.md`, CC BY-ND 4.0 verbatim render — currently a placeholder pending canonical-bytes population), and (M2 onward) artifact-schema, jurisdiction-uk, ICO DUAA + enforcement-reality indices, open-template-anchors, HMRC VCM index, IR35 / CEST factors. See [docs/design/biz-skill-pack-overview.md](design/biz-skill-pack-overview.md) for the full design.
-- **Shared scaffolding for the SAST rule-gen pack lives at `references/sast/`** (planned, lands in M1 of Runbook A). Same installer-bypass pattern as `references/biz/` — sibling of `skills/`, never walked by `discover_skills()`. Holds `cwe-map-rust.md` (top-10 Rust CWEs from a 2-hop RustSec → GHSA → OSV join), `variations/cwe-<NNN>.md` (one per CWE, declares minimum-N for `pattern-either` enumeration coverage), `semgrep-rust-syntax.md` (Semgrep primitives confirmed working for Rust in 2026 + smoke-test results for `pattern-inside: unsafe { ... }`), `manifest-schema.md` (rule YAML metadata schema including `cwe`, `sldo-rulegen-version`, `sldo-variation-template` fields), `MIN-SEMGREP-VERSION.md` (pinned minimum semgrep CLI), `AUTHORING.md` (Trail of Bits AGPL clean-room re-authoring policy), and `prompts/{bootstrap,extend}.md` (the prompt bodies the skills consume). See [docs/design/sast-rulegen-skill-pack-overview.md](design/sast-rulegen-skill-pack-overview.md) for the full design.
-- **The SAST verifier xtask lives at `xtasks/sast-verify/`** (planned, lands in M1 of Runbook A — DESIGN, not yet implemented). New Cargo workspace member registered in repo-root `Cargo.toml`. Cargo alias `xtask = "run --package sast-verify --"` declared in a new repo-root `.cargo/config.toml` (matklad/cargo-xtask convention; rust-analyzer / Tokio / wasmtime / OpenVMM precedent). Single binary with subcommands `validate` / `test` / `check-coverage` / `check-clean` / `gate` — `gate` composes the four into a single deterministic exit code that `/slo-rulegen` and `/slo-ruleverify` both shell out to. Body wraps `semgrep --validate` and `semgrep --test`; never reaches the network. Adds `-p sast-verify` to [CLAUDE.md](../CLAUDE.md)'s baseline test list (still NOT `--workspace` — `sldo-tauri` remains parked).
-
-## Workspace Structure
-
-```
-SunLitOrchestrate/
-├── crates/
-│   ├── sldo-common/          # Shared library (copilot, runbook, preflight, etc.)
-│   ├── sldo-plan/            # CLI: runbook generation
-│   ├── sldo-run/             # CLI: milestone execution
-│   └── sldo-tauri/           # Tauri v2 desktop app
-│       ├── src/
-│       │   ├── main.rs       # Tauri entry point, command registration
-│       │   ├── commands/     # Tauri command handlers
-│       │   │   └── plan.rs   # Planning commands (wraps sldo-common)
-│       │   ├── state.rs      # Managed app state (AppState, AppSettings)
-│       │   └── events.rs     # Event payload types for streaming
-│       └── ui/               # React + TypeScript frontend
-│           └── src/
-│               ├── hooks/    # useStreamingEvents, usePlan
-│               ├── components/
-│               └── types/
-├── tests/                    # Workspace-level E2E tests
-└── docs/
-```
-
-## Shared Library: sldo-common
-
-| Module | Purpose |
+| Document | Role |
 |---|---|
-| `copilot.rs` | `CopilotInvocation` — builds and runs Copilot CLI commands |
-| `runbook.rs` | Markdown milestone tracker parsing |
-| `toolflags.rs` | Allow/deny permission flags for Copilot invocations |
-| `preflight.rs` | Pre-flight validation (copilot installed, git safety) |
-| `git.rs` | Repository and branch detection |
-| `detect.rs` | Build/test command auto-detection |
-| `logging.rs` | Timestamped log file writing |
-| `color.rs` | Colored terminal output |
+| `README.md` | Repo orientation for humans browsing the project |
+| `docs/getting-started.md` | First-run guide with exact install and first-use steps |
+| `docs/skill-pack-catalog.md` | Canonical living catalog of shipped skills |
+| `CLAUDE.md` | Claude Code overlay for the catalog |
+| `copilot-instructions.md` | GitHub Copilot overlay for the catalog |
+| `docs/design/agent-host-capabilities.md` | Capability matrix for install, interactive use, and runtime boundaries |
 
-## Tauri Desktop App
+## Skill pack
 
-### Command Registration
+The skill pack is the primary user-facing product. Each skill lives in `skills/<name>/SKILL.md` and is installed into a host-specific skills directory by `sldo-install`.
 
-Tauri commands are registered in `main.rs` via `invoke_handler`:
+### Skill-pack surfaces at HEAD
 
-```rust
-tauri::Builder::default()
-    .setup(|app| {
-        // Load persisted settings on startup
-        let settings = state::load_settings(&app.path().app_data_dir()?);
-        *app.state::<AppState>().settings.lock().unwrap() = settings;
-        Ok(())
-    })
-    .manage(AppState::default())
-    .invoke_handler(tauri::generate_handler![
-        commands::plan::start_planning,
-        commands::plan::read_runbook,
-        commands::plan::save_runbook,
-        commands::run::start_execution,
-        commands::run::cancel_execution,
-        commands::settings::get_settings,
-        commands::settings::update_settings,
-        commands::settings::get_available_providers,
-        commands::settings::get_available_models,
-    ])
-    .run(tauri::generate_context!())
-```
-
-### Event Streaming Pattern (M3)
-
-The Tauri backend communicates with the React frontend via **events**. This pattern enables real-time streaming of Copilot output without blocking the UI.
-
-**Flow:**
-
-1. Frontend calls `invoke("start_planning", { prompt, repoDir })` — returns immediately
-2. Backend spawns an async task via `tokio::spawn`
-3. Task runs `CopilotInvocation::run_with_callback()`, which calls a closure for each output line
-4. Closure calls `app.emit("plan-progress", PlanProgressEvent { ... })` for each line
-5. On completion: emits `plan-complete` with runbook path and validation issues
-6. On error: emits `plan-error` with error description
-
-**Event Types** (defined in `events.rs`):
-
-| Event | Payload | When |
+| Surface | Location | What ships today |
 |---|---|---|
-| `plan-progress` | `PlanProgressEvent { line, stream, timestamp }` | Each line of Copilot stdout/stderr |
-| `plan-complete` | `PlanCompleteEvent { runbook_path, validation_issues }` | Planning finishes |
-| `plan-error` | `PlanErrorEvent { error }` | Planning fails |
+| Sprint flow | `skills/slo-*` | Ideate → research → architect → plan → critique → execute → verify → retro → ship |
+| Business advisor pack | `skills/slo-{legal,accounting,equity,fundraise}` | UK-only advisor flows with hard-block routing |
+| Business generator pack | `skills/slo-{talk-to-users,gtm,product,marketing,launch,sales-funnel,pricing,metrics,cofounder,hire,founder-check}` | Artifact generators for discovery, GTM, product, finance, hiring, and founder ops |
+| Security and SAST helpers | `skills/slo-{rulegen,ruleverify,sast}` | Semgrep rule generation, verification, and SAST wiring |
+| Utilities | `skills/slo-{freeze,resume,second-opinion}` | Session control, resumption, and disagreement surfacing |
+| Vendored helper | `skills/get-api-docs` | Third-party API doc fetches via `chub` |
 
-**Frontend Hooks:**
+For the full host-neutral skill inventory, read `docs/skill-pack-catalog.md`.
 
-- `useStreamingEvents<T>(eventName)` — Generic hook wrapping Tauri `listen()`, accumulates event payloads into React state
-- `usePlan()` — Orchestrates `start_planning` invocation and listens to all three event types
+## Skill pack invariants (reality at HEAD)
 
-### `run_with_callback` Extension (M3)
+- **Markdown-only skill contract.** The portable unit is `skills/<name>/SKILL.md`.
+- **Canonical catalog plus host overlays.** `docs/skill-pack-catalog.md` is the shared catalog. `CLAUDE.md` and `copilot-instructions.md` are overlays, not competing sources of truth.
+- **Canonical planning artifact.** Every feature runbook is `docs/RUNBOOK-<FEATURE>.md` and follows `docs/runbook-template_v_3_template.md`.
+- **Reality-first ARCHITECTURE.md.** This file records implemented surfaces only.
+- **Host-aware installer roots.** Global installs land in `~/.claude/skills/` or `~/.copilot/skills/`. Local installs land in `./.claude/skills/` or `./.copilot/skills/`.
+- **Shared manifest with explicit host ownership.** `~/.sldo/install.toml` stores install records by host so `status`, `verify`, and `uninstall` stay scoped.
+- **Baseline test command.** `cargo test -p sldo-common -p sldo-install -p sldo-research`.
+- **Current runtime boundary.** GitHub Copilot is an interactive host today, not a headless runtime target.
 
-The `CopilotInvocation` struct in `sldo-common/copilot.rs` was extended with a callback-based variant:
+### References subtrees
 
-```rust
-pub fn run_with_callback<F>(&self, log_file: &LogFile, mut on_line: F) -> Result<i32>
-where
-    F: FnMut(&str, &str),  // (line_content, stream_name)
-```
+- `references/biz/` holds shared business-pack scaffolding such as gates, jurisdiction notes, templates, and regulator indexes.
+- `references/sast/` holds SAST-specific references consumed by the security tooling and rule-pack work.
+- These trees are read by skills, but they are not discovered as installable skills because `sldo-install` only walks `skills/<name>/SKILL.md`.
 
-- **`on_line`** receives each output line and the stream name (`"stdout"` or `"stderr"`)
-- The original `run()` method now delegates to `run_with_callback` with a print closure, preserving backward compatibility
-- The Tauri backend uses `run_with_callback` to emit events instead of printing
+## Rust workspace
 
-### Managed State
+The current workspace has four active members:
 
-`AppState` (in `state.rs`) holds:
-
-- `current_session: Mutex<Option<PlanningSession>>` — tracks active planning session
-- `settings: Mutex<AppSettings>` — provider, model, allow/deny flags, execution params, repo directory
-- `cancel_execution: Arc<AtomicBool>` — cancellation flag for execution loop
-- `execution_running: Arc<AtomicBool>` — whether an execution is currently running
-
-### ConversationView Streaming
-
-`ConversationView` accepts an optional `streamingLines` prop:
-
-```tsx
-interface ConversationViewProps {
-  messages: Message[];
-  onSubmit: (text: string) => void;
-  streamingLines?: PlanProgressEvent[];
-}
-```
-
-When `streamingLines` is non-empty, a streaming output block renders below the conversation messages, showing each line with its stream class (`streamLine--stdout` or `streamLine--stderr`).
-
-### Runbook Persistence & Editor (M4)
-
-After planning completes, the runbook is loaded into a Markdown editor for review and editing.
-
-**Backend Commands:**
-
-| Command | Input | Output | Purpose |
-|---|---|---|---|
-| `read_runbook` | `path: String` | `RunbookData { content, milestones, path }` | Read file, parse tracker, return content + milestones |
-| `save_runbook` | `path: String, content: String` | `Vec<String>` (warnings) | Write to disk, re-validate, return any issues |
-
-**Data Flow:**
-
-1. `plan-complete` event fires with `runbook_path`
-2. Frontend calls `read_runbook(path)` → gets content + parsed milestones
-3. MarkdownEditor displays content in edit/preview toggle
-4. MilestoneTracker renders milestone rows with color-coded status
-5. User edits and saves → `save_runbook(path, content)` validates and writes
-6. Warnings (missing sections, empty tracker) displayed below editor
-
-**Frontend Components (M4):**
-
-- `MarkdownEditor` — Toggle between raw textarea (edit) and rendered preview. Supports Ctrl+S, auto-save on blur, validation warnings display
-- `MilestoneTracker` — Renders milestone rows with status icons (✅ done, 🔄 in_progress, ⬜ not_started) and progress bar
-
-**App Phase: "reviewing":**
-
-After planning, the app transitions to the `"reviewing"` phase which shows:
-- MarkdownEditor (main area) — editable runbook content
-- MilestoneTracker (sidebar) — milestone progress overview
-- "Execute Plan" button — transitions to `"executing"` phase (wired in M5)
-
-### Execution Backend & Live Progress (M5)
-
-The execution backend drives Copilot through runbook milestones, streaming live progress to the frontend.
-
-**Backend Commands:**
-
-| Command | Input | Output | Purpose |
-|---|---|---|---|
-| `start_execution` | `runbook_path: String, repo_dir: String` | `String` (status message) | Starts async execution loop on `tokio::spawn` |
-| `cancel_execution` | _(none)_ | `String` (status message) | Sets `AtomicBool` cancellation flag to stop the loop |
-
-**Execution Flow:**
-
-1. Frontend calls `start_execution(runbookPath, repoDir)`
-2. Backend validates inputs, parses tracker, detects build/test commands
-3. If all milestones done, emits `execution-complete` immediately
-4. Otherwise, spawns async loop via `tokio::spawn`:
-   - Reads runbook, finds next incomplete milestone
-   - Emits `milestone-started` event
-   - Builds execution prompt (matching `sldo-run` pattern)
-   - Invokes Copilot via `run_with_callback`, emitting `execution-progress` for each line
-   - Runs build/test verification commands, emitting `build-test-result` for each
-   - Emits `milestone-completed`
-   - Checks cancellation flag before next iteration
-   - Sleeps cooldown between attempts
-5. On completion (or cancellation), emits `execution-complete` with summary
-
-**Cancellation Pattern:**
-
-- `AppState` contains `cancel_execution: Arc<AtomicBool>` and `execution_running: Arc<AtomicBool>`
-- `cancel_execution` command sets the flag to `true`
-- The execution loop checks `cancel_flag.load(Ordering::Relaxed)` between iterations
-- On cancel, the loop breaks and emits `execution-complete`
-
-**Execution Event Types** (defined in `events.rs`):
-
-| Event | Payload | When |
-|---|---|---|
-| `milestone-started` | `MilestoneStartedEvent { milestone_number, title, attempt }` | Each milestone attempt begins |
-| `execution-progress` | `ExecutionProgressEvent { line, stream, timestamp }` | Each line of Copilot output |
-| `build-test-result` | `BuildTestResultEvent { command, success, output }` | After each build/test command |
-| `milestone-completed` | `MilestoneCompletedEvent { milestone_number, success }` | Milestone attempt finishes |
-| `execution-complete` | `ExecutionCompleteEvent { all_done, milestones_completed, total }` | Entire execution run ends |
-
-**Frontend Components (M5):**
-
-- `ExecutionView` — Main execution display with log panel, build/test results, cancel button, and sidebar milestone tracker
-- `useExecution` hook — Wraps `start_execution`/`cancel_execution` commands and listens to all execution events
-- `MilestoneTracker` — Updated with optional `activeMilestone` prop to highlight the currently executing milestone
-
-**App Phase: "executing":**
-
-After clicking "Execute Plan", the app transitions to the `"executing"` phase which shows:
-- Log panel (main area) — streaming agent output with stdout/stderr distinction
-- Build/test results — pass/fail indicators for verification commands
-- Cancel button — stops execution mid-run
-- MilestoneTracker (sidebar) — live progress with active milestone highlight
-
-### Provider Trait & Settings (M6)
-
-The `Provider` trait (in `provider.rs`) abstracts agent invocation so the system can support multiple coding agents:
-
-```rust
-pub trait Provider: Send + Sync {
-    fn name(&self) -> &str;
-    fn available_models(&self) -> Vec<String>;
-    fn invoke(&self, prompt: &str, model: &str, allow_flags: &[String],
-              deny_flags: &[String], working_dir: &Path, log_file: &LogFile,
-              on_line: Box<dyn FnMut(&str, &str) + Send>) -> Result<i32>;
-}
-```
-
-- `CopilotProvider` wraps `CopilotInvocation::run_with_callback()`
-- `get_provider(name)` factory function returns a boxed provider by name
-- `available_providers()` lists all registered provider names
-
-**Settings Persistence:**
-
-`AppSettings` (in `state.rs`) is serialized as JSON to `<tauri_app_data_dir>/settings.json`:
-
-| Field | Type | Default | Purpose |
-|---|---|---|---|
-| `provider` | `String` | `"copilot"` | Active agent provider |
-| `model` | `String` | `"claude-opus-4-7"` | Model for planning/execution |
-| `allow_flags` | `Vec<String>` | `toolflags::plan_allow_flags()` | Tool permission allow flags |
-| `deny_flags` | `Vec<String>` | `toolflags::plan_deny_flags()` | Tool permission deny flags |
-| `max_attempts` | `u32` | `150` | Max execution attempts |
-| `cooldown_secs` | `u64` | `5` | Cooldown between attempts |
-| `max_iterations` | `u32` | `3` | Max planning iterations |
-| `repo_dir` | `Option<String>` | `None` | Repository directory |
-
-- Settings are loaded on app startup via `setup()` hook
-- Invalid/missing settings.json falls back to defaults with a warning
-- Planning and execution commands read from managed `AppSettings` instead of hardcoded values
-
-**Settings Commands:**
-
-| Command | Input | Output | Purpose |
-|---|---|---|---|
-| `get_settings` | _(none)_ | `AppSettings` | Read current in-memory settings |
-| `update_settings` | `AppSettings` | `()` | Persist to disk and update state |
-| `get_available_providers` | _(none)_ | `Vec<String>` | List provider names |
-| `get_available_models` | `provider_name: String` | `Vec<String>` | List models for a provider |
-
-**Frontend Components (M6):**
-
-- `SettingsPanel` — Form with provider selector, model input, tool flags editor, execution params, save button
-- `AppSettings` TypeScript type mirrors the Rust struct
-
-**App Phase: "settings":**
-
-Clicking "Settings" in the sidebar transitions to the `"settings"` phase, rendering the `SettingsPanel` component with current settings values.
-
-### Voice Input & Speech-to-Text (M7)
-
-**Architecture:**
-
-The voice feature uses a three-layer design:
-
-1. **Frontend** — `VoiceButton` component + `useVoice` hook manage `MediaRecorder` API lifecycle
-2. **Tauri Command** — `transcribe_audio` receives base64-encoded audio, proxies to STT provider
-3. **STT Provider** — Initially OpenAI Whisper API; the backend handles the API key securely
-
-**Security:** The `OPENAI_API_KEY` is never sent to the frontend. The Tauri backend reads it from the environment (via `dotenvy` loading `.env` if present) and proxies the STT request.
-
-**Voice Command:**
-
-| Command | Input | Output | Purpose |
-|---|---|---|---|
-| `transcribe_audio` | `audio_base64: String` | `String` | Send audio to STT via Rig abstraction (chat input) |
-| `transcribe_audio_standalone` | `audio_base64: String, mime_type: String` | `String` | Direct reqwest multipart POST to OpenAI with MIME-aware filename (standalone page) |
-
-**Frontend Components (M7):**
-
-- `VoiceButton` — Three-state button: idle (🎙), recording (⏹ pulsing), transcribing (⏳ spinner)
-- `useVoice` hook — Manages `MediaRecorder`, converts audio to base64, invokes Tauri command
-- `ChatInput` — Integrates `VoiceButton` next to the Send button; transcription populates textarea
-
-**Data Flow:**
-
-```
-User clicks 🎙 → MediaRecorder.start() → User clicks ⏹ → MediaRecorder.stop()
-→ Blob → base64 → invoke("transcribe_audio") → Rust backend
-→ dotenvy loads .env → reqwest POST to OpenAI Whisper API
-→ transcribed text → frontend → textarea populated
-```
-
-**Error Handling:**
-
-- Missing API key → descriptive error mentioning "API key"
-- Invalid base64 → error mentioning "base64"
-- Network failure → error mentioning "connection"
-- Empty transcription → error mentioning "empty"
-
-### Polish, Error Boundaries & Keyboard Shortcuts (M8)
-
-**Error Boundary:**
-
-The app uses a React `ErrorBoundary` class component (in `components/ErrorBoundary.tsx`) that wraps the entire application in `main.tsx`. If any child component throws during rendering:
-
-1. `getDerivedStateFromError` captures the error and switches to fallback UI
-2. Fallback shows "Something went wrong" with the error message and a "Try Again" button
-3. "Try Again" resets the boundary state, re-rendering children
-
-### Voice Transcriber — Standalone Page (voice-tx M1)
-
-The app includes a dedicated standalone voice transcription page, separate from the chat-embedded `VoiceButton`. This page is accessible via the "Transcriber" button in the sidebar.
-
-**Routing:**
-
-- `AppPhase` type includes `"transcriber"` as a valid phase
-- `App.tsx` renders `VoiceTranscriber` when the phase is `"transcriber"`
-- `Sidebar.tsx` has a "Transcriber" button that sets the app phase
-
-**Component: `VoiceTranscriber.tsx`**
-
-A functional recording page with:
-- Heading: "Tauri Voice Transcriber"
-- Description text
-- Start recording button (enabled when idle, disabled when recording/transcribing)
-- Stop recording button (enabled only when recording)
-- Status display: "Listening to your microphone…" during recording, "Transcribing with OpenAI…" during transcription
-- Transcript textarea (editable, populated after transcription)
-- Error display area (red-bordered box on error)
-
-**Hook: `useStandaloneVoice.ts`**
-
-Manages the full MediaRecorder lifecycle for the standalone transcriber:
-- `startRecording()`: requests microphone via `getUserMedia`, creates `MediaRecorder` with MIME type preference (`audio/webm;codecs=opus` → `audio/webm` → `audio/mp4` → `audio/ogg;codecs=opus`), collects chunks via `ondataavailable`
-- `stopRecording()`: stops recorder, in `onstop` combines chunks, converts to base64 via `FileReader.readAsDataURL`, invokes `transcribe_audio_standalone` Tauri command with actual `mimeType`
-- State: `isRecording`, `isTranscribing`, `transcript`, `error`, `setTranscript`
-- Cleanup: releases microphone tracks on stop and on unmount
-- Empty recording guard: rejects 0-byte recordings with "No audio was captured" before calling the backend
-
-**macOS Microphone Permission:**
-
-The file `crates/sldo-tauri/Info.plist` declares `NSMicrophoneUsageDescription` so that macOS prompts the user for microphone access on first use. This plist entry is required for any macOS app that accesses the microphone via `getUserMedia`.
-
-**Styling:**
-
-`VoiceTranscriber` uses CSS classes defined in `App.css` (prefixed with `voiceTranscriber`) that follow the app's design system — dark background, gold accent tokens, consistent border-radius, and the same font/spacing scale used throughout. Inline styles have been removed in favor of these shared classes.
-
-**Production Security Guidance:**
-
-The `OPENAI_API_KEY` is loaded server-side by the Tauri backend — it is never exposed to the frontend process. For local development, place the key in a `.env` file at the project root. **Do not ship a shared API key in a distributed binary.** In production, each user should provide their own key (via environment variable, `.env` file, or a future settings UI backed by the OS keychain).
-
-**Design rule:** `VoiceTranscriber` is fully separate from `VoiceButton` — it does not reuse `useVoice`. It uses its own `useStandaloneVoice` hook.
-
-**Keyboard Shortcuts:**
-
-Global keyboard shortcuts are registered via a `useEffect` in `App.tsx`:
-
-| Shortcut | Action |
+| Member | Role |
 |---|---|
-| `Cmd/Ctrl+Enter` | Submit prompt (handled in `ChatInput.tsx` via `onKeyDown`) |
-| `Cmd/Ctrl+N` | New session — resets all state to home screen |
-| `Cmd/Ctrl+,` | Open settings panel |
-| `Escape` | Close settings panel |
+| `crates/sldo-common` | Shared library used by the remaining Rust tools |
+| `crates/sldo-research` | Research backend for sourced dossier generation |
+| `crates/sldo-install` | Host-aware installer for the skill pack |
+| `xtasks/sast-verify` | Deterministic Semgrep validation, coverage, and gate runner |
 
-**Concurrency Safety:**
+The root package `sunlit-orchestrate-tests` hosts workspace-level integration tests in `tests/`.
 
-- `AppState.execution_running: Arc<AtomicBool>` prevents concurrent execution runs
-- `PlanningSession.in_progress` prevents concurrent planning sessions
-- Both use `compare_exchange` with `SeqCst` ordering for thread-safe checks
+## Shared library: `sldo-common`
 
-## sldo-research CLI
+`crates/sldo-common/src/lib.rs` currently exports these modules:
 
-A third CLI, `sldo-research`, generates a structured research dossier that can be
-fed as the `prompt_file` argument to `sldo-plan`. The full pipeline lands across
-milestones; the sections below grow as each milestone ships.
-
-### sldo-research — Research Prompt Builder (M2)
-
-`crates/sldo-research/src/prompt.rs` holds three pure prompt constructors that
-return `String` values. They take plain inputs (slices and optional paths) and
-perform no I/O, no network, and no environment access — the caller is
-responsible for canonicalising paths and reading prompt files.
-
-| Function | Purpose |
+| Module | Responsibility |
 |---|---|
-| `build_exploration_prompt(prompt_content, repo_dir)` | Asks Claude Code to decompose the topic, identify key concepts, gather initial findings, and optionally observe a repo. |
-| `build_deepening_prompt(prompt_content, previous_findings, iteration, repo_dir)` | Re-feeds prior findings (truncated at ~32 KiB) and asks for deepened findings, library evaluations, architecture options, and unanswered questions. Iteration ≥ 3 invites consolidation for the M6 synthesis pass. |
-| `build_repo_context_prompt(repo_dir)` | Asks Claude Code to summarise tech stack, project structure, build/test commands, existing patterns, and constraints from a given repository. |
+| `color` | Small color and output helpers |
+| `copilot` | Agent/CLI invocation helpers used by the Rust backends |
+| `detect` | Environment and tool detection helpers |
+| `git` | Git inspection helpers |
+| `logging` | Logging setup and formatting |
+| `preflight` | Pre-run checks for required binaries and environment state |
+| `runbook` | Shared runbook parsing and validation helpers |
+| `toolflags` | Shared allow-flag definitions and related helpers |
 
-Each prompt embeds fixed `## …` section headers as a contract that later
-milestones rely on:
+## Research backend: `sldo-research`
 
-- **Exploration phase:** `## Topic Decomposition`, `## Key Questions`, `## Initial Findings`, and (when a repo is supplied) `## Repo Context`.
-- **Deepening phase:** `## Deepened Findings`, `## Library Evaluations`, `## Architecture Options`, `## Unanswered Questions`.
-- **Repo-context phase:** `## Tech Stack`, `## Project Structure`, `## Build & Test`, `## Existing Patterns`, `## Constraints`.
+`crates/sldo-research/` is the Rust backend for the `/slo-research` skill. Its source is organized into:
 
-At M2 the binary constructs the exploration prompt after pre-flight and prints
-its byte length + first line. The Claude Code invocation itself lands in M3.
-
-### sldo-research — Research Loop (M3)
-
-`crates/sldo-research/src/research.rs` drives Claude Code through the
-exploration → deepening pipeline. The module is two layers:
-
-- **`ResearchConfig`** — owned input bundle (prompt, optional canonicalised
-  repo dir, output path, model, max iterations, cooldown seconds, log
-  directory). Constructed once in `main.rs::run()` and passed by reference
-  into `research_loop`.
-- **`research_loop(&ResearchConfig) -> Result<String>`** — drives three
-  phases and returns the accumulated findings string. Per-phase failures are
-  logged via `warn(...)` but never abort the loop; the function only fails
-  fast on filesystem errors (e.g., the output parent cannot be created).
-
-**Phases:**
-
-| Phase | Log file | Triggered when |
-|---|---|---|
-| Repo context | `.sldo-logs/research-repo-context.log` | `repo_dir` is `Some` |
-| Exploration | `.sldo-logs/research-exploration.log` | always (iteration 1) |
-| Deepening   | `.sldo-logs/research-deepen-N.log` (N=2..max) | `max_iterations >= 2` |
-
-A `cooldown_secs` sleep is inserted **before** each deepening iteration
-(matching `sldo-plan`'s pacing). A scratch file named
-`.research-scratch-iter-N.md` is written next to the dossier output path
-after each phase that produced findings — these are the raw per-phase
-captures used by M5 (web-search) and M6 (synthesis).
-
-Claude Code is invoked through `sldo_common::copilot::ClaudeInvocation`
-with `toolflags::research_allow_flags()` / `research_deny_flags()`. The
-working directory passed to Claude is the canonical `repo_dir` if provided,
-otherwise the process CWD.
-
-The binary surfaces an `info("Research accumulated N bytes of findings")`
-line after the loop — the M3 E2E test asserts on this string to prove the
-loop ran end-to-end without invoking the real Claude API (the test suite
-prepends a temp-dir containing a stub `claude` shell script to `PATH`).
-
-### Dossier format (M4)
-
-`crates/sldo-research/src/dossier.rs` holds the dossier markdown schema and
-the writer/validator pair that sit between the research loop and the rest of
-the pipeline. The writer is pure `std + chrono` — no I/O beyond the target
-file — and the validator follows `sldo-plan::validate_runbook`'s shape
-(returns `Vec<String>` issues, never panics).
-
-**Required sections (order-preserving):**
-
-| Section | Purpose |
+| File | Responsibility |
 |---|---|
-| `## Executive Summary` | One-paragraph synthesis (stubbed at M4, filled at M6). |
-| `## Topic Decomposition` | The sub-questions from the exploration phase. |
-| `## Key Findings` | Raw findings captured from the research loop. |
-| `## Library & Tool Evaluations` | Libraries considered and pros/cons. |
-| `## Architecture Options` | Candidate architectures with trade-offs. |
-| `## API & SDK Documentation` | Notes from web search / vendor docs. |
-| `## Design Recommendations` | Ranked recommendations (confidence at M6). |
-| `## Risks & Open Questions` | Anything left unanswered. |
-| `## References` | URLs and citations. |
+| `main.rs` | CLI entrypoint |
+| `research.rs` | Research orchestration |
+| `prompt.rs` | Prompt construction |
+| `dossier.rs` | Dossier assembly and related helpers |
 
-The optional `## Repository Context` section is inserted between the
-frontmatter and the required sections when `--repo-dir` was supplied and the
-repo-context phase produced output.
+The installed skill is host-neutral. The automated batch backend behind it is still Claude-specific today, which is why the capability matrix calls that boundary out explicitly.
 
-**Frontmatter fields:** `topic` (single-line excerpt of the user prompt,
-≤200 chars), `generated_on` (local timestamp), `source_prompt_bytes`,
-`generator: sldo-research`.
+## Installer: `sldo-install`
 
-**Key constants:**
+`crates/sldo-install/` is the bridge between the repo and host-specific skill directories.
 
-- `REQUIRED_SECTIONS` — the nine always-present section headers above.
-- `PLACEHOLDER_PATTERNS` — `[TBD]`, `[description]`, `[findings]`,
-  `[to be filled]`, `TODO:`. These cause `validate_dossier` to report an
-  issue.
-- `M4_STUB_SENTINEL` — the literal string `"To be synthesised in M6"` that
-  the writer emits inside every non-`Key Findings` required section. M4's
-  validator tolerates the sentinel; M6's synthesis pass replaces it; M7's
-  `check_plan_readiness` asserts its absence.
+| File | Responsibility |
+|---|---|
+| `main.rs` | CLI parsing and command dispatch |
+| `host.rs` | Host descriptor table (`claude-code`, `github-copilot`) |
+| `paths.rs` | Host-specific global and local path resolution |
+| `manifest.rs` | Shared install manifest with per-host ownership |
+| `install.rs` | Install, verify, status, and uninstall behavior |
 
-**`write_dossier`** creates any missing parent directories, writes the
-frontmatter + section skeleton, and fails only if the target path cannot
-be written. **`validate_dossier`** checks file existence, size ≥ 500 bytes,
-every `REQUIRED_SECTIONS` header, and any placeholder pattern. M3's
-`research_loop` return type became `ResearchFindings { raw, repo_context }`
-in M4 so the writer can emit the repo-context section separately from the
-raw findings.
+## SAST xtask: `xtasks/sast-verify`
 
-### Synthesis pass (M6)
+`xtasks/sast-verify/` is the deterministic Semgrep verification toolchain used by the SAST skill work.
 
-`build_synthesis_prompt(prompt, all_findings, repo_context)` in
-`crates/sldo-research/src/prompt.rs` produces a single Claude Code prompt
-that consumes the concatenated raw findings (exploration + web-search +
-deepening) and asks for a coherent dossier body conforming exactly to
-`dossier::REQUIRED_SECTIONS`. The prompt embeds the section list verbatim
-(so Claude cannot rename or omit headers), requires `(confidence: high|
-medium|low)` tags on every entry under `## Design Recommendations`, asks
-for explicit `## Risks & Open Questions` flagging, and instructs URL
-extraction into `## References` as `- [Title](URL)` bullets. Raw findings
-are truncated at 100 KiB (tail-preserving) to keep the prompt under
-Claude's context window.
+| File | Responsibility |
+|---|---|
+| `main.rs` | Subcommand entrypoint |
+| `validate.rs` | `semgrep --validate` wrapper |
+| `test_cmd.rs` | `semgrep --test` wrapper |
+| `check_coverage.rs` | Coverage checks |
+| `check_clean.rs` | Clean-tree checks for generated fixtures |
+| `gate.rs` | Composes the full deterministic gate |
+| `tier_detect.rs` | Rule-tier detection |
+| `semgrep_runner.rs` | Shared Semgrep invocation plumbing |
+| `validate_file_paths.rs` | Input path checks |
+| `yaml_schema.rs` | YAML/schema helpers |
 
-`research_loop` runs synthesis as one final invocation after the
-deepening loop. The captured stdout becomes
-`ResearchFindings.synthesised: Option<String>`. Synthesis output is gated
-by `synth_output_well_formed` — every entry in `REQUIRED_SECTIONS` must
-appear in the response, otherwise the result is treated as malformed and
-`synthesised` stays `None`. This shields the M4 fallback path from
-truncated, off-spec, or test-shim responses. Spawn errors, non-zero exit
-codes, and empty output also resolve to `None`. The phase log file is
-`.sldo-logs/research-synthesis.log`.
+## Current host boundaries
 
-`dossier::write_dossier` accepts an additional `synthesised: Option<&str>`
-parameter. When `Some(text)` and `text` is non-empty, the synthesised
-body is embedded verbatim in place of the M4 stub skeleton. When `None`,
-the writer falls back to the M4 layout (raw findings under
-`## Key Findings`, `M4_STUB_SENTINEL` everywhere else). The dossier is
-always written.
+The current host line is simple:
 
-`dossier::check_synthesis_complete(path)` is a stricter post-M6 readiness
-helper that returns issues if the dossier still contains the
-`M4_STUB_SENTINEL`. Designed to be called by M7's plan-readiness gate;
-intentionally separate from `validate_dossier`, which still tolerates the
-sentinel for M4 compatibility.
+- Install support is multi-host.
+- The catalog and the `SKILL.md` contract are host-neutral.
+- Interactive skill use is supported in Claude Code and GitHub Copilot.
+- Headless runtime automation is still Claude-specific where it exists today.
+- `/slo-research` automated batch execution and the live business judgment runtime harness are the main remaining Claude-only paths.
 
-The phase is **prompt-driven** — no new Rust crates were added, no parsing
-of section headers happens on the Rust side. Claude Code does the
-synthesis; the Rust pipeline structurally validates the result and falls
-back when necessary.
-
-### Web search phase (M5)
-
-`build_websearch_prompt(topic, questions, search_index)` in
-`crates/sldo-research/src/prompt.rs` produces a Claude Code prompt that
-asks the model to use its built-in `WebFetch` and `WebSearch` tools to
-find current documentation, library versions, and community articles for
-the supplied topic. The prompt requires output under three fixed headers
-— `## Web Search Results`, `## Documentation Found`, and
-`## Library Versions` — and explicitly asks for URL + title pairs so
-M6 can extract them into the dossier's `## References` section.
-
-`research_loop` runs `cfg.max_searches` web-search invocations between
-exploration (iteration 1) and deepening (iterations 2..=max). Per-search
-log files are named `.sldo-logs/research-websearch-<N>.log`. The phase
-partitions the exploration's `## Key Questions` body across invocations
-via `extract_key_questions`; when the section is absent the prompt falls
-back to broad topic research. `--max-searches 0` skips the phase entirely
-(no log files, no invocations). Per-search Claude failures (spawn errors,
-non-zero exits) log a warning and the loop continues — they never halt
-the pipeline. No `cooldown_secs` sleep is inserted between web-search
-invocations: web phases are lighter than deepening passes and don't need
-the inter-call pause.
-
-The phase is **prompt-driven**: no new Rust HTTP client or `reqwest`
-dependency was added. Tool access is gated by
-`toolflags::research_allow_flags()` (which already shipped `WebFetch` and
-`WebSearch` at M1). `plan_allow_flags()` does **not** include `WebSearch`
-— planning runs offline by design — and a regression test pins this.
-
-### Plan-readiness gate (M7)
-
-`dossier::check_plan_readiness(path) -> Vec<String>` is the strict
-end-of-pipeline gate that confirms the dossier is suitable as input to
-`sldo-plan`. It composes `validate_dossier` + `check_synthesis_complete`
-with three additional constraints:
-
-1. The file is valid UTF-8 (`std::fs::read_to_string` succeeds) — the
-   contract `sldo-plan` requires of its `prompt_file`.
-2. Total size > `MIN_PLAN_READY_SIZE` (1 KiB) — stricter than the M4
-   500-byte threshold.
-3. `## Design Recommendations` has > `MIN_SECTION_BODY_BYTES` (100 bytes)
-   of content after its header, AND at least one of `## Library & Tool
-   Evaluations` / `## Architecture Options` has > 100 bytes of content.
-
-Section-body extraction uses a private `section_body(content, header)`
-helper that returns the text between a header and the next top-level
-`## ` marker. The helper is line-aware (skips the header's own newline
-before slicing) so a header followed immediately by another header
-returns an empty body.
-
-`sldo-plan` is **not modified**. The gate lives entirely inside
-`sldo-research` and is layered on top of the existing M4/M6 validators —
-none of those are weakened.
-
-`sldo-research::main` calls the gate after `validate_dossier` and prints
-either:
-- a "Research dossier is ready for planning" success block followed by a
-  suggested `sldo-plan <dossier> <repo-dir>` command, when the gate
-  returns no issues, or
-- a warning block listing the issues, with the next-step suggestion
-  suppressed.
-
-Either way the binary exits 0 and the dossier is always written —
-plan-readiness is observability, not a hard gate. A "Summary" block
-(dossier path, byte count, iteration/search counts, total wall time) is
-printed unconditionally before the readiness verdict, mirroring
-`sldo-plan`'s end-of-run summary style.
-
-### sldo-research pipeline overview
-
-End-to-end, a single `sldo-research` invocation runs:
-
-```
-prompt + (optional repo-dir)
-   │
-   ▼
-preflight ──── claude-on-PATH check, optional repo + git safety check
-   │
-   ▼
-[optional] repo-context phase ─── one Claude call per --repo-dir
-   │
-   ▼
-exploration phase ─── one Claude call (always)
-   │                   ↓ raw findings appended
-   ▼
-web-search phase ─── 0..=N Claude calls (N = --max-searches)
-   │                   ↓ each appended to raw
-   ▼
-deepening phase ─── 0..=M Claude calls (M = --max-iterations - 1)
-   │                   ↓ each appended to raw, cooldown_secs between calls
-   ▼
-synthesis phase ─── one Claude call (skipped only when raw is empty)
-   │                   ↓ Option<String>; well-formedness gate rejects
-   │                     responses missing required dossier headers
-   ▼
-write_dossier ─── synth body if Some; M4 fallback layout otherwise
-   │
-   ▼
-validate_dossier (M4 ruleset) ─── informational
-   │
-   ▼
-check_plan_readiness (M7 strict ruleset) ─── prints Next-step or warnings
-```
-
-Per-phase log files: `.sldo-logs/research-repo-context.log`,
-`research-exploration.log`, `research-websearch-<N>.log`,
-`research-deepen-<N>.log`, `research-synthesis.log`. Per-phase scratch
-files (raw stdout captures): `.research-scratch-iter-<N>.md` next to the
-dossier output. The full pipeline is **prompt-driven** — every Claude
-invocation goes through `sldo_common::copilot::ClaudeInvocation` with the
-`research_allow_flags()` / `research_deny_flags()` toolset.
-
-### Pipeline composition
-
-The three CLIs compose into a single user workflow:
-
-```
-$ sldo-research --prompt "add feature flags" --repo-dir ./my-repo
-  → output/research-dossier.md  (plan-ready)
-
-$ sldo-plan output/research-dossier.md ./my-repo -o docs/RUNBOOK.md
-  → docs/RUNBOOK.md             (milestone tracker)
-
-$ sldo-run docs/RUNBOOK.md ./my-repo
-  → drives Claude Code through each milestone
-```
-
-`sldo-research` is the only CLI that runs web search; `sldo-plan` and
-`sldo-run` operate offline (their `*_allow_flags()` deliberately exclude
-`WebFetch`/`WebSearch`).
-
-## Test Architecture
-
-### Backend Tests
-
-| Suite | Location | Tests | Purpose |
-|---|---|---|---|
-| sldo-common unit | `crates/sldo-common/src/*.rs` | 48 | Core library validation |
-| sldo-plan unit | `crates/sldo-plan/src/main.rs` | 21 | Planning CLI tests |
-| sldo-run unit | `crates/sldo-run/src/main.rs` | 13 | Execution CLI tests |
-| sldo-tauri unit | `crates/sldo-tauri/src/**/*.rs` | 65 | Tauri backend tests |
-| E2E scaffold | `tests/e2e_scaffold_m1.rs` | 4 | Framework validation |
-| E2E common | `tests/e2e_common_m2.rs` | 7 | Shared library E2E |
-| E2E plan | `tests/e2e_plan_m3.rs` | 4 | Planning CLI E2E |
-| E2E run | `tests/e2e_run_m4.rs` | 4 | Execution CLI E2E |
-| E2E integration | `tests/e2e_integration_m5.rs` | 4 | Cross-crate integration |
-| E2E tauri M1 | `tests/e2e_tauri_m1.rs` | 7 | Tauri scaffold E2E |
-| E2E tauri M3 | `tests/e2e_tauri_m3.rs` | 5 | Planning backend E2E |
-| E2E tauri M4 | `tests/e2e_tauri_m4.rs` | 3 | Editor backend E2E |
-| E2E tauri M5 | `tests/e2e_tauri_m5.rs` | 10 | Execution backend E2E |
-| E2E tauri M6 | `tests/e2e_tauri_m6.rs` | 6 | Settings/provider E2E |
-| E2E tauri M7 | `tests/e2e_tauri_m7.rs` | 2 | Voice backend E2E |
-| E2E tauri M8 | `tests/e2e_tauri_m8.rs` | 6 | Integration & polish E2E |
-| E2E voice-tx M1 | `tests/e2e_voice_tx_m1.rs` | 2 | Voice transcriber route E2E |
-| E2E voice-tx M2 | `tests/e2e_voice_tx_m2.rs` | 5 | Standalone transcription backend E2E |
-| E2E voice-tx M4 | `tests/e2e_voice_tx_m4.rs` | 4 | Edge cases & macOS permission E2E |
-| E2E voice-tx M5 | `tests/e2e_voice_tx_m5.rs` | 3 | Polish & documentation E2E |
-| E2E research M1 | `tests/e2e_research_m1.rs` | 6 | Research scaffold E2E |
-| E2E research M2 | `tests/e2e_research_m2.rs` | 3 | Prompt builder E2E |
-| E2E research M3 | `tests/e2e_research_m3.rs` | 9 | Research loop E2E |
-| E2E research M4 | `tests/e2e_research_m4.rs` | 6 | Dossier writer & validator E2E |
-| E2E research M5 | `tests/e2e_research_m5.rs` | 4 | Web-search phase integration E2E |
-| E2E research M6 | `tests/e2e_research_m6.rs` | 4 | Multi-source synthesis pass E2E |
-| E2E research M7 | `tests/e2e_research_m7.rs` | 7 | Plan-readiness gate + sldo-plan integration E2E |
-
-**Total backend tests: 241**
-
-### Frontend Tests
-
-| Suite | Location | Tests | Purpose |
-|---|---|---|---|
-| BDD component tests | `ui/src/components/*.test.tsx` | 55+ | Component behavior validation |
-| E2E chatui | `ui/src/e2e/chatui.e2e.test.tsx` | 4 | Chat UI runtime validation |
-| E2E planning | `ui/src/e2e/planning.e2e.test.tsx` | 2 | Planning flow validation |
-| E2E editor | `ui/src/e2e/editor.e2e.test.tsx` | 3+ | Editor runtime validation |
-| E2E execution | `ui/src/e2e/execution.e2e.test.tsx` | 3 | Execution flow validation |
-| E2E settings | `ui/src/e2e/settings.e2e.test.tsx` | 3 | Settings panel validation |
-| E2E voice | `ui/src/e2e/voice.e2e.test.tsx` | 3 | Voice input validation |
-| E2E transcriber | `ui/src/e2e/transcriber.e2e.test.tsx` | 4 | Standalone transcriber E2E |
-| E2E integration | `ui/src/e2e/integration.e2e.test.tsx` | 6 | Full workflow integration |
-
-**Total frontend tests: 122**
+Read `docs/design/agent-host-capabilities.md` before making any stronger host-compatibility promise than that.

--- a/docs/PARADIGM-OVER-ENGINEERING-FOR-SIMPLICITY.md
+++ b/docs/PARADIGM-OVER-ENGINEERING-FOR-SIMPLICITY.md
@@ -1,0 +1,154 @@
+---
+name: paradigm-over-engineering-for-simplicity
+created: 2026-04-28
+status: living-doc — paradigm reference, no staleness check
+audience: every contributor (human or agent) authoring or modifying SLO skills, runbooks, or references
+purpose: |
+  Capture the design paradigm that LLM-driven workflows can sustainably carry MORE
+  discipline than human-driven workflows — because LLMs do not pay the cognitive-load
+  tax humans do. Apply this lens when deciding whether a given discipline (security
+  step, validation gate, intake question, citation requirement) is "too much".
+  Balance against context-window constraints, not against human attention spans.
+---
+
+# Over-engineering for simplicity — the paradigm
+
+## The premise
+
+Traditional engineering and product practice has a load-bearing constraint: **humans are the executors**. Every checklist item costs attention. Every gate slows a sprint. Every required citation multiplies code-review effort. The result is a constant trade-off: ship more discipline → people skip steps → discipline degrades into theatre. Ship less discipline → real risks slip through.
+
+The compromise is well-documented in the security literature: tell users to do 20 things → they do 3 → the 17 they skipped are the gaps that get exploited. Same shape in code review (PRs with 200-item checklists go unreviewed), in onboarding (15-step setup procedures get cargo-culted), in reliability (SRE playbooks of 50 steps get partially-followed under stress).
+
+LLMs change this calculation.
+
+An LLM agent does not pay the cognitive-load tax. It does not skip step 14 because it is tired. It does not paraphrase a citation because reading the source is tedious. It does not collapse a 12-question intake to 3 questions because the founder seems impatient (assuming the skill prose says don't). Within its context window, it executes the discipline as written.
+
+This means: **the SLO skill pack can sustainably carry more discipline than a human-driven equivalent**. Where humans optimize for the smallest viable set of practices that will actually get followed, LLMs let us optimize for the largest set that fits the context window without degrading attention.
+
+The result, paradoxically, is **simpler** experience for the primary persona — the user (founder, engineer, employee). The user sees the OUTPUT of the disciplined process: the lawyer-review-recommended draft, the source-cited KPI dashboard, the threat-modeled architecture, the verified math. They do not see the 20 steps that produced it.
+
+## What "over-engineering for simplicity" means concretely
+
+Concrete patterns we apply across the SLO skill pack because the LLM is the executor:
+
+### 1. Multi-layer defense without user friction
+
+A human-driven workflow with 4 redundant defenses against the same risk feels paranoid; the human notices the redundancy and shortcuts to one. An LLM-driven workflow with 4 redundant defenses simply runs all 4 — the user sees one outcome.
+
+Example: PII protection in [the biz pack](RUNBOOK-BIZ-SKILL-PACK-A.md):
+- Layer 1: `tier: confidential` artifact frontmatter + auto-routing to `docs/biz/`.
+- Layer 2: `.gitignore` rule excluding `docs/biz/` from version control.
+- Layer 3: skill write-time warning when target dir is git-tracked AND a remote exists AND `tier: confidential`.
+- Layer 4: `/slo-verify` Pass 4 PII-pattern scan over `docs/biz-public/` catches anonymisation failures.
+
+A human pipeline would pick one and move on; the LLM pipeline runs all four. The user just sees "your interview transcript is saved confidentially."
+
+### 2. Comprehensive, not minimum-viable, intake
+
+Where a human-designed form might ask 3 questions and infer the rest, an LLM-designed conversational intake asks 12 questions because the marginal cost of the 9 extra questions is "the conversation lasts 30 seconds longer, and the LLM needs no extra training to ask them well". The data quality at the gate-evaluation step is dramatically better.
+
+Example: [the legal-intake-contract](../references/biz/legal-intake-form.md)'s F1-F6 fields with explicit-comprehension follow-ups (per critique S-1). A human template would skip half; an LLM contract preserves them all because the conversational delivery makes them feel natural.
+
+### 3. Exhaustive citation discipline
+
+Source hierarchy (tool docs at pinned version → tool repo CHANGELOG → upstream advisory DB → conference papers → vendor blog secondary → never Stack Overflow) is unrealistic for human authors at scale — the manual fact-checking cost is prohibitive. For an LLM authoring a skill or runbook, consulting authority files is just-another-tool-call; the discipline holds across hundreds of citations per runbook.
+
+This is why R3 (business skill improvements) can mandate verbatim quotes from `legislation.gov.uk` for every UK statute citation across 5 advisor skills + 7 generator skills, where a human team would settle for "general counsel reviewed this once".
+
+### 4. Layered structural-contract tests
+
+Where a human team might ship one or two integration tests per milestone, the SLO pack ships:
+
+- BDD tests per scenario
+- E2E runtime validation tests
+- Structural-contract tests (markdown-shape assertions)
+- Cross-skill citation tests
+- Frontmatter schema validation tests
+- Soft line-cap tests
+- Closed-enum immutability tests
+
+Each adds a few minutes of LLM-authoring cost; they catch a different failure class. Humans would resist 7 test categories per milestone; the LLM pipeline absorbs them.
+
+### 5. Comprehensive abuse-case enumeration
+
+For every new surface a milestone introduces, [`/slo-architect`](../skills/slo-architect/SKILL.md) Step 3.5 mandates THREE abuse cases (attacker, attack step, desired outcome, control, stable id). For 5 milestones with new surfaces, that's 15 abuse cases per runbook. A human team threat-models once at design time and forgets; the LLM pipeline keeps the rows in the milestone Contract Block, cited from the threat model, traced through `/slo-critique`'s security persona, asserted at `/slo-verify` Pass 4.
+
+### 6. Verbatim discipline preservation across decomposition
+
+R2's M2/M3 decompositions of `/slo-sast` (296 → ≤100 lines) and `/slo-tla` (323 → ≤150 lines) require **prose preservation**: every line of the old SKILL.md must appear in the new (SKILL.md ∪ methodology files), verifiable by structural-contract test. A human refactor would summarize for "readability"; the LLM-driven decomposition preserves discipline even when the lines look redundant.
+
+## Where the paradigm balances
+
+The over-engineering paradigm is bounded by **context window**, not by attention.
+
+If a SKILL.md has 296 lines and a methodology spread across 8 reference files totals 1,200 lines, an LLM agent under context pressure WILL read less of it. The decomposition disciplines (R2 M2-M4) and the soft line-cap structural-contract test (R2 M4) exist because **the LLM is not infinitely-tolerant**; it is highly-tolerant relative to humans, but its limit is the context window.
+
+Practical balance rules:
+
+- **SKILL.md ≤ 200 lines** (soft line-cap, with `# soft-cap-exception:` pragma for documented exceptions). The orchestrator stays lean; methodology lives in references loaded on-demand.
+- **Per-stage methodology files ≤ 500 lines** each. Beyond that, sub-decompose.
+- **Reference files (authority docs)** can be much longer (5,000+ lines for a verbatim statute anchor file) because they are consulted by file:section, not read end-to-end.
+- **Eval cases** stay small (≤ 100 lines each) because they're enumerated, not loaded into context all at once.
+
+The pattern: **front-load the discipline into the orchestrator's instruction surface (SKILL.md, intake contracts, gates); load detail on-demand (references, methodology, evals)**. This is the LLM-equivalent of the "indirect address" pattern in software design — the orchestrator stays small; the body lives in addressable chunks.
+
+## How to apply this paradigm in skill / runbook design
+
+When deciding whether a given discipline is "too much", ask:
+
+| Question | Human-driven answer | LLM-driven answer |
+|---|---|---|
+| Will the executor remember every step? | No, after step 8 they skip ahead. | Yes, within the context window. |
+| Is the marginal-cost-per-step small or large? | Large (cognitive load + time). | Small (next-token prediction). |
+| Does the user see the discipline or the output? | They see the discipline (every checkbox). | They see the output (the artifact). |
+| Will the discipline degrade into theatre? | Often, after a few sprints. | Rarely, if SKILL.md prose holds. |
+| Do redundant defenses add user friction? | Yes (each defense is a checkbox). | No (each defense runs silently). |
+
+If the answers to all five favor LLM-execution, **err on the side of more discipline, not less**. The user experiences the simplicity of the output; the agent does the work.
+
+## Domain examples
+
+### Security
+
+Traditional security advice ("rotate API keys quarterly, audit IAM monthly, scan dependencies daily, review SBOMs per release, threat-model every new feature, enforce least-privilege per identity, log every authn / authz decision") is famously unrealistic for human teams. Most teams follow 2-3 of these and call the rest aspirational.
+
+The SLO security pillar (Phase 1 + R2 + R4) lets the LLM execute all of them. The user sees: a runbook with verified threat-model citations, abuse cases per surface, Pass 4 supply-chain scan, capability-gap filing. The user does not see the 20 distinct disciplines that produced the result.
+
+### Reliability / quality
+
+A human PR template that asks 12 questions ("backward-compatible? migration tested? observability added? alerts configured? runbook updated? rollback tested? canary plan?") gets shortcut. An LLM-driven `/slo-execute` pre-flight that runs all 12 questions plus restate-and-confirm + allow-list check + baseline test + lessons-file consultation does not get shortcut.
+
+The result: more reliability, fewer regressions, less perceived "process overhead".
+
+### Legal / advisor work
+
+A human-written legal intake form with 6 fields gets filled in 2 minutes; founders skip the structured fields and write paragraphs. The LLM-driven conversational intake (R3 M2) asks 6 questions one at a time, pushes on vague answers, and synthesizes the structured `intake_summary:` block with comparable rigor to a paralegal interview. The founder experiences a 5-minute conversation instead of a 30-minute form.
+
+## Anti-patterns
+
+The paradigm does NOT mean:
+
+- **Add infinite gates**. Context-window is finite. Decomposition is required.
+- **Skip user agency**. Conversational intake is bidirectional; the founder corrects. Restate-and-confirm is mandatory before consequential writes. Risky actions still require user authorization.
+- **Trust LLM execution unconditionally**. Structural-contract tests, abuse-case BDD scenarios, and `/slo-verify` Pass 4 catch what the LLM might silently miss.
+- **Pretend the agent understands every nuance**. Source hierarchy ranks Stack Overflow as never-authoritative because LLMs WILL otherwise paraphrase SO confidently. The discipline is structural, not optimistic.
+- **Replace explicit defaults with implicit "the agent will figure it out"**. Closed-enum regulator lists, fixed predicate IDs, immutable contracts protect against agent-as-judge drift.
+
+## Cross-references
+
+- [`docs/RUNBOOK-LOOPS-AND-LESSONS-CLOSURE.md`](RUNBOOK-LOOPS-AND-LESSONS-CLOSURE.md) — the lessons loop is itself an example of the paradigm: humans skip post-mortems, LLMs file them as tracked work.
+- [`docs/RUNBOOK-ENGINEERING-SKILL-IMPROVEMENTS.md`](RUNBOOK-ENGINEERING-SKILL-IMPROVEMENTS.md) — `references/templates/` shared library + per-skill evals + research-validation discipline embody the paradigm at engineering scale.
+- [`docs/RUNBOOK-BUSINESS-SKILL-IMPROVEMENTS.md`](RUNBOOK-BUSINESS-SKILL-IMPROVEMENTS.md) — conversational intake contracts + verbatim statute citations + KPI baseline source-verification embody the paradigm at biz-pack scale.
+- [`docs/RUNBOOK-SLO-SEC-LIBS.md`](RUNBOOK-SLO-SEC-LIBS.md) — capability-gap filing turns library-feedback from "lessons file commentary" into structured upstream work, exactly because the LLM doesn't tire of filing.
+- [`docs/runbook-template_v_3_template.md`](runbook-template_v_3_template.md) — the v3 template's per-milestone Contract Block with Data classification + Proactive controls + Abuse acceptance scenarios + 7 BDD coverage categories is the structural anchor of the paradigm.
+- [`SECURITY.md`](../SECURITY.md) — project-wide security defaults that the LLM applies to every milestone.
+
+## When to update this doc
+
+This is a **living doc**. Update when:
+
+- A new SLO discipline pattern emerges that exemplifies the paradigm.
+- A retrospective surfaces a case where over-engineering DID degrade user experience (counter-example worth documenting).
+- The context-window calculus changes (e.g., new model versions push the soft line-cap or per-skill methodology size cap).
+
+Anti-pattern: do NOT update with new disciplines that haven't yet shipped in a runbook. The paradigm captures patterns we've validated in practice; aspirational patterns belong in idea docs or runbook proposals.

--- a/docs/RUNBOOK-AGENT-HOST-COMPATIBILITY.md
+++ b/docs/RUNBOOK-AGENT-HOST-COMPATIBILITY.md
@@ -38,7 +38,7 @@ Update this table as each milestone is completed. This is the single source of t
 | # | Milestone | Status | Started | Completed | Lessons File | Completion Summary |
 |---|---|---|---|---|---|---|
 | 1 | Installer host profiles | `done` | 2026-04-29 | 2026-04-29 | `docs/lessons/agent-host-m1.md` | `docs/completion/agent-host-m1.md` |
-| 2 | Living docs, getting started, and host overlays | `not_started` | | | | |
+| 2 | Living docs, getting started, and host overlays | `done` | 2026-04-29 | 2026-04-29 | `docs/lessons/agent-host-m2.md` | `docs/completion/agent-host-m2.md` |
 | 3 | Agent-neutral `/slo-research` interactive path | `not_started` | | | | |
 | 4 | Isolate Claude-only automation surfaces | `not_started` | | | | |
 | 5 | Targeted skill and structural-test cleanup | `not_started` | | | | |
@@ -887,11 +887,11 @@ Complete the Global Exit Rules above. Key documentation updates:
 
 #### Compatibility Checklist
 
-- [ ] `CLAUDE.md` still exists and remains usable for Claude users.
-- [ ] Host install examples in docs match actual installer behavior.
-- [ ] `README.md` links to `docs/getting-started.md` as the first-run path.
-- [ ] No historical runbook, lessons, or completion file was edited outside the allow-list.
-- [ ] `docs/ARCHITECTURE.md` matches the current workspace, not removed legacy surfaces.
+- [x] `CLAUDE.md` still exists and remains usable for Claude users.
+- [x] Host install examples in docs match actual installer behavior.
+- [x] `README.md` links to `docs/getting-started.md` as the first-run path.
+- [x] No historical runbook, lessons, or completion file was edited outside the allow-list.
+- [x] `docs/ARCHITECTURE.md` matches the current workspace, not removed legacy surfaces.
 
 #### E2E Runtime Validation
 
@@ -905,29 +905,29 @@ Complete the Global Exit Rules above. Key documentation updates:
 
 #### Smoke Tests
 
-- [ ] Read the README install section end-to-end; it mentions both Claude and Copilot and links to `docs/getting-started.md`
-- [ ] Read `docs/getting-started.md` end-to-end; it explains prerequisites, install, first-use, and troubleshooting without assuming prior SLO knowledge
-- [ ] Read `CLAUDE.md`; it remains useful but no longer claims to be the only canonical skill catalog
-- [ ] Read `copilot-instructions.md`; it is actionable for a Copilot session
-- [ ] Read `docs/ARCHITECTURE.md`; it reflects the actual workspace members
-- [ ] `cargo test -p sldo-install --test e2e_agent_host_m2` passes
-- [ ] `git status` shows no untracked test artifacts
+- [x] Read the README install section end-to-end; it mentions both Claude and Copilot and links to `docs/getting-started.md`
+- [x] Read `docs/getting-started.md` end-to-end; it explains prerequisites, install, first-use, and troubleshooting without assuming prior SLO knowledge
+- [x] Read `CLAUDE.md`; it remains useful but no longer claims to be the only canonical skill catalog
+- [x] Read `copilot-instructions.md`; it is actionable for a Copilot session
+- [x] Read `docs/ARCHITECTURE.md`; it reflects the actual workspace members
+- [x] `cargo test -p sldo-install --test e2e_agent_host_m2` passes
+- [x] `git status` shows no untracked test artifacts
 
 #### Evidence Log
 
 | Step | Command / Check | Expected Result | Actual Result | Pass/Fail | Notes |
 |---|---|---|---|---|---|
-| Baseline tests | `cargo test -p sldo-common -p sldo-install -p sldo-research` | all green for in-scope crates | | | |
-| BDD tests created | `crates/sldo-install/tests/e2e_agent_host_m2.rs` | fail for expected reason | | | |
-| E2E stubs created | same file | fail for expected reason | | | |
-| Implementation | living docs + getting-started guide + overlays | docs become truthful, beginner-friendly, and non-duplicative | | | |
-| Full tests | `cargo test -p sldo-install --test e2e_agent_host_m2` | green | | | |
-| E2E runtime | `cargo test -p sldo-install --test e2e_agent_host_m2` | green | | | |
-| Build/boot | `cargo build -p sldo-install` | builds cleanly | | | |
-| Smoke tests | manual doc review | all checked | | | |
-| Test artifact cleanup | `git status` | no untracked test artifacts | | | |
-| .gitignore review | review `.gitignore` | no new patterns needed beyond M1 | | | |
-| Compatibility checks | overlay, architecture, and onboarding checks | no regressions | | | |
+| Baseline tests | `cargo test -p sldo-common -p sldo-install -p sldo-research` | all green for in-scope crates | all targeted crates and doc-structure tests passed; one unrelated pre-existing unused-import warning remained in `e2e_biz_followup_m5.rs` | Pass | Warning is non-blocking and outside this milestone's scope |
+| BDD tests created | `crates/sldo-install/tests/e2e_agent_host_m2.rs` | fail for expected reason | first run failed because `copilot-instructions.md`, `docs/getting-started.md`, and `docs/design/agent-host-capabilities.md` did not exist yet | Pass | Missing-doc failure cleanly exposed the required M2 deliverables |
+| E2E stubs created | same file | fail for expected reason | initial structural checks also showed the old catalog and overlay split was still implicit | Pass | The failing test gave the smallest truthful edit surface |
+| Implementation | living docs + getting-started guide + overlays | docs become truthful, beginner-friendly, and non-duplicative | added `copilot-instructions.md`, `docs/getting-started.md`, and `docs/design/agent-host-capabilities.md`; rewrote `docs/skill-pack-catalog.md` and `docs/ARCHITECTURE.md`; updated `README.md`, `CLAUDE.md`, and `skills/README.md` | Pass | Canonical catalog, overlays, onboarding, and capability matrix now have distinct roles |
+| Full tests | `cargo test -p sldo-install --test e2e_agent_host_m2` | green | 4 passed; 0 failed | Pass | Confirms the new doc contract |
+| E2E runtime | `cargo test -p sldo-install --test e2e_agent_host_m2` | green | 4 passed; 0 failed | Pass | Same focused validation used for the milestone gate |
+| Build/boot | `cargo build -p sldo-install` | builds cleanly | build finished successfully | Pass | Confirms docs-only milestone did not disturb the supported installer target |
+| Smoke tests | manual doc review | all checked | README, getting-started, Claude overlay, Copilot overlay, and architecture doc were read end-to-end and aligned with the current host split | Pass | No prior-SLO assumptions remain in the first-run guide |
+| Test artifact cleanup | `git status` | no untracked test artifacts | worktree showed only intended source edits and newly added milestone files; no generated artifacts appeared | Pass | New tracked docs/tests are expected |
+| .gitignore review | review `.gitignore` | no new patterns needed beyond M1 | existing `.claude/` and `.copilot/` ignores already cover the local host state introduced so far | Pass | No M2 `.gitignore` change required |
+| Compatibility checks | overlay, architecture, and onboarding checks | no regressions | Claude overlay remained usable, install examples matched M1 behavior, README linked to the first-run guide, and architecture now matches the four active workspace members | Pass | Current Claude-only runtime limits are documented instead of implied |
 
 #### Definition of Done
 

--- a/docs/RUNBOOK-AGENT-HOST-COMPATIBILITY.md
+++ b/docs/RUNBOOK-AGENT-HOST-COMPATIBILITY.md
@@ -39,7 +39,7 @@ Update this table as each milestone is completed. This is the single source of t
 |---|---|---|---|---|---|---|
 | 1 | Installer host profiles | `done` | 2026-04-29 | 2026-04-29 | `docs/lessons/agent-host-m1.md` | `docs/completion/agent-host-m1.md` |
 | 2 | Living docs, getting started, and host overlays | `done` | 2026-04-29 | 2026-04-29 | `docs/lessons/agent-host-m2.md` | `docs/completion/agent-host-m2.md` |
-| 3 | Agent-neutral `/slo-research` interactive path | `not_started` | | | | |
+| 3 | Agent-neutral `/slo-research` interactive path | `in_progress` | 2026-04-29 | | | |
 | 4 | Isolate Claude-only automation surfaces | `not_started` | | | | |
 | 5 | Targeted skill and structural-test cleanup | `not_started` | | | | |
 
@@ -1050,10 +1050,10 @@ Complete the Global Exit Rules above. Key documentation updates:
 
 #### Compatibility Checklist
 
-- [ ] `docs/research/<slug>/` output paths are unchanged.
-- [ ] `incomplete: true` remains the explicit missing-coverage signal.
-- [ ] `sldo-research` still builds for existing Claude batch users.
-- [ ] No living doc now implies that all hosts must install Claude to use `/slo-research` interactively.
+- [x] `docs/research/<slug>/` output paths are unchanged.
+- [x] `incomplete: true` remains the explicit missing-coverage signal.
+- [x] `sldo-research` still builds for existing Claude batch users.
+- [x] No living doc now implies that all hosts must install Claude to use `/slo-research` interactively.
 
 #### E2E Runtime Validation
 
@@ -1068,25 +1068,25 @@ Complete the Global Exit Rules above. Key documentation updates:
 
 - [ ] Follow `docs/verify/agent-host-m3-smoke.md` in a Claude session
 - [ ] Follow `docs/verify/agent-host-m3-smoke.md` in a Copilot session
-- [ ] `cargo test -p sldo-install --test e2e_agent_host_m3` passes
-- [ ] `cargo test -p sldo-research` stays green
-- [ ] `git status` shows no untracked test artifacts
+- [x] `cargo test -p sldo-install --test e2e_agent_host_m3` passes
+- [x] `cargo test -p sldo-research` stays green
+- [x] `git status` shows no untracked test artifacts
 
 #### Evidence Log
 
 | Step | Command / Check | Expected Result | Actual Result | Pass/Fail | Notes |
 |---|---|---|---|---|---|
-| Baseline tests | `cargo test -p sldo-common -p sldo-install -p sldo-research` | all green for in-scope crates | | | |
-| BDD tests created | `crates/sldo-install/tests/e2e_agent_host_m3.rs` | fail for expected reason | | | |
-| E2E stubs created | same file + smoke checklist | fail or remain incomplete for expected reason | | | |
-| Implementation | `/slo-research` rewrite + doc clarification | interactive path is host-neutral | | | |
-| Full tests | `cargo test -p sldo-install --test e2e_agent_host_m3 && cargo test -p sldo-research` | green | | | |
-| E2E runtime | manual smoke checklist | both hosts behave as documented | | | |
-| Build/boot | `cargo build -p sldo-research` | builds cleanly | | | |
-| Smoke tests | `docs/verify/agent-host-m3-smoke.md` | all checked | | | |
-| Test artifact cleanup | `git status` | no untracked test artifacts | | | |
-| .gitignore review | review `.gitignore` | no new patterns needed | | | |
-| Compatibility checks | artifact-path and incomplete-flag checks | no regressions | | | |
+| Baseline tests | `cargo test -p sldo-common -p sldo-install -p sldo-research` | all green for in-scope crates | full in-scope baseline passed before and after the M3 implementation slice; one unrelated pre-existing unused-import warning remained in `crates/sldo-install/tests/e2e_biz_followup_m5.rs` | Pass | Final rerun was taken after the capability-matrix wording correction so the last green run matches the final tree |
+| BDD tests created | `crates/sldo-install/tests/e2e_agent_host_m3.rs` | fail for expected reason | first run failed because `skills/slo-research/SKILL.md` still lacked a host-native path and the living docs did not yet call `sldo-research` an optional Claude batch backend | Pass | Failure stayed local to the intended M3 contract |
+| E2E stubs created | same file + smoke checklist | fail or remain incomplete for expected reason | structural test file and `docs/verify/agent-host-m3-smoke.md` were added first; the checklist intentionally kept host-session items manual while the new test exposed the hidden dependency wording | Pass | This gave a concrete guardrail before rewriting the skill |
+| Implementation | `/slo-research` rewrite + doc clarification | interactive path is host-neutral | rewrote `skills/slo-research/SKILL.md` around interactive host-native research; marked `sldo-research` as an optional Claude batch backend in README, overlays, catalog, architecture, getting-started, capability matrix, and `sldo-research` help/module docs | Pass | `docs/getting-started.md` and `docs/design/agent-host-capabilities.md` were updated as living-doc truth fixes so host-support claims stayed consistent |
+| Full tests | `cargo test -p sldo-install --test e2e_agent_host_m3 && cargo test -p sldo-research` | green | `e2e_agent_host_m3`, existing `e2e_slo_sp_m3`, `cargo test -p sldo-research`, and the final full baseline all passed | Pass | Confirms both the new contract and the pre-existing `/slo-research` structural guard still hold |
+| E2E runtime | manual smoke checklist | both hosts behave as documented | local validation items were completed, but the actual Claude-session and Copilot-session checklist steps remain pending because this terminal-only environment cannot open those host UIs directly | Partial | Manual host smoke is the only remaining milestone closeout item |
+| Build/boot | `cargo build -p sldo-research` | builds cleanly | `cargo build -p sldo-install -p sldo-research` passed; `./target/debug/sldo-research --help` exits 0 and now describes the optional batch backend honestly | Pass | Existing CLI flags remained intact |
+| Smoke tests | `docs/verify/agent-host-m3-smoke.md` | all checked | local validation checks are done; the two host-session checks are still unchecked pending manual execution in Claude Code and GitHub Copilot | Partial | Do not mark the milestone done until those two session checks are completed |
+| Test artifact cleanup | `git status` | no untracked test artifacts | final `git status --short` showed only intended tracked edits and the two new milestone files; no generated artifacts were left behind | Pass | New source files are expected |
+| .gitignore review | review `.gitignore` | no new patterns needed | existing `.claude/`, `.copilot/`, `.sldo-logs/`, `.copilot-logs/`, and `output/` ignores already cover the surfaces touched by this milestone | Pass | No `.gitignore` change required |
+| Compatibility checks | artifact-path and incomplete-flag checks | no regressions | `docs/research/<slug>/` paths stayed unchanged, `incomplete: true` remained explicit, `sldo-research` still builds for Claude batch users, and no living doc now tells Copilot users to install Claude for interactive `/slo-research` use | Pass | `sldo-research --help` now names the backend boundary explicitly |
 
 #### Definition of Done
 

--- a/docs/RUNBOOK-AGENT-HOST-COMPATIBILITY.md
+++ b/docs/RUNBOOK-AGENT-HOST-COMPATIBILITY.md
@@ -1,0 +1,1454 @@
+# Agent-Host Compatibility Cleanup — SunLitOrchestrate (AI-First Runbook v3)
+
+> **Purpose**: Make the SLO skill pack work cleanly in multiple skill-capable coding agents, starting with Claude Code and GitHub Copilot, by removing hidden Claude-only assumptions from installation, living docs, interactive skill flows, and test harness naming while preserving existing skill names and artifact contracts. Treat open-source user documentation as a first-class deliverable: README and getting-started usage docs must be as intentional and testable as the code.  
+> **Audience**: AI coding agents first, humans second. This document is written to reduce ambiguity, prevent scope drift, and keep the portability work honest about what is truly host-neutral versus what remains Claude-only batch automation.  
+> **How to use**: Work through milestones sequentially. Before starting any milestone, read its full section and the Global Execution Rules. After completing it, follow the Global Exit Rules. Never skip ahead. Never silently widen scope.  
+> **Prerequisite reading**: [README.md](../README.md), [CLAUDE.md](../CLAUDE.md), [ARCHITECTURE.md](ARCHITECTURE.md), [skill-pack-catalog.md](skill-pack-catalog.md), [skills/README.md](../skills/README.md)
+
+---
+
+## Runbook Metadata
+
+- **Runbook ID**: `agent-host-compat`
+- **Prefix for test files and lessons files**: `agent-host`
+- **Primary stack**: Markdown `SKILL.md` files + Rust 2021 workspace (`sldo-install`, `sldo-common`, `sldo-research`) + Rust structural/E2E tests
+- **Primary package/app names**: `skills/`, `sldo-install`, `sldo-common`, `sldo-research`
+- **Default test commands**:
+  - Backend: `cargo test -p sldo-common -p sldo-install -p sldo-research`
+  - Frontend: `N/A — no frontend surface in scope`
+  - E2E backend: `cargo test -p sldo-install --tests`
+  - E2E frontend: `N/A — no frontend surface in scope`
+  - Build/boot: `cargo build -p sldo-install -p sldo-research`
+- **Allowed new dependencies by default**: `none`
+- **Schema/config migration allowed by default**: `no`
+- **Public interfaces that must remain stable unless explicitly listed otherwise**:
+  - `skills/<name>/SKILL.md` layout with `name` and `description` frontmatter
+  - Existing skill names (`/slo-*` and `get-api-docs`)
+  - `sldo-install` subcommands: `install`, `uninstall`, `status`, `verify`
+  - Default no-arg `sldo-install` behavior targeting Claude Code for backward compatibility
+  - `references/biz/` and `references/sast/` as repo-root shared scaffolding directories
+  - Existing artifact paths written by skills (for example `docs/idea/<slug>.md`, `docs/research/<slug>/`, `docs/biz/`, `docs/biz-public/`)
+
+---
+
+## Milestone Tracker
+
+Update this table as each milestone is completed. This is the single source of truth for progress.
+
+| # | Milestone | Status | Started | Completed | Lessons File | Completion Summary |
+|---|---|---|---|---|---|---|
+| 1 | Installer host profiles | `done` | 2026-04-29 | 2026-04-29 | `docs/lessons/agent-host-m1.md` | `docs/completion/agent-host-m1.md` |
+| 2 | Living docs, getting started, and host overlays | `not_started` | | | | |
+| 3 | Agent-neutral `/slo-research` interactive path | `not_started` | | | | |
+| 4 | Isolate Claude-only automation surfaces | `not_started` | | | | |
+| 5 | Targeted skill and structural-test cleanup | `not_started` | | | | |
+
+<!-- Status values: not_started | in_progress | blocked | done -->
+<!-- Lessons files go in docs/lessons/<prefix>-m<N>.md -->
+<!-- Completion summaries go in docs/completion/<prefix>-m<N>.md -->
+
+---
+
+## End-to-End Architecture Diagram
+
+Provide a complete architecture diagram of the proposed end state after all milestones are complete. This diagram should be understandable at a glance and serve as the north star for every milestone.
+
+### Diagram Requirements
+
+- Show all major components, services, and actors.
+- Show data flow direction between components with labeled arrows.
+- Show persistence boundaries (databases, file systems, caches).
+- Show trust boundaries and external integration points.
+- Show IPC, API, and event boundaries.
+- Distinguish between what exists today (solid lines) and what will be built (dashed lines).
+- Include a legend explaining symbols and line styles.
+
+### Architecture Diagram
+
+```mermaid
+flowchart LR
+    User[User in current host agent]
+
+    subgraph Repo[SunLitOrchestrate repo]
+        Skills[skills/*/SKILL.md]
+        Catalog[docs/skill-pack-catalog.md]
+        Install[sldo-install]
+        Capability[docs/design/agent-host-capabilities.md]
+        ClaudeOverlay[CLAUDE.md]
+        CopilotOverlay[copilot-instructions.md]
+        ResearchSkill[/slo-research/]
+        Batch[sldo-research batch backend]
+        Runtime[Claude-only runtime harness]
+    end
+
+    User -->|interactive skill invocation| Skills
+    Skills -->|installable pack| Install
+    Skills -->|canonical skill inventory| Catalog
+    Catalog -.->|host overlay render| ClaudeOverlay
+    Catalog -.->|host overlay render| CopilotOverlay
+    Catalog -.->|capability matrix| Capability
+
+    Install -->|existing global install| ClaudeRoot[~/.claude/skills]
+    Install -.->|new global install| CopilotRoot[~/.copilot/skills]
+    Install -->|existing local install| LocalClaude[./.claude/skills]
+    Install -.->|new local install| LocalCopilot[./.copilot/skills]
+
+    ResearchSkill -.->|interactive host-native research| User
+    ResearchSkill -.->|optional explicit batch path only| Batch
+    Batch -->|Claude CLI only| ClaudeCli[claude CLI]
+    Runtime -->|live fixture automation| ClaudeCli
+
+    Legend[Legend: solid = existing, dashed = new or changed]
+```
+
+### Component Summary Table
+
+| Component | Responsibility | Milestone Introduced/Changed | Key Interfaces |
+|---|---|---|---|
+| `skills/` | Canonical skill prompts and output contracts | M3, M5 | `SKILL.md`, artifact paths |
+| `sldo-install` | Discovers skills and installs them into host-specific skill roots | M1 | `sldo-install [--host <id>] [--local] <subcommand>` |
+| `docs/skill-pack-catalog.md` | Agent-neutral skill inventory and source-of-truth catalog | M2 | Markdown catalog consumed by living docs/tests |
+| `CLAUDE.md` | Claude-specific overlay doc, not the canonical pack catalog | M2 | Claude session guidance |
+| `copilot-instructions.md` | GitHub Copilot-specific overlay doc | M2 | Copilot workspace guidance |
+| `sldo-research` | Optional batch research backend for Claude-driven automation only | M3, M4 | `sldo-research --prompt ...` |
+| Claude runtime harness | Runs live judgment/runtime tests only where a verified Claude CLI path exists | M4 | `BIZ_JUDGMENT_RUNTIME_CLAUDE_BIN`, temp repo harness |
+| `docs/design/agent-host-capabilities.md` | Declares which hosts support install, interactive execution, and headless automation | M2, M5 | Capability matrix, compatibility notes |
+
+### Data Flow Summary
+
+| Flow | From | To | Protocol/Mechanism | Milestone |
+|---|---|---|---|---|
+| Skill install | `skills/*` | Host skill root | Filesystem symlink via `sldo-install` | M1 |
+| Catalog publication | `docs/skill-pack-catalog.md` | `CLAUDE.md`, `copilot-instructions.md` | Manual sync with structural tests | M2 |
+| Interactive research | Current host agent | `/slo-research` skill | Skill-native tool use + file writes | M3 |
+| Optional batch research | `/slo-research` skill or user | `sldo-research` | Explicit CLI invocation | M3 |
+| Batch LLM execution | `sldo-research` / runtime harness | `claude` CLI | Subprocess | M4 |
+| Runtime validation | Fixture tests | Claude runtime harness | Rust tests + subprocess | M4 |
+
+---
+
+## High-Level Design for Formal Verification (TLA+ Section)
+
+This section captures the system's abstract behavior as a protocol/state-machine design suitable for TLA+ modeling. It focuses on correctness-critical concurrency, state, and failure modes — not implementation details.
+
+**When to fill this section**: Before starting milestone implementation if the system involves concurrent actors, distributed state, ordering guarantees, resource ownership, or failure recovery. For simple CRUD systems with no concurrency concerns, mark `N/A` with a brief justification.
+
+**Design guidance**: Omit low-level code, APIs, schemas, retries, logging, metrics, and deployment details. Avoid timestamps, UUIDs, large payloads, or unbounded queues unless correctness depends on them. Reduce the design to the smallest set of states and transitions that captures the real correctness risks.
+
+### 1. System Goal
+
+N/A — this runbook changes installer path selection, Markdown skill contracts, documentation overlays, and single-process CLI/test harness naming. There are no concurrent actors sharing mutable state, no ordering guarantees across processes, and no distributed recovery protocol to model.
+
+### 2. Main Components
+
+| Component | Responsibility | Key State (durable / volatile) | Visible Actions |
+|---|---|---|---|
+| N/A | No protocol-level concurrent component set in scope | N/A | N/A |
+
+### 3. Abstract State
+
+| Variable | Type (abstract) | Why Necessary | Explosion Risk |
+|---|---|---|---|
+| N/A | N/A | No formal verification target in this cleanup | low |
+
+### 4. Key Actions / Transitions
+
+| Action | Preconditions | State Updates | Failure / Interleaving Notes |
+|---|---|---|---|
+| N/A | N/A | N/A | No concurrency-sensitive transitions in scope |
+
+### 5. Safety Properties
+
+- **N/A**: No shared-state safety invariant beyond ordinary single-process tests is required for this cleanup.
+
+### 6. Liveness Assumptions
+
+- **N/A**: No fairness or progress proof is needed for installer/doc/test-harness cleanup.
+
+### 7. Simplifications Made for TLA+
+
+| What Was Simplified | Why It Still Covers the Bugs We Care About |
+|---|---|
+| Entire section marked N/A | The real risks here are path correctness, documentation drift, and hidden host assumptions; those are better covered by structural and runtime tests than by model checking. |
+
+---
+
+## Global Execution Rules
+
+These rules apply to every milestone without exception.
+
+### 1) Stay inside scope
+
+- Only change files listed in the current milestone unless a listed step explicitly requires one additional file.
+- Do not refactor unrelated code.
+- Do not rename public APIs, commands, routes, events, persisted state shapes, or config keys unless the milestone explicitly says so.
+- Do not introduce a new dependency unless the milestone explicitly allows it.
+- Do not change database schema, file formats, or migration behavior unless the milestone explicitly includes migration work and migration tests.
+
+### 2) Tests define the contract
+
+- Write BDD tests before production code.
+- Write E2E runtime validation stubs before production code.
+- Confirm new tests fail for the right reason before implementing.
+- A milestone is not done when code compiles. It is done when the declared contract is satisfied and evidence is recorded.
+
+### 3) No placeholders in production paths
+
+The following are not allowed unless explicitly permitted in the milestone:
+
+- TODO or placeholder logic in production code
+- silent fallbacks that hide errors
+- swallowed errors without structured logging or user-visible handling
+- fake implementations left in place after tests pass
+- commented-out dead code
+- temporary mocks in production paths
+- hard-coded secrets, test keys, or unsafe defaults
+
+### 4) Preserve backwards compatibility
+
+Every milestone must explicitly verify that previously working user flows, commands, routes, persisted state, and public interfaces still work unless the milestone explicitly replaces them.
+
+### 5) Prefer smallest safe change
+
+- Prefer narrow, local modifications over broad rewrites.
+- Prefer extending existing patterns over inventing new abstractions.
+- Prefer deleting complexity over adding new layers.
+- If a refactor is required, keep it minimal and directly justified by the milestone goal.
+
+### 6) Record evidence, not claims
+
+All meaningful checks must be recorded in the milestone Evidence Log:
+
+- command run
+- relevant file or test
+- expected result
+- actual result
+- pass/fail
+- notes
+
+### 7) Keep .gitignore current and clean up test artifacts
+
+- If a milestone introduces new build outputs, generated files, test fixtures, scratch directories, or tool-specific caches, add matching patterns to `.gitignore` before committing.
+- Review `.gitignore` at the end of every milestone for staleness — remove patterns that no longer apply.
+- Never commit test output data, temporary fixtures, scratch files, or generated artifacts to source control.
+- Every test that creates files on disk must clean up after itself (use `tempdir`, `tempfile`, `afterEach` cleanup, or equivalent). Tests must not leave residual data in the working tree.
+- Record the `.gitignore` review in the Evidence Log.
+
+### 8) Treat User Docs As First-Class
+
+- For any milestone that changes installation, onboarding, host support, or user-facing workflow, update `README.md` and `docs/getting-started.md` together. If `docs/getting-started.md` does not exist yet, the milestone that first changes onboarding must create it.
+- Write for a smart 17-year-old contributor: assume curiosity and competence, but do not assume insider vocabulary, prior SLO knowledge, or familiarity with Claude/Copilot-specific concepts.
+- Define jargon before using it, especially terms like `skill pack`, `overlay doc`, `manifest`, `host`, `batch backend`, and `runtime harness`.
+- Show exact commands, where to run them, what success looks like, and what to do when a step fails. Do not rely on implied steps.
+- Avoid patronizing or hand-wavy wording. Ban filler like `just`, `simply`, `obviously`, and `of course` when they skip real complexity or dismiss the reader's likely questions.
+- Treat documentation quality as testable behavior: smoke tests must include reading the onboarding docs end to end and following at least one real first-run path.
+
+---
+
+## Global Entry Rules (Pre-Milestone Protocol)
+
+Do this before every milestone.
+
+1. Read the lessons file from the previous milestone, if one exists. Apply any design corrections, naming rules, test strategy improvements, and failure-mode coverage it calls for before writing new code.
+2. Read the current milestone fully: goal, context, contract block, out-of-scope block, file list, BDD scenarios, regression tests, E2E tests, smoke tests, and definition of done.
+3. Run the full existing test suite and confirm it passes. Record the baseline in the Evidence Log.
+   ```bash
+   cargo test -p sldo-common -p sldo-install -p sldo-research
+   # Frontend: N/A
+   ```
+   Note: root-package `tests/e2e_research_m*.rs` are currently hardcoded to `target/debug/sldo-research` and are already red for reasons outside this runbook. Do not widen scope to fix them here unless a milestone explicitly touches those files.
+4. Read the files listed in "Files Allowed To Change" and "Files To Read Before Changing Anything". Understand their current shape before editing.
+5. Update the Milestone Tracker in this file: set the current milestone status to `in_progress` and record the Started date.
+6. Create BDD test files first.
+7. Create E2E runtime validation test stubs first.
+8. Copy the milestone's Evidence Log template into working notes and begin filling it out as work happens.
+9. Re-state the milestone constraints in your own words before coding:
+   - goal
+   - allowed files
+   - forbidden changes
+   - compatibility requirements
+   - tests that must pass
+
+---
+
+## Global Exit Rules (Post-Milestone Protocol)
+
+Do this after every milestone.
+
+1. Run the full test suite. Every pre-existing test must still pass. Every new BDD scenario must pass.
+   ```bash
+   cargo test -p sldo-common -p sldo-install -p sldo-research
+   # Frontend: N/A
+   ```
+2. Run the milestone E2E runtime validation tests.
+   ```bash
+   cargo test -p sldo-install --tests
+   # Frontend E2E: N/A
+   ```
+3. Verify the app builds and boots to a usable state.
+   ```bash
+   cargo build -p sldo-install -p sldo-research
+   ```
+4. Run the smoke tests listed in the milestone. Check off each item in the runbook.
+5. Verify backward compatibility for all items listed in the milestone Compatibility Checklist.
+6. Complete the Self-Review Gate.
+7. **Clean up test artifacts**: Verify no test output files, temporary fixtures, or generated data remain in the working tree. Run `git status` and confirm no untracked test artifacts exist.
+8. **Review .gitignore**: Ensure any new build outputs, generated files, or tool caches introduced in this milestone have matching `.gitignore` patterns. Remove stale patterns that no longer apply.
+9. Update ARCHITECTURE.md following the Documentation Update Table.
+10. Update `README.md` and `docs/getting-started.md` if user-facing capabilities changed. If `docs/getting-started.md` does not exist yet and the milestone changes onboarding, install, or first-use flow, create it in that milestone.
+11. Write a lessons-learned file at `docs/lessons/<prefix>-m<N>.md`.
+12. Write a completion summary at `docs/completion/<prefix>-m<N>.md`.
+13. Update the Milestone Tracker in this file: set status to `done`, record Completed date, and fill in the lessons and completion summary paths.
+14. Re-read the next milestone with fresh eyes and record any assumption changes in the lessons file.
+
+---
+
+## Background Context
+
+### Current State
+
+SunLitOrchestrate today is a mixed Markdown-skill and Rust-tooling repo with four active workspace members in [Cargo.toml](../Cargo.toml): `sldo-common`, `sldo-research`, `sldo-install`, and `xtasks/sast-verify`. The skill pack itself lives under [skills](../skills/), where each skill is a directory containing `SKILL.md`. That contract is already compatible with GitHub Copilot's installed-skill layout on this machine (`~/.copilot/skills/get-api-docs/SKILL.md` exists and uses the same frontmatter/body shape).
+
+The main portability blockers are not the skill file format. They are the surrounding assumptions. [crates/sldo-install/src/main.rs](../crates/sldo-install/src/main.rs), [crates/sldo-install/src/paths.rs](../crates/sldo-install/src/paths.rs), and [crates/sldo-install/tests/install_e2e.rs](../crates/sldo-install/tests/install_e2e.rs) hardcode `.claude` roots and only implement `claude-code` as a host. [CLAUDE.md](../CLAUDE.md), [README.md](../README.md), [skills/README.md](../skills/README.md), [docs/skill-pack-catalog.md](skill-pack-catalog.md), and [docs/ARCHITECTURE.md](ARCHITECTURE.md) still present Claude-specific guidance as canonical project truth. Several historical docs also reference removed legacy crates and outdated baselines.
+
+There is also a hidden runtime coupling. [skills/slo-research/SKILL.md](../skills/slo-research/SKILL.md) tells the host agent to shell out to `sldo-research`, and [crates/sldo-research/src/main.rs](../crates/sldo-research/src/main.rs) plus [crates/sldo-research/src/research.rs](../crates/sldo-research/src/research.rs) preflight and invoke the `claude` CLI. That means `/slo-research` appears host-neutral at the Markdown layer but still requires a separate Claude installation behind the scenes. Finally, the live judgment/runtime harness under [crates/sldo-install/tests/common/judgment_runtime.rs](../crates/sldo-install/tests/common/judgment_runtime.rs) is generic in name but explicitly hardcodes `.claude/skills`, `CLAUDE.md`, `claude -p`, and `BIZ_JUDGMENT_RUNTIME_CLAUDE_BIN`.
+
+### Problem
+
+1. **Installer portability stops at the enum definition**: `sldo-install` exposes `--host` but only `claude-code` is implemented, while all path resolution still assumes `.claude`. That blocks first-class Copilot installation despite the skill format already matching.
+2. **Living docs treat Claude-specific material as the repo-wide source of truth**: users and tests are trained to read `CLAUDE.md` as canonical, and key docs still describe a Claude-only pack or removed legacy crates. That creates drift and makes future host support look larger than it is.
+3. **`/slo-research` has a hidden nested-agent dependency**: the interactive skill delegates to a Rust backend that delegates again to the `claude` CLI. In Copilot, that would make the skill look supported while silently depending on another agent installation.
+4. **Claude-only automation is named too generically**: `copilot.rs` contains `ClaudeInvocation`, and `judgment_runtime.rs` sounds host-neutral while depending on Claude-specific files, flags, and auth assumptions. The naming hides real capability boundaries.
+5. **Tests and local-state hygiene lag the host story**: install tests only cover `.claude`, `.gitignore` ignores `.claude/` but not `.copilot/`, and structural tests only partially guard against reintroducing Claude-only wording into host-neutral surfaces.
+
+### Target Architecture
+
+```text
+Canonical skill contract
+  skills/<name>/SKILL.md
+          |
+          +--> sldo-install --host claude-code --------> ~/.claude/skills/<name>/
+          |
+          +--> sldo-install --host github-copilot -----> ~/.copilot/skills/<name>/
+          |
+          +--> docs/skill-pack-catalog.md --------------> host overlays
+                                                           |-> CLAUDE.md
+                                                           |-> copilot-instructions.md
+
+Interactive host execution
+  current host agent reads installed skill directly
+          |
+          +--> host-neutral skills run in-host
+          |
+          +--> explicit optional batch tools only where documented
+                  |
+                  +--> sldo-research (Claude batch backend only)
+
+Automation boundary
+  structural tests = host-neutral where possible
+  live runtime tests = Claude-only, explicitly named and documented as such
+```
+
+### Key Design Principles
+
+1. **Keep the skill contract agent-neutral**: `SKILL.md` files and skill output paths are the portable surface. Host-specific differences belong in installer profiles, overlay docs, and capability notes.
+2. **Prefer honest capability boundaries over fake parity**: do not invent a cross-agent CLI abstraction where only Claude automation exists today. Support interactive Copilot usage directly and keep Claude-only batch/runtime automation explicitly Claude-only.
+3. **One canonical catalog, multiple overlays**: `docs/skill-pack-catalog.md` is the source of truth for the pack. `CLAUDE.md` and `copilot-instructions.md` are projections for specific hosts, not competing catalogs.
+4. **Preserve backward compatibility by default**: default `sldo-install` behavior remains Claude-oriented until users opt into `--host github-copilot`, and existing skill names, artifact paths, and manifest installs continue to work.
+5. **Treat user docs as product surface**: this is an open-source project, so `README.md` and `docs/getting-started.md` are not cleanup tasks or optional polish. They must explain the product to a smart 17-year-old contributor: define jargon, assume less, show exact commands and outcomes, and avoid patronizing or over-familiar tone.
+6. **Do not churn historical artifacts**: historical runbooks, lessons, completion docs, and critique docs are records. Fix living docs and add forward-looking compatibility notes instead of rewriting the project’s history.
+
+### What to Keep
+
+- Skill discovery based on `skills/<name>/SKILL.md` in `sldo-install`
+- Existing skill names and artifact locations
+- `references/biz/` and `references/sast/` at the repo root
+- Claude Code as the default host for backward compatibility
+- `sldo-research` as an optional batch backend for users who intentionally want that path
+- Existing historical runbooks, lessons, completion docs, and critique artifacts unless a milestone explicitly says otherwise
+
+### What to Change
+
+- **`crates/sldo-install`** — add real host profiles, manifest awareness, and Copilot install roots
+- **Living docs** — move the canonical skill inventory to `docs/skill-pack-catalog.md`, keep `CLAUDE.md`, add `copilot-instructions.md`, create `docs/getting-started.md`, and make README/ARCHITECTURE truthful and beginner-friendly
+- **`skills/slo-research/SKILL.md`** — remove the hidden requirement that interactive host execution must shell out to `sldo-research`
+- **Claude-only runtime helpers and tests** — rename and isolate them so they stop looking host-neutral
+- **Structural tests** — add explicit coverage for Copilot install roots, overlay docs, and remaining Claude-only wording
+
+### Global Red Lines
+
+- No unrelated refactors
+- No new dependencies unless a milestone explicitly allows them
+- No schema migrations except the `sldo-install` manifest migration in Milestone 1
+- No config key renames outside files explicitly listed in a milestone
+- No skill-name renames
+- No production placeholders
+- No silent fallbacks from one host to another
+- No fake Copilot runtime automation layer
+- No edits to `crates/sldo-tauri/`
+- No mass-edit of historical runbooks, lessons, completion docs, or critique docs
+
+---
+
+## BDD and Runtime Validation Rules
+
+Every milestone follows these rules.
+
+### Write Tests Before Production Code
+
+For each milestone:
+1. Read the BDD acceptance table.
+2. Create the test file(s) first.
+3. Confirm the tests fail for the expected reason.
+4. Write production code to make the tests pass.
+5. Re-run tests after any refactor.
+
+### Required Test Coverage Categories
+
+Every milestone must explicitly cover the categories that apply:
+
+- happy path
+- invalid input
+- empty state / first-run state
+- dependency failure / partial failure
+- retry or rollback behavior if relevant
+- concurrency or race behavior if relevant
+- persistence / restore behavior if relevant
+- backward compatibility behavior
+- abuse case behavior when the milestone introduces a new surface
+
+If a category does not apply, state why.
+
+### Scenario Structure
+
+Every BDD scenario uses Given/When/Then:
+
+```rust
+#[test]
+fn descriptive_test_name() {
+    // Given: [precondition]
+    // When: [action]
+    // Then: [expected outcome]
+}
+```
+
+```typescript
+it("descriptive_test_name", () => {
+  // Given: [precondition]
+  // When: [action]
+  // Then: [expected outcome]
+});
+```
+
+### Test File Naming
+
+| Layer | Convention | Location |
+|---|---|---|
+| Backend unit tests | `#[cfg(test)] mod tests` inside the source file | Same file as production code |
+| Backend integration/BDD tests | `tests/<prefix>_<feature>.rs` | `crates/<crate>/tests/` or workspace `tests/` |
+| Scenario/e2e tests | `tests/e2e_<prefix>_m<N>.rs` | `crates/<crate>/tests/` |
+| Smoke-test checklists | `<prefix>-m<N>-smoke.md` | `docs/verify/` |
+
+### Test Artifact Cleanup Rules
+
+Every test that creates files, directories, or temporary data on disk must follow these rules:
+
+1. **Use temporary directories**: Prefer `tempdir()`, `tempfile::TempDir`, or OS-provided temp locations. Never write test output into the source tree unless the milestone explicitly allows it.
+2. **Clean up on completion and failure**: Use RAII patterns or explicit cleanup so test artifacts do not survive failed runs.
+3. **No residual state**: After the full test suite runs, `git status` must show no untracked files from test execution.
+4. **Dedicated output directories**: If a test must write to a project-relative path, that directory must be in `.gitignore` and cleaned between runs.
+5. **CI parity**: Test cleanup behavior must be identical locally and in CI.
+
+### End-to-End Runtime Validation
+
+Every milestone must include E2E tests that go beyond compilation and verify that the system works correctly at runtime. These tests prove:
+
+1. the app boots without errors
+2. runtime contracts are met across filesystem/CLI boundaries
+3. BDD scenarios work at runtime, not just in isolation
+4. there are no runtime panics or silent failures
+5. degraded states behave safely and visibly
+
+### E2E Test Design Rules
+
+1. Test runtime behavior, not just types.
+2. Test the full stack where possible.
+3. Test degraded and failure states, not just the happy path.
+4. Assert against observable behavior.
+5. Prefer at least one manual smoke test when the host runtime is interactive-only and no supported noninteractive driver exists.
+
+---
+
+## Dependency, Migration, and Refactor Policy
+
+### Dependency policy
+
+A new dependency is allowed only if the milestone explicitly includes:
+
+- package/crate name
+- why existing dependencies are insufficient
+- security and maintenance rationale
+- build/runtime cost rationale
+- tests covering the new integration
+
+### Migration policy
+
+Any schema, config, or persisted-state change requires:
+
+- migration plan
+- backward compatibility strategy
+- migration tests
+- rollback strategy if relevant
+- documentation updates
+
+### Refactor budget
+
+Each milestone must state one of the following:
+
+- `No refactor permitted beyond direct implementation`
+- `Minimal local refactor permitted in listed files only`
+- `Targeted refactor permitted for [specific reason]`
+
+---
+
+## Evidence Log Template
+
+Copy this table into each milestone section and fill it in during execution.
+
+| Step | Command / Check | Expected Result | Actual Result | Pass/Fail | Notes |
+|---|---|---|---|---|---|
+| Baseline tests | `cargo test -p sldo-common -p sldo-install -p sldo-research` | all pre-existing tests green for the in-scope crates | | | |
+| BDD tests created | `[files]` | compile or fail for expected reason | | | |
+| E2E stubs created | `[files]` | compile or fail for expected reason | | | |
+| Implementation | `[summary]` | contract satisfied | | | |
+| Full tests | `cargo test -p sldo-common -p sldo-install -p sldo-research` | green | | | |
+| E2E runtime | `cargo test -p sldo-install --tests` | green | | | |
+| Build/boot | `cargo build -p sldo-install -p sldo-research` | boots cleanly | | | |
+| Smoke tests | `[steps]` | all checked | | | |
+| Test artifact cleanup | `git status` | no untracked test artifacts | | | |
+| .gitignore review | review `.gitignore` | patterns current, no stale entries | | | |
+| Compatibility checks | `[checks]` | no regressions | | | |
+
+---
+
+## Self-Review Gate
+
+Before marking a milestone done, answer every question.
+
+- Did I change only allowed files?
+- Did I avoid unrelated refactors?
+- Did I preserve all listed public interfaces and compatibility requirements?
+- Did I add tests for failure modes, not just happy paths?
+- Did I remove temporary debug code, mocks, placeholders, and commented-out dead code?
+- Did I update documentation to match the implementation?
+- Are `README.md` and `docs/getting-started.md` clear enough for a smart 17-year-old contributor to follow without hidden assumptions or patronizing tone?
+- Is every assumption either verified or explicitly documented as unresolved?
+- Do all tests clean up their output artifacts? Does `git status` show a clean working tree?
+- Is `.gitignore` up to date with any new generated files or build outputs?
+- Is the milestone truly done according to its Definition of Done?
+
+If any answer is "no", the milestone is not complete.
+
+---
+
+## Lessons-Learned File Template
+
+Path: `docs/lessons/<prefix>-m<N>.md`
+
+```md
+# Lessons Learned — <prefix> Milestone <N>
+
+## What changed
+- [summary]
+
+## Design decisions and why
+- [decision] — [reason]
+
+## Mistakes made
+- [mistake]
+
+## Root causes
+- [root cause]
+
+## What was harder than expected
+- [note]
+
+## Naming conventions established
+- [types, files, tests, events, commands]
+
+## Test patterns that worked well
+- [pattern]
+
+## Missing tests that should exist now
+- [test]
+
+## Rules for the next milestone
+- [rule]
+
+## Template improvements suggested
+- [improvement]
+```
+
+---
+
+## Completion Summary Template
+
+Path: `docs/completion/<prefix>-m<N>.md`
+
+```md
+# Completion Summary — <prefix> Milestone <N>
+
+## Goal completed
+- [what capability now exists]
+
+## Files changed
+- [file]
+- [file]
+
+## Tests added
+- [test file]
+- [test file]
+
+## Runtime validations added
+- [e2e file]
+
+## Compatibility checks performed
+- [check]
+
+## Documentation updated
+- [doc and section]
+
+## .gitignore changes
+- [patterns added or removed]
+
+## Test artifact cleanup verified
+- [confirmation that git status is clean after test run]
+
+## Deferred follow-ups
+- [follow-up]
+
+## Known non-blocking limitations
+- [limitation]
+```
+
+---
+
+## Milestone Plan
+
+### Milestone 1 — Installer Host Profiles
+
+**Goal**: `sldo-install` installs, verifies, reports status for, and uninstalls skills for both `claude-code` and `github-copilot`, while preserving today's Claude default behavior and safely upgrading existing manifests.
+
+**Context**: [crates/sldo-install/src/main.rs](../crates/sldo-install/src/main.rs) already exposes a `--host` flag, but the enum only implements `claude-code`. [crates/sldo-install/src/paths.rs](../crates/sldo-install/src/paths.rs) hardcodes `.claude` roots for both global and local installs, and [crates/sldo-install/tests/install_e2e.rs](../crates/sldo-install/tests/install_e2e.rs) only validates that behavior. On this machine, Copilot skills live under `~/.copilot/skills`, so the missing piece is host-aware install logic, not a different skill file format.
+
+**Important design rule**: All host-specific filesystem paths and labels must come from one descriptor table. Do not scatter string comparisons for `claude-code` and `github-copilot` across install logic.
+
+**Refactor budget**: `Minimal local refactor permitted in listed files only`
+
+#### Contract Block
+
+| Field | Value |
+|---|---|
+| Inputs | `sldo-install [install\|uninstall\|status\|verify] [--host <id>] [--local] [--skills-dir <path>] [--force] [--dry-run]` |
+| Outputs | Host-specific skill symlinks under `~/.claude/skills/`, `./.claude/skills/`, `~/.copilot/skills/`, or `./.copilot/skills/`; manifest entries that record host id and target path |
+| Interfaces touched | `sldo-install` CLI, manifest schema, path resolution, install/status/verify output |
+| Files allowed to change | `crates/sldo-install/src/main.rs`, `crates/sldo-install/src/install.rs`, `crates/sldo-install/src/manifest.rs`, `crates/sldo-install/src/paths.rs`, `crates/sldo-install/tests/install_e2e.rs`, `README.md`, `skills/README.md`, `.gitignore` |
+| Files to read before changing anything | `crates/sldo-install/src/main.rs`, `crates/sldo-install/src/install.rs`, `crates/sldo-install/src/manifest.rs`, `crates/sldo-install/src/paths.rs`, `crates/sldo-install/tests/install_e2e.rs`, `README.md`, `skills/README.md`, `.gitignore` |
+| New files allowed | `crates/sldo-install/src/host.rs`, `crates/sldo-install/tests/e2e_agent_host_m1.rs` |
+| New dependencies allowed | `none` |
+| Migration allowed | `yes` — manifest schema may move from v1 to v2 if needed to record host metadata; v1 files must still load safely with default `claude-code` semantics |
+| Compatibility commitments | No-arg `sldo-install` still targets Claude Code; existing installed Claude skills remain uninstallable; generic skill pickup still works for `get-api-docs`; existing manifest files remain readable |
+| Forbidden shortcuts | No host-specific logic duplicated outside the descriptor table; no silent fallback from `github-copilot` to `claude-code`; no destructive uninstall outside manifest-owned host roots |
+| Data classification | `Internal` — installer paths, manifest files, and local development state; no customer data or secrets should enter source control |
+| Proactive controls in play | `C5 Validate All Inputs` — host ids, manifest schema, and target paths must be validated; `C8 Protect Data Everywhere` — local host state directories must be gitignored and test-isolated; `C10 Handle All Errors and Exceptions` — unknown hosts and invalid manifests fail loudly |
+| Abuse acceptance scenarios | `install_root_escape_refused (tm-agent-host-compat-abuse-1)` and `legacy_manifest_cannot_remove_wrong_host_root (tm-agent-host-compat-abuse-2)` in the BDD table below |
+
+#### Out of Scope / Must Not Do
+
+- Do not rewrite skill content in `skills/*`.
+- Do not add a third host beyond `claude-code` and `github-copilot` in this milestone.
+- Do not change runtime harnesses or `sldo-research` in this milestone.
+
+#### Pre-Flight
+
+1. Complete the Global Entry Rules.
+2. Read `crates/sldo-install/src/main.rs`, `install.rs`, `manifest.rs`, `paths.rs`, `tests/install_e2e.rs`, `README.md`, `skills/README.md`, and `.gitignore`.
+3. Copy the Evidence Log template into working notes.
+4. Restate the milestone constraints before coding.
+
+#### Files Allowed To Change
+
+| File | Planned Change |
+|---|---|
+| `crates/sldo-install/src/main.rs` | Add `github-copilot` host selection and wire host-aware options through the CLI |
+| `crates/sldo-install/src/install.rs` | Consume host descriptors during plan/install/status/verify/uninstall |
+| `crates/sldo-install/src/manifest.rs` | Add safe host-aware manifest fields and v1 load compatibility |
+| `crates/sldo-install/src/paths.rs` | Move hardcoded `.claude` roots behind host profile helpers |
+| `crates/sldo-install/src/host.rs` | NEW: central host descriptor table and root-path helpers |
+| `crates/sldo-install/tests/install_e2e.rs` | Extend existing install lifecycle tests for both hosts |
+| `crates/sldo-install/tests/e2e_agent_host_m1.rs` | NEW: host-specific install/status/verify regression coverage |
+| `README.md` | Update installer usage examples with `--host github-copilot` |
+| `skills/README.md` | Document both global/local install roots |
+| `.gitignore` | Add `/.copilot/` for local host installs and review existing local-state rules |
+
+#### Step-by-Step
+
+1. Write BDD tests for host profile resolution, manifest compatibility, and dual-host install behavior.
+2. Write E2E tests for install/status/verify/uninstall across both hosts.
+3. Introduce a single host descriptor module.
+4. Refactor path resolution and manifest handling to use the descriptor.
+5. Keep Claude as the default host and add Copilot as an opt-in host.
+6. Update README and `skills/README.md` to match the new CLI behavior.
+7. Add `.copilot/` to `.gitignore` if local host installs would create it in the repo.
+8. Run the backend and E2E tests.
+9. Run smoke tests and complete the Self-Review Gate.
+
+#### BDD Acceptance Scenarios
+
+**Feature: multi-host skill installation**
+
+| Scenario | Category | Given | When | Then |
+|---|---|---|---|---|
+| `claude_default_install_remains_unchanged` | happy path | A repo with installable skills and no explicit `--host` | `sldo-install install` runs | Skills land under `~/.claude/skills/` and the manifest records `claude-code` |
+| `github_copilot_global_install_works` | happy path | A repo with installable skills | `sldo-install --host github-copilot install` runs | Skills land under `~/.copilot/skills/` and `status` reports `github-copilot` |
+| `github_copilot_local_install_uses_repo_state` | empty state | An empty temp project and no prior install | `sldo-install --host github-copilot --local install` runs | Skills land under `./.copilot/skills/` and no global host state is written |
+| `legacy_manifest_upgrades_without_breaking_uninstall` | persistence / backward compatibility | A schema-v1 manifest created before host metadata existed | `sldo-install uninstall` runs after upgrade | Only Claude-owned paths recorded by the legacy manifest are removed |
+| `unknown_host_fails_loud` | invalid input | An unsupported host id | `sldo-install --host not-a-host install` runs | Exit is non-zero with a supported-host list; nothing is written |
+| `install_root_escape_refused (tm-agent-host-compat-abuse-1)` | abuse case | A crafted manifest entry or target path outside the selected host root | `uninstall` or `verify` evaluates that entry | The path is rejected and surfaced as an error; nothing outside the host root is removed |
+| `legacy_manifest_cannot_remove_wrong_host_root (tm-agent-host-compat-abuse-2)` | abuse case | A migrated manifest mixes Claude and Copilot entries | `uninstall --host github-copilot` runs | Only Copilot-owned entries are considered; Claude entries are left untouched |
+
+#### Regression Tests
+
+- `crates/sldo-install/tests/install_e2e.rs` still covers idempotent install, dry-run, force overwrite, and local install.
+- `crates/sldo-install/tests/e2e_slo_sp_m10.rs::get_api_docs_installs_through_generic_pickup` still passes.
+- Existing `sldo-install status` and `verify` behavior for Claude installs still works.
+
+#### Compatibility Checklist
+
+- [x] Running `sldo-install` with no `--host` still targets Claude Code.
+- [x] Existing `~/.claude/skills/` installs remain readable and uninstallable.
+- [x] `get-api-docs` still installs through generic skill discovery.
+- [x] Local installs do not leak into global host roots.
+
+#### E2E Runtime Validation
+
+**File**: `crates/sldo-install/tests/e2e_agent_host_m1.rs`
+
+| E2E Test | What It Proves | Pass Criteria |
+|---|---|---|
+| `test_claude_and_copilot_roots_are_distinct` | Each host resolves to a different install root and manifest target | Install roots match `.claude` vs `.copilot` exactly |
+| `test_status_and_verify_report_selected_host` | CLI output remains truthful for both hosts | `status`/`verify` mention the selected host and installed skills |
+
+#### Smoke Tests
+
+- [x] `cargo test -p sldo-install --test install_e2e --test e2e_agent_host_m1` passes
+- [x] `./target/debug/sldo-install --host github-copilot --dry-run` reports `.copilot/skills` when run against a temporary `HOME`; running it against the real `HOME` correctly surfaced an existing non-symlink conflict at `~/.copilot/skills/get-api-docs`
+- [x] `./target/debug/sldo-install --dry-run` still reports `.claude/skills`
+- [x] Local Copilot install writes under `./.copilot/skills/` only
+- [x] `git status` shows no untracked test artifacts; only intended source edits remain
+- [x] `.gitignore` covers `.copilot/`
+
+#### Evidence Log
+
+| Step | Command / Check | Expected Result | Actual Result | Pass/Fail | Notes |
+|---|---|---|---|---|---|
+| Baseline tests | `cargo test -p sldo-common -p sldo-install -p sldo-research` | all green for in-scope crates | Passed across all three crates before milestone closeout | Pass | Included `sldo-install`, `sldo-common`, and `sldo-research` |
+| BDD tests created | `crates/sldo-install/tests/e2e_agent_host_m1.rs`, `install_e2e.rs` | fail for expected reason | New host tests failed on missing manifest host ownership, missing host-aware status/verify output, and missing host-root guard | Pass | Failures matched the intended M1 gaps |
+| E2E stubs created | same files | fail for expected reason | Host-specific install/status/uninstall/verify coverage compiled and exposed the missing host-scoped behavior | Pass | Added legacy-manifest and hostile-manifest cases before the final implementation slice |
+| Implementation | host descriptor + manifest upgrade | installer honors both hosts | Added `host.rs`, host-aware roots, schema-v2 manifest entries with per-host ownership, and verify/uninstall root guards | Pass | Claude remains the default host |
+| Full tests | `cargo test -p sldo-install --tests` | green | Green under the broader `cargo test -p sldo-common -p sldo-install -p sldo-research` run | Pass | `sldo-install` unit + integration tests all passed |
+| E2E runtime | `cargo test -p sldo-install --test install_e2e --test e2e_agent_host_m1` | green | `install_e2e` and `e2e_agent_host_m1` both passed in the final crate test run | Pass | Covers default Claude, Copilot global/local, legacy manifest, and hostile target cases |
+| Build/boot | `cargo build -p sldo-install` | builds cleanly | Build completed cleanly | Pass | Used the newly updated host-aware CLI |
+| Smoke tests | installer dry-run checks | all checked | Default Claude and GitHub Copilot roots both reported correctly under a temporary `HOME`; real-home Copilot dry-run surfaced an existing non-symlink conflict instead of overwriting it | Pass | Conflict handling is expected and desirable |
+| Test artifact cleanup | `git status` | no untracked test artifacts | No generated artifacts remained; working tree only showed intended source edits | Pass | Includes the new host module/test files and the runbook docs |
+| .gitignore review | review `.gitignore` | `.copilot/` covered if introduced | Added `/.copilot/` and updated the comment to cover host-agent state generically | Pass | Matches the new local install surface |
+| Compatibility checks | default-host and legacy-manifest checks | no regressions | Default no-arg install stayed Claude-first, legacy v1 manifests still uninstall cleanly, `get-api-docs` still installs, and local Copilot installs stayed repo-local | Pass | Verified by integration tests and dry-run smoke checks |
+
+#### Definition of Done
+
+The milestone is done only when all of the following are true:
+
+- all listed BDD scenarios pass
+- all listed E2E runtime validations pass
+- full existing in-scope test suite remains green
+- smoke tests are checked off
+- compatibility checklist is complete
+- no forbidden shortcuts remain in production code
+- all tests clean up their output artifacts — `git status` is clean
+- `.gitignore` is up to date with any new generated files or build outputs
+- docs are updated to match implementation
+- lessons file is written
+- completion summary is written
+- Milestone Tracker is updated
+
+#### Post-Flight
+
+Complete the Global Exit Rules above. Key documentation updates:
+
+- **ARCHITECTURE.md**: add host-aware install roots and manifest notes.
+- **README.md**: update install examples.
+- **Other docs**: `skills/README.md` and `.gitignore` comments.
+
+#### Notes
+
+- This milestone introduces a new filesystem surface (`./.copilot/`), so the abuse-case coverage is mandatory.
+- The manifest migration must be additive and reversible; do not require users to reinstall existing Claude skills.
+
+---
+
+### Milestone 2 — Living Docs, Getting Started, and Host Overlays
+
+**Goal**: Establish one agent-neutral living catalog for the skill pack, ship a first-class `docs/getting-started.md` onboarding guide, and keep host-specific overlay docs for Claude Code and GitHub Copilot in sync without rewriting historical project artifacts.
+
+**Context**: [README.md](../README.md), [CLAUDE.md](../CLAUDE.md), [skills/README.md](../skills/README.md), [docs/skill-pack-catalog.md](skill-pack-catalog.md), and [docs/ARCHITECTURE.md](ARCHITECTURE.md) currently mix real skill-pack state with Claude-only framing and stale legacy crate references. There is also no dedicated getting-started guide for new contributors who need a step-by-step install and first-use path. Many historical runbooks and completion docs mention `CLAUDE.md`, but those documents are records of prior work and should not become churn targets for this cleanup.
+
+**Important design rule**: The README is for orientation and trust; `docs/getting-started.md` is for step-by-step first use. Both must be written for a smart 17-year-old contributor: clear, complete, jargon-aware, and never patronizing.
+
+**Refactor budget**: `No refactor permitted beyond direct implementation`
+
+#### Contract Block
+
+| Field | Value |
+|---|---|
+| Inputs | Existing skill catalog, README, architecture doc, Claude overlay, new Copilot overlay, current installer behavior |
+| Outputs | Updated living docs that distinguish canonical catalog from host overlays; new `copilot-instructions.md`; new `docs/getting-started.md`; explicit capability matrix |
+| Interfaces touched | `README.md`, `CLAUDE.md`, `copilot-instructions.md`, `docs/getting-started.md`, `docs/skill-pack-catalog.md`, `docs/ARCHITECTURE.md`, `skills/README.md` |
+| Files allowed to change | `README.md`, `CLAUDE.md`, `skills/README.md`, `docs/skill-pack-catalog.md`, `docs/ARCHITECTURE.md` |
+| Files to read before changing anything | `README.md`, `CLAUDE.md`, `skills/README.md`, `docs/skill-pack-catalog.md`, `docs/ARCHITECTURE.md`, `Cargo.toml`, `crates/sldo-install/src/main.rs`, `crates/sldo-install/src/paths.rs` |
+| New files allowed | `copilot-instructions.md`, `docs/getting-started.md`, `docs/design/agent-host-capabilities.md`, `crates/sldo-install/tests/e2e_agent_host_m2.rs` |
+| New dependencies allowed | `none` |
+| Migration allowed | `no` |
+| Compatibility commitments | `CLAUDE.md` remains present and useful for Claude users; historical docs remain untouched unless explicitly listed; skill names and install commands stay the same |
+| Forbidden shortcuts | No global search-and-replace of `Claude`; no rewriting historical artifacts; no documentation promise of noninteractive Copilot runtime automation; no vague onboarding prose that omits steps or assumes prior SLO context |
+| Data classification | `Public` — repository documentation and skill catalog only |
+| Proactive controls in play | `C1 Define Security Requirements` — document host capability limits explicitly; `C8 Protect Data Everywhere` — document local-state directories accurately; `C10 Handle All Errors and Exceptions` — docs must state unsupported surfaces instead of implying support |
+| Abuse acceptance scenarios | `copilot_overlay_does_not_promise_headless_cli (tm-agent-host-docs-abuse-1)`, `living_docs_do_not_claim_removed_crates_exist (tm-agent-host-docs-abuse-2)`, and `getting_started_does_not_skip_required_context (tm-agent-host-docs-abuse-3)` in the BDD table below |
+
+#### Out of Scope / Must Not Do
+
+- Do not edit historical runbooks, completion summaries, or lessons files beyond adding forward-looking notes in living docs.
+- Do not change installer code in this milestone except where a documentation test needs to read it.
+- Do not introduce runtime automation for Copilot.
+
+#### Pre-Flight
+
+1. Complete the Global Entry Rules.
+2. Read the listed docs and current installer path code.
+3. Copy the Evidence Log template.
+4. Restate the milestone constraints before coding.
+
+#### Files Allowed To Change
+
+| File | Planned Change |
+|---|---|
+| `README.md` | Make host support, install roots, surviving workspace members, and onboarding entry points truthful |
+| `CLAUDE.md` | Keep as a Claude-specific overlay doc instead of implicit canonical catalog |
+| `copilot-instructions.md` | NEW: GitHub Copilot overlay doc for the same pack |
+| `docs/getting-started.md` | NEW: first-run guide with prerequisites, install, first-use path, and troubleshooting written in plain language |
+| `skills/README.md` | Explain canonical skill contract plus Claude/Copilot install targets |
+| `docs/skill-pack-catalog.md` | Recast as the canonical living skill inventory and host-neutral contract |
+| `docs/ARCHITECTURE.md` | Replace stale legacy crate references with current workspace reality and host overlay notes |
+| `docs/design/agent-host-capabilities.md` | NEW: capability matrix for install, interactive execution, and headless automation |
+| `crates/sldo-install/tests/e2e_agent_host_m2.rs` | NEW: structural tests for living docs and overlay drift |
+
+#### Step-by-Step
+
+1. Write structural tests for canonical catalog, overlay presence, truthful architecture references, and onboarding-doc requirements.
+2. Create `copilot-instructions.md`, `docs/getting-started.md`, and `docs/design/agent-host-capabilities.md` as the new living overlay/onboarding/capability docs.
+3. Update `README.md`, `CLAUDE.md`, `skills/README.md`, `docs/skill-pack-catalog.md`, and `docs/ARCHITECTURE.md`.
+4. Keep `CLAUDE.md` useful but explicitly non-canonical.
+5. Make `docs/getting-started.md` the step-by-step first-run path and link it prominently from `README.md`.
+6. Add capability notes for unsupported headless Copilot automation.
+7. Run structural tests.
+8. Run smoke tests by reading the rendered docs end-to-end and following at least one first-run path.
+9. Complete Self-Review Gate.
+
+#### BDD Acceptance Scenarios
+
+**Feature: living docs and host overlays**
+
+| Scenario | Category | Given | When | Then |
+|---|---|---|---|---|
+| `canonical_catalog_lists_pack_once` | happy path | A current checkout with all shipped skills | `docs/skill-pack-catalog.md` is read | It describes the pack as agent-neutral and points users to host overlays for host-specific guidance |
+| `claude_overlay_remains_complete` | backward compatibility | Existing Claude users rely on `CLAUDE.md` | `CLAUDE.md` is read after the update | It still catalogs the pack for Claude sessions and points back to the canonical catalog |
+| `copilot_overlay_exists_and_is_actionable` | happy path | A Copilot user opens the repo | `copilot-instructions.md` is read | It explains install roots, limitations, and next steps without referencing `~/.claude/skills` as the only path |
+| `first_time_user_can_follow_getting_started` | happy path | A new contributor with no prior SLO knowledge | `docs/getting-started.md` is followed top to bottom | The guide explains prerequisites, install, first-use, and where success or failure will show up |
+| `docs_define_jargon_before_using_it` | invalid input / clarity | A reader does not know SLO-specific terms | README and `docs/getting-started.md` are read | Terms like skill pack, host, overlay doc, and manifest are defined or explained before they are relied on |
+| `architecture_doc_matches_surviving_workspace_members` | backward compatibility | The current workspace has four active members | `docs/ARCHITECTURE.md` is read | It no longer claims `sldo-plan`, `sldo-run`, or `sldo-tauri` are active head surfaces |
+| `copilot_overlay_does_not_promise_headless_cli (tm-agent-host-docs-abuse-1)` | abuse case | A reader looks for Copilot automation guidance | `copilot-instructions.md` is read | It states that interactive skill execution is supported, but headless runtime automation is not yet claimed |
+| `living_docs_do_not_claim_removed_crates_exist (tm-agent-host-docs-abuse-2)` | abuse case | A reader uses the docs to orient to the repo | `README.md` and `docs/ARCHITECTURE.md` are read | No active-surface section claims removed crates still ship as current interfaces |
+| `getting_started_does_not_skip_required_context (tm-agent-host-docs-abuse-3)` | abuse case | A new contributor follows the onboarding docs literally | `docs/getting-started.md` is read and executed | The guide does not omit prerequisites, working directory assumptions, or where commands should be run |
+
+#### Regression Tests
+
+- Existing tests that assert `CLAUDE.md` exists and catalogs shipped skills continue to pass.
+- Installer usage shown in docs still matches Milestone 1 behavior.
+- `docs/skill-pack-catalog.md` remains the pack-level inventory document instead of being deleted.
+
+#### Compatibility Checklist
+
+- [ ] `CLAUDE.md` still exists and remains usable for Claude users.
+- [ ] Host install examples in docs match actual installer behavior.
+- [ ] `README.md` links to `docs/getting-started.md` as the first-run path.
+- [ ] No historical runbook, lessons, or completion file was edited outside the allow-list.
+- [ ] `docs/ARCHITECTURE.md` matches the current workspace, not removed legacy surfaces.
+
+#### E2E Runtime Validation
+
+**File**: `crates/sldo-install/tests/e2e_agent_host_m2.rs`
+
+| E2E Test | What It Proves | Pass Criteria |
+|---|---|---|
+| `test_living_docs_distinguish_catalog_from_overlays` | Canonical vs overlay responsibilities are explicit | Each doc contains the expected responsibility line and cross-links |
+| `test_capability_matrix_marks_headless_copilot_as_unsupported` | The docs are honest about unsupported surfaces | Capability doc contains explicit unsupported/interactive-only note |
+| `test_readme_links_to_getting_started_and_getting_started_has_first_run_sections` | The onboarding path is explicit and structured | README links to `docs/getting-started.md`; the guide contains prerequisites, install, first-use, and troubleshooting sections |
+
+#### Smoke Tests
+
+- [ ] Read the README install section end-to-end; it mentions both Claude and Copilot and links to `docs/getting-started.md`
+- [ ] Read `docs/getting-started.md` end-to-end; it explains prerequisites, install, first-use, and troubleshooting without assuming prior SLO knowledge
+- [ ] Read `CLAUDE.md`; it remains useful but no longer claims to be the only canonical skill catalog
+- [ ] Read `copilot-instructions.md`; it is actionable for a Copilot session
+- [ ] Read `docs/ARCHITECTURE.md`; it reflects the actual workspace members
+- [ ] `cargo test -p sldo-install --test e2e_agent_host_m2` passes
+- [ ] `git status` shows no untracked test artifacts
+
+#### Evidence Log
+
+| Step | Command / Check | Expected Result | Actual Result | Pass/Fail | Notes |
+|---|---|---|---|---|---|
+| Baseline tests | `cargo test -p sldo-common -p sldo-install -p sldo-research` | all green for in-scope crates | | | |
+| BDD tests created | `crates/sldo-install/tests/e2e_agent_host_m2.rs` | fail for expected reason | | | |
+| E2E stubs created | same file | fail for expected reason | | | |
+| Implementation | living docs + getting-started guide + overlays | docs become truthful, beginner-friendly, and non-duplicative | | | |
+| Full tests | `cargo test -p sldo-install --test e2e_agent_host_m2` | green | | | |
+| E2E runtime | `cargo test -p sldo-install --test e2e_agent_host_m2` | green | | | |
+| Build/boot | `cargo build -p sldo-install` | builds cleanly | | | |
+| Smoke tests | manual doc review | all checked | | | |
+| Test artifact cleanup | `git status` | no untracked test artifacts | | | |
+| .gitignore review | review `.gitignore` | no new patterns needed beyond M1 | | | |
+| Compatibility checks | overlay, architecture, and onboarding checks | no regressions | | | |
+
+#### Definition of Done
+
+The milestone is done only when all of the following are true:
+
+- all listed BDD scenarios pass
+- all listed E2E runtime validations pass
+- full existing in-scope test suite remains green
+- smoke tests are checked off
+- compatibility checklist is complete
+- no forbidden shortcuts remain in production code
+- all tests clean up their output artifacts — `git status` is clean
+- `.gitignore` is up to date with any new generated files or build outputs
+- docs are updated to match implementation
+- lessons file is written
+- completion summary is written
+- Milestone Tracker is updated
+
+#### Post-Flight
+
+Complete the Global Exit Rules above. Key documentation updates:
+
+- **ARCHITECTURE.md**: living doc truth refresh.
+- **README.md**: host-aware getting-started, current workspace structure, and prominent link to `docs/getting-started.md`.
+- **Other docs**: `CLAUDE.md`, `copilot-instructions.md`, `docs/getting-started.md`, `docs/design/agent-host-capabilities.md`.
+
+#### Notes
+
+- Historical docs can still mention Claude-era decisions. The milestone only corrects living orientation docs.
+- `copilot-instructions.md` is a new host overlay, so its scope must stay tight and factual.
+- `docs/getting-started.md` is the place to slow down, define terms, and remove hidden assumptions. It should sound like a patient senior maintainer, not a marketing page and not a classroom scolding.
+
+---
+
+### Milestone 3 — Agent-Neutral `/slo-research` Interactive Path
+
+**Goal**: Make `/slo-research` usable from skill-capable hosts without a hidden requirement that the current host shell out to the `sldo-research` Claude backend; retain `sldo-research` only as an explicit optional Claude batch path.
+
+**Context**: [skills/slo-research/SKILL.md](../skills/slo-research/SKILL.md) currently says the host agent has one tool, the `sldo-research` binary. That binary then preflights and invokes the `claude` CLI in [crates/sldo-research/src/main.rs](../crates/sldo-research/src/main.rs) and [crates/sldo-research/src/research.rs](../crates/sldo-research/src/research.rs). In GitHub Copilot, that would present `/slo-research` as a supported skill while silently depending on another agent installation. The interactive skill must stop doing that.
+
+**Important design rule**: Interactive skill execution must never rely on a second agent being installed behind the scenes. Optional batch backends are acceptable only when they are explicitly named as optional.
+
+**Refactor budget**: `Minimal local refactor permitted in listed files only`
+
+#### Contract Block
+
+| Field | Value |
+|---|---|
+| Inputs | `/slo-research <slug>` invocation, `docs/idea/<slug>.md`, host-native research tools (for example web search/fetch and file writes), optional explicit `sldo-research` CLI usage |
+| Outputs | `docs/research/<slug>/dossier.md`, `docs/research/<slug>/sources.md`, `docs/research/<slug>/synthesis.md`, and optional explicit batch-backend notes when the user chooses that path |
+| Interfaces touched | `skills/slo-research/SKILL.md`, living docs describing `/slo-research`, optional `sldo-research` help/description text |
+| Files allowed to change | `skills/slo-research/SKILL.md`, `README.md`, `CLAUDE.md`, `copilot-instructions.md`, `docs/skill-pack-catalog.md`, `docs/ARCHITECTURE.md`, `crates/sldo-research/src/main.rs`, `crates/sldo-research/src/research.rs` |
+| Files to read before changing anything | `skills/slo-research/SKILL.md`, `crates/sldo-research/src/main.rs`, `crates/sldo-research/src/research.rs`, `README.md`, `docs/skill-pack-catalog.md`, `CLAUDE.md`, `copilot-instructions.md` |
+| New files allowed | `crates/sldo-install/tests/e2e_agent_host_m3.rs`, `docs/verify/agent-host-m3-smoke.md` |
+| New dependencies allowed | `none` |
+| Migration allowed | `no` |
+| Compatibility commitments | `/slo-research` keeps writing the same artifact paths; `incomplete: true` remains the signal for missing research coverage; `sldo-research` remains buildable for explicit Claude batch users |
+| Forbidden shortcuts | No “if Copilot then install Claude too” guidance; no research-from-memory fallback; no removal of incomplete-state handling; no promise that Copilot has a headless `sldo-research` equivalent |
+| Data classification | `Internal` — research prompts, output artifacts, and capability notes; still no secrets or customer data in source control |
+| Proactive controls in play | `C5 Validate All Inputs` — slug and idea-doc preconditions stay enforced; `C8 Protect Data Everywhere` — output locations remain explicit; `C10 Handle All Errors and Exceptions` — missing sources or missing idea docs must still fail or mark incomplete visibly |
+| Abuse acceptance scenarios | `hidden_claude_dependency_rejected (tm-agent-host-research-abuse-1)` and `incomplete_research_is_visible (tm-agent-host-research-abuse-2)` in the BDD table below |
+
+#### Out of Scope / Must Not Do
+
+- Do not rewrite the Rust research loop into a new non-Claude backend.
+- Do not promise noninteractive Copilot batch research.
+- Do not change the dossier output shape or destination paths.
+
+#### Pre-Flight
+
+1. Complete the Global Entry Rules.
+2. Read the listed skill/backend files and living docs.
+3. Copy the Evidence Log template.
+4. Restate the milestone constraints before coding.
+
+#### Files Allowed To Change
+
+| File | Planned Change |
+|---|---|
+| `skills/slo-research/SKILL.md` | Rewrite the skill around host-native research execution first, with `sldo-research` as an explicit optional batch path |
+| `crates/sldo-research/src/main.rs` | Clarify help text so the binary is described honestly as a Claude batch backend |
+| `crates/sldo-research/src/research.rs` | Clarify module docs/log messages if needed so the backend is explicitly Claude-specific |
+| `README.md` | Update `/slo-research` usage notes |
+| `CLAUDE.md` | Keep Claude batch guidance, but stop implying every host must use it |
+| `copilot-instructions.md` | Add `/slo-research` guidance that does not require `sldo-research` |
+| `docs/skill-pack-catalog.md` | Record `/slo-research` as host-native interactive first, optional batch backend second |
+| `docs/ARCHITECTURE.md` | Reflect the new split between interactive skill and optional batch backend |
+| `crates/sldo-install/tests/e2e_agent_host_m3.rs` | NEW: structural tests guarding against hidden `sldo-research`/`claude` requirements in the skill |
+| `docs/verify/agent-host-m3-smoke.md` | NEW: manual smoke checklist for Claude and Copilot interactive runs |
+
+#### Step-by-Step
+
+1. Write structural tests that fail if `/slo-research` still requires `sldo-research` or `claude` for the interactive path.
+2. Add a manual smoke checklist for interactive validation in Claude and Copilot.
+3. Rewrite `skills/slo-research/SKILL.md` to be host-native first and explicit about the optional batch backend.
+4. Make the Rust backend docs honest that `sldo-research` is Claude-batch-only.
+5. Update the living docs and architecture notes to match.
+6. Run structural tests.
+7. Execute the manual smoke checklist in at least one host-capable session.
+8. Complete Self-Review Gate.
+
+#### BDD Acceptance Scenarios
+
+**Feature: host-neutral interactive research skill**
+
+| Scenario | Category | Given | When | Then |
+|---|---|---|---|---|
+| `interactive_skill_writes_existing_artifact_paths` | happy path | A valid idea doc exists | `/slo-research <slug>` is run interactively in a host agent | The skill writes `dossier.md`, `sources.md`, and `synthesis.md` under `docs/research/<slug>/` |
+| `missing_idea_doc_refuses_cleanly` | invalid input | No `docs/idea/<slug>.md` exists | `/slo-research <slug>` runs | The skill refuses and points the user to `/slo-ideate` |
+| `existing_incomplete_flag_contract_remains` | backward compatibility | Research cannot satisfy the required minimum bars | `/slo-research` completes with gaps | `dossier.md` still marks `incomplete: true` visibly |
+| `optional_batch_backend_is_documented_not_implied` | dependency failure | The current host does not have or need `sldo-research` | `/slo-research` guidance is read | The interactive path remains usable; optional batch guidance is clearly separate |
+| `hidden_claude_dependency_rejected (tm-agent-host-research-abuse-1)` | abuse case | A Copilot user reads the skill and follows it literally | `/slo-research` is invoked | The skill does not require installing or shelling out to `claude` or `sldo-research` just to perform the interactive path |
+| `incomplete_research_is_visible (tm-agent-host-research-abuse-2)` | abuse case | Sources or competitors are missing | The skill finishes | Missing evidence is surfaced as incomplete instead of being papered over |
+
+#### Regression Tests
+
+- Existing dossier artifact names and locations remain unchanged.
+- `sldo-research --help` still works and describes the batch backend honestly.
+- Existing research unit tests continue to compile and pass.
+
+#### Compatibility Checklist
+
+- [ ] `docs/research/<slug>/` output paths are unchanged.
+- [ ] `incomplete: true` remains the explicit missing-coverage signal.
+- [ ] `sldo-research` still builds for existing Claude batch users.
+- [ ] No living doc now implies that all hosts must install Claude to use `/slo-research` interactively.
+
+#### E2E Runtime Validation
+
+**File**: `crates/sldo-install/tests/e2e_agent_host_m3.rs`
+
+| E2E Test | What It Proves | Pass Criteria |
+|---|---|---|
+| `test_slo_research_skill_no_longer_requires_batch_backend_for_interactive_flow` | The skill copy is truly host-native first | `SKILL.md` does not mandate `sldo-research` as the only tool |
+| `test_batch_backend_is_marked_optional_and_claude_specific` | Batch guidance is honest and bounded | Living docs mention `sldo-research` only as explicit optional Claude batch path |
+
+#### Smoke Tests
+
+- [ ] Follow `docs/verify/agent-host-m3-smoke.md` in a Claude session
+- [ ] Follow `docs/verify/agent-host-m3-smoke.md` in a Copilot session
+- [ ] `cargo test -p sldo-install --test e2e_agent_host_m3` passes
+- [ ] `cargo test -p sldo-research` stays green
+- [ ] `git status` shows no untracked test artifacts
+
+#### Evidence Log
+
+| Step | Command / Check | Expected Result | Actual Result | Pass/Fail | Notes |
+|---|---|---|---|---|---|
+| Baseline tests | `cargo test -p sldo-common -p sldo-install -p sldo-research` | all green for in-scope crates | | | |
+| BDD tests created | `crates/sldo-install/tests/e2e_agent_host_m3.rs` | fail for expected reason | | | |
+| E2E stubs created | same file + smoke checklist | fail or remain incomplete for expected reason | | | |
+| Implementation | `/slo-research` rewrite + doc clarification | interactive path is host-neutral | | | |
+| Full tests | `cargo test -p sldo-install --test e2e_agent_host_m3 && cargo test -p sldo-research` | green | | | |
+| E2E runtime | manual smoke checklist | both hosts behave as documented | | | |
+| Build/boot | `cargo build -p sldo-research` | builds cleanly | | | |
+| Smoke tests | `docs/verify/agent-host-m3-smoke.md` | all checked | | | |
+| Test artifact cleanup | `git status` | no untracked test artifacts | | | |
+| .gitignore review | review `.gitignore` | no new patterns needed | | | |
+| Compatibility checks | artifact-path and incomplete-flag checks | no regressions | | | |
+
+#### Definition of Done
+
+The milestone is done only when all of the following are true:
+
+- all listed BDD scenarios pass
+- all listed E2E runtime validations pass
+- full existing in-scope test suite remains green
+- smoke tests are checked off
+- compatibility checklist is complete
+- no forbidden shortcuts remain in production code
+- all tests clean up their output artifacts — `git status` is clean
+- `.gitignore` is up to date with any new generated files or build outputs
+- docs are updated to match implementation
+- lessons file is written
+- completion summary is written
+- Milestone Tracker is updated
+
+#### Post-Flight
+
+Complete the Global Exit Rules above. Key documentation updates:
+
+- **ARCHITECTURE.md**: record the split between host-native interactive research and optional batch backend.
+- **README.md**: update `/slo-research` usage guidance.
+- **Other docs**: `CLAUDE.md`, `copilot-instructions.md`, `docs/skill-pack-catalog.md`, `docs/verify/agent-host-m3-smoke.md`.
+
+#### Notes
+
+- This milestone is the most important user-facing portability change because it removes a hidden second-agent dependency from the interactive skill path.
+- The batch backend remains useful, but it must stop being the implicit path for every host.
+
+---
+
+### Milestone 4 — Isolate Claude-Only Automation Surfaces
+
+**Goal**: Make the repo’s remaining Claude-only automation code and live runtime harnesses explicit in module names, docs, and env vars, without inventing a fake cross-agent runtime abstraction.
+
+**Context**: [crates/sldo-common/src/copilot.rs](../crates/sldo-common/src/copilot.rs) defines `ClaudeInvocation`, and [crates/sldo-common/src/preflight.rs](../crates/sldo-common/src/preflight.rs) exports `check_claude_installed()`. Meanwhile, [crates/sldo-install/tests/common/judgment_runtime.rs](../crates/sldo-install/tests/common/judgment_runtime.rs) sounds generic but hardcodes `.claude/skills`, `CLAUDE.md`, `claude -p`, and `BIZ_JUDGMENT_RUNTIME_CLAUDE_BIN`. The portability cleanup is safer if those surfaces are labeled honestly rather than abstracted prematurely.
+
+**Important design rule**: Honest names beat premature abstractions. If only Claude batch automation exists, name it `claude_*`, document it, and keep unsupported hosts explicit.
+
+**Refactor budget**: `Targeted refactor permitted for naming + isolation only`
+
+#### Contract Block
+
+| Field | Value |
+|---|---|
+| Inputs | Existing Claude-only batch/runtime helper modules, live judgment runtime tests, optional env vars for live runs |
+| Outputs | Explicitly named Claude-only modules/docs/tests; preserved runtime behavior for users who intentionally run the live harness |
+| Interfaces touched | `sldo-common` module names/exports, `sldo-research` imports, live judgment-runtime test helpers, fixture README docs |
+| Files allowed to change | `crates/sldo-common/src/lib.rs`, `crates/sldo-common/src/copilot.rs`, `crates/sldo-common/src/preflight.rs`, `crates/sldo-research/src/research.rs`, `crates/sldo-install/tests/common/mod.rs`, `crates/sldo-install/tests/common/judgment_runtime.rs`, `crates/sldo-install/tests/e2e_biz_judgment_runtime_m1.rs`, `crates/sldo-install/tests/e2e_biz_judgment_runtime_m2.rs`, `references/biz/judgment-fixtures/README.md`, `docs/RUNBOOK-BIZ-PACK-JUDGMENT-RUNTIME.md`, `docs/ARCHITECTURE.md` |
+| Files to read before changing anything | `crates/sldo-common/src/lib.rs`, `crates/sldo-common/src/copilot.rs`, `crates/sldo-common/src/preflight.rs`, `crates/sldo-research/src/research.rs`, `crates/sldo-install/tests/common/judgment_runtime.rs`, `crates/sldo-install/tests/common/mod.rs`, `references/biz/judgment-fixtures/README.md`, `docs/RUNBOOK-BIZ-PACK-JUDGMENT-RUNTIME.md` |
+| New files allowed | `crates/sldo-common/src/claude_cli.rs`, `crates/sldo-install/tests/common/claude_runtime.rs` |
+| New dependencies allowed | `none` |
+| Migration allowed | `no` |
+| Compatibility commitments | Existing Claude batch research and live judgment runtime still work; any env var rename must keep backward-compatible aliases; no host-neutral runtime API is promised |
+| Forbidden shortcuts | No trait or enum abstraction without a second real implementation; no silent fallback from unsupported hosts to Claude; no breaking env-var rename without alias/deprecation note |
+| Data classification | `Internal` — local runtime harness behavior, temp repos, and skill automation docs |
+| Proactive controls in play | `C5 Validate All Inputs` — runtime fixture paths and env vars stay validated; `C8 Protect Data Everywhere` — temp repos must stay isolated from real host state; `C10 Handle All Errors and Exceptions` — unsupported or missing Claude runtime must fail loudly |
+| Abuse acceptance scenarios | `temp_repo_never_touches_real_home (tm-agent-host-runtime-abuse-1)` and `unsupported_runtime_is_not_faked (tm-agent-host-runtime-abuse-2)` in the BDD table below |
+
+#### Out of Scope / Must Not Do
+
+- Do not build a Copilot CLI driver.
+- Do not rewrite the live judgment tests to target another host.
+- Do not change the business-skill artifacts or fixture semantics.
+
+#### Pre-Flight
+
+1. Complete the Global Entry Rules.
+2. Read the listed helper/test/doc files.
+3. Copy the Evidence Log template.
+4. Restate the milestone constraints before coding.
+
+#### Files Allowed To Change
+
+| File | Planned Change |
+|---|---|
+| `crates/sldo-common/src/lib.rs` | Export the honest Claude-specific module name |
+| `crates/sldo-common/src/copilot.rs` | Rename or replace with an explicitly Claude-specific module |
+| `crates/sldo-common/src/claude_cli.rs` | NEW: clear module name for `ClaudeInvocation` and related helpers |
+| `crates/sldo-common/src/preflight.rs` | Keep Claude checks explicit and document them as such |
+| `crates/sldo-research/src/research.rs` | Update imports/callers to the new honest module name |
+| `crates/sldo-install/tests/common/mod.rs` | Re-export the renamed runtime helper |
+| `crates/sldo-install/tests/common/judgment_runtime.rs` | Rename or split into explicit Claude runtime helpers |
+| `crates/sldo-install/tests/common/claude_runtime.rs` | NEW: explicit Claude live-runtime helper module |
+| `crates/sldo-install/tests/e2e_biz_judgment_runtime_m1.rs` | Update helper imports and keep behavior |
+| `crates/sldo-install/tests/e2e_biz_judgment_runtime_m2.rs` | Update helper imports and keep behavior |
+| `references/biz/judgment-fixtures/README.md` | Update live-runtime instructions and module naming |
+| `docs/RUNBOOK-BIZ-PACK-JUDGMENT-RUNTIME.md` | Record the Claude-only automation boundary explicitly |
+| `docs/ARCHITECTURE.md` | Note the Claude-only batch/runtime automation surfaces |
+
+#### Step-by-Step
+
+1. Write tests or compile-failing stubs around the renamed module boundaries.
+2. Create the explicitly named Claude helper module.
+3. Update callers and re-exports.
+4. Keep live-runtime behavior unchanged while making the boundary honest.
+5. Update the fixture README and judgment-runtime runbook.
+6. Run the in-scope test suite and live-runtime structural checks.
+7. Run smoke tests for the temp repo and optional live runtime.
+8. Complete Self-Review Gate.
+
+#### BDD Acceptance Scenarios
+
+**Feature: honest Claude-only automation boundaries**
+
+| Scenario | Category | Given | When | Then |
+|---|---|---|---|---|
+| `claude_batch_module_is_named_honestly` | happy path | The shared library is read after the refactor | `sldo-common` exports the runtime helper | The module and docs explicitly say Claude, not generic Copilot/agent wording |
+| `existing_claude_batch_research_still_compiles` | backward compatibility | `sldo-research` imports the shared helper | the crate is built and tested | Existing Claude batch behavior still compiles and runs |
+| `live_runtime_env_var_alias_is_preserved` | backward compatibility | Existing users set `BIZ_JUDGMENT_RUNTIME_CLAUDE_BIN` | the harness is run after the refactor | The old env var still works or fails with a clear deprecation message plus replacement |
+| `temp_repo_never_touches_real_home (tm-agent-host-runtime-abuse-1)` | abuse case | The temp repo harness builds a live-run workspace | tests inspect the temp layout | The harness never writes into the user’s real host state and documents that boundary |
+| `unsupported_runtime_is_not_faked (tm-agent-host-runtime-abuse-2)` | abuse case | A reader looks for non-Claude live automation | runtime docs/tests are read | Unsupported hosts are marked unsupported instead of being mapped silently to Claude |
+
+#### Regression Tests
+
+- `cargo test -p sldo-common -p sldo-research` remains green after the module rename.
+- Live judgment runtime tests still compile and use the renamed helper.
+- Fixture README instructions remain consistent with the actual harness behavior.
+
+#### Compatibility Checklist
+
+- [ ] Existing Claude batch research still builds and runs.
+- [ ] Existing live judgment runtime tests still compile.
+- [ ] Existing env var instructions are preserved or explicitly deprecated with aliasing.
+- [ ] No new host-neutral runtime promise was introduced.
+
+#### E2E Runtime Validation
+
+**File**: `crates/sldo-install/tests/e2e_biz_judgment_runtime_m1.rs` and `crates/sldo-install/tests/e2e_biz_judgment_runtime_m2.rs`
+
+| E2E Test | What It Proves | Pass Criteria |
+|---|---|---|
+| Existing live-runtime fixture tests | Claude-only live harness still works after isolation refactor | Tests compile; live runs remain opt-in and structurally correct |
+| Temp repo layout checks | The helper still builds an isolated runtime workspace | `.claude/skills`, `CLAUDE.md`, and temp HOME layout remain isolated and documented |
+
+#### Smoke Tests
+
+- [ ] `cargo test -p sldo-common -p sldo-research` passes
+- [ ] `cargo test -p sldo-install --test e2e_biz_judgment_runtime_m1 --test e2e_biz_judgment_runtime_m2 -- --ignored` is still opt-in and documented correctly
+- [ ] `references/biz/judgment-fixtures/README.md` matches the actual env vars and helper names
+- [ ] `git status` shows no untracked test artifacts
+
+#### Evidence Log
+
+| Step | Command / Check | Expected Result | Actual Result | Pass/Fail | Notes |
+|---|---|---|---|---|---|
+| Baseline tests | `cargo test -p sldo-common -p sldo-install -p sldo-research` | all green for in-scope crates | | | |
+| BDD tests created | helper/module rename tests | fail for expected reason | | | |
+| E2E stubs created | live-runtime compile checks | fail for expected reason | | | |
+| Implementation | explicit Claude module + harness rename | runtime boundary becomes honest | | | |
+| Full tests | `cargo test -p sldo-common -p sldo-research -p sldo-install` | green | | | |
+| E2E runtime | judgment-runtime structural/live checks | green or correctly skipped when not enabled | | | |
+| Build/boot | `cargo build -p sldo-common -p sldo-research` | builds cleanly | | | |
+| Smoke tests | README/runbook/runtime helper review | all checked | | | |
+| Test artifact cleanup | `git status` | no untracked test artifacts | | | |
+| .gitignore review | review `.gitignore` | current patterns still sufficient | | | |
+| Compatibility checks | compile + env var checks | no regressions | | | |
+
+#### Definition of Done
+
+The milestone is done only when all of the following are true:
+
+- all listed BDD scenarios pass
+- all listed E2E runtime validations pass
+- full existing in-scope test suite remains green
+- smoke tests are checked off
+- compatibility checklist is complete
+- no forbidden shortcuts remain in production code
+- all tests clean up their output artifacts — `git status` is clean
+- `.gitignore` is up to date with any new generated files or build outputs
+- docs are updated to match implementation
+- lessons file is written
+- completion summary is written
+- Milestone Tracker is updated
+
+#### Post-Flight
+
+Complete the Global Exit Rules above. Key documentation updates:
+
+- **ARCHITECTURE.md**: mark Claude-only batch/runtime automation explicitly.
+- **README.md**: only if module names or live-runtime instructions need user-facing clarification.
+- **Other docs**: `references/biz/judgment-fixtures/README.md`, `docs/RUNBOOK-BIZ-PACK-JUDGMENT-RUNTIME.md`.
+
+#### Notes
+
+- This milestone deliberately resists a generic `AgentRuntime` abstraction because there is only one verified live runtime today.
+- Honest naming is part of the user-facing cleanup; it prevents future docs/tests from over-claiming support.
+
+---
+
+### Milestone 5 — Targeted Skill and Structural-Test Cleanup
+
+**Goal**: Clean up the remaining skill/test copy that assumes Claude is the current host by default, while preserving explicit Claude-only references where they are semantically correct and adding tests that prevent regressions.
+
+**Context**: The repo search still shows Claude-centric wording in a small set of real living surfaces: [skills/slo-second-opinion/SKILL.md](../skills/slo-second-opinion/SKILL.md), [skills/slo-rulegen/SKILL.md](../skills/slo-rulegen/SKILL.md), [skills/slo-sast/SKILL.md](../skills/slo-sast/SKILL.md), and pack-level structural tests such as [crates/sldo-install/tests/e2e_slo_sp_m8.rs](../crates/sldo-install/tests/e2e_slo_sp_m8.rs). After Milestones 1–4, these become the main remaining drift surface between host-neutral skills and Claude-only automation.
+
+**Important design rule**: Generalize wording only where the behavior is actually host-neutral. If a surface is intentionally Claude-only, keep the word `Claude` and add an explicit capability note.
+
+**Refactor budget**: `Minimal local refactor permitted in listed files only`
+
+#### Contract Block
+
+| Field | Value |
+|---|---|
+| Inputs | Existing living skill docs, capability matrix, structural tests, pack-level copy drift |
+| Outputs | Updated skill wording, targeted structural tests, and an explicit capability matrix that distinguishes host-neutral from Claude-only surfaces |
+| Interfaces touched | Selected `SKILL.md` files, capability docs, pack-level structural tests |
+| Files allowed to change | `skills/slo-second-opinion/SKILL.md`, `skills/slo-rulegen/SKILL.md`, `skills/slo-sast/SKILL.md`, `README.md`, `docs/skill-pack-catalog.md`, `docs/design/agent-host-capabilities.md`, `docs/ARCHITECTURE.md`, `crates/sldo-install/tests/e2e_slo_sp_m8.rs` |
+| Files to read before changing anything | `skills/slo-second-opinion/SKILL.md`, `skills/slo-rulegen/SKILL.md`, `skills/slo-sast/SKILL.md`, `docs/design/agent-host-capabilities.md`, `crates/sldo-install/tests/e2e_slo_sp_m8.rs`, `README.md`, `docs/skill-pack-catalog.md` |
+| New files allowed | `crates/sldo-install/tests/e2e_agent_host_m5.rs` |
+| New dependencies allowed | `none` |
+| Migration allowed | `no` |
+| Compatibility commitments | Skill names, outputs, and security restrictions stay unchanged; `/slo-second-opinion` still shows raw disagreement rather than a vote; rulegen/ruleverify restrictions remain explicit |
+| Forbidden shortcuts | No repo-wide text replace of `Claude`; no edits to historical docs; no softening of security/tool restrictions to make wording easier |
+| Data classification | `Internal` — skill prompt text, structural tests, and capability docs |
+| Proactive controls in play | `C1 Define Security Requirements` — explicit capability matrix; `C5 Validate All Inputs` — structural tests guard allowed wording; `C10 Handle All Errors and Exceptions` — unsupported-host notes remain explicit |
+| Abuse acceptance scenarios | `second_opinion_does_not_fake_disagreement (tm-agent-host-skill-abuse-1)` and `host_neutral_skills_do_not_require_claude_without_note (tm-agent-host-skill-abuse-2)` in the BDD table below |
+
+#### Out of Scope / Must Not Do
+
+- Do not rewrite every skill in the pack.
+- Do not change security behavior just to simplify wording.
+- Do not edit historical runbooks or completion docs that mention Claude.
+
+#### Pre-Flight
+
+1. Complete the Global Entry Rules.
+2. Read the listed skill files, capability doc, and structural tests.
+3. Copy the Evidence Log template.
+4. Restate the milestone constraints before coding.
+
+#### Files Allowed To Change
+
+| File | Planned Change |
+|---|---|
+| `skills/slo-second-opinion/SKILL.md` | Replace assumed-current-host Claude wording with “current host agent” where the behavior is host-neutral |
+| `skills/slo-rulegen/SKILL.md` | Replace “Claude-found bug” wording with host-neutral language where appropriate; keep explicit Claude-only notes where still true |
+| `skills/slo-sast/SKILL.md` | Keep explicit subprocess/runtime notes honest and aligned with the capability matrix |
+| `README.md` | Align any pack-level wording that still assumes Claude as the default current host story |
+| `docs/skill-pack-catalog.md` | Reflect which skills are host-neutral and which remain host-specific in automation |
+| `docs/design/agent-host-capabilities.md` | Finalize the capability matrix and per-skill notes |
+| `docs/ARCHITECTURE.md` | Record the steady-state boundary after cleanup |
+| `crates/sldo-install/tests/e2e_slo_sp_m8.rs` | Update structural assertions for `/slo-second-opinion` wording |
+| `crates/sldo-install/tests/e2e_agent_host_m5.rs` | NEW: guard against reintroducing hidden Claude requirements into host-neutral skills |
+
+#### Step-by-Step
+
+1. Write structural tests for the selected skill wording and capability notes.
+2. Update the capability matrix to mark each touched skill as host-neutral or Claude-only in the relevant dimension.
+3. Rewrite only the selected skill copy and pack-level doc lines.
+4. Keep explicit Claude-only wording where the capability matrix says that is still true.
+5. Run the structural tests.
+6. Spot-check the selected skills in a host session if practical.
+7. Complete Self-Review Gate.
+
+#### BDD Acceptance Scenarios
+
+**Feature: final living-surface portability cleanup**
+
+| Scenario | Category | Given | When | Then |
+|---|---|---|---|---|
+| `second_opinion_refs_current_host_for_host_neutral_logic` | happy path | `/slo-second-opinion` compares the current host against another provider | the skill text is read | It says “current host” where the logic is host-neutral |
+| `rulegen_copy_does_not_assume_claude_found_the_bug` | backward compatibility | A bug summary can come from any host-driven workflow | `skills/slo-rulegen/SKILL.md` is read | It uses host-neutral wording unless a step is truly Claude-only |
+| `explicit_claude_only_notes_are_preserved_where_true` | backward compatibility | Some automation surfaces remain Claude-only | the capability docs and skills are read | They retain explicit Claude wording plus a limitation note |
+| `second_opinion_does_not_fake_disagreement (tm-agent-host-skill-abuse-1)` | abuse case | A user wants cross-model review | `/slo-second-opinion` runs | The skill still requires raw provider output instead of asking Claude to imitate another provider |
+| `host_neutral_skills_do_not_require_claude_without_note (tm-agent-host-skill-abuse-2)` | abuse case | A user reads a host-neutral skill in Copilot | the skill instructions are followed | The skill does not hide a Claude requirement unless the capability matrix and the skill both say so explicitly |
+
+#### Regression Tests
+
+- Existing `/slo-second-opinion` structural tests still enforce the “comparison, not verdict” contract.
+- Existing rulegen/ruleverify restrictions on tool use remain documented and tested.
+- `CLAUDE.md` continues to catalog the pack for Claude users after the wording cleanup.
+
+#### Compatibility Checklist
+
+- [ ] Skill names and outputs remain unchanged.
+- [ ] `/slo-second-opinion` still surfaces raw disagreement rather than a vote.
+- [ ] Rulegen/ruleverify wording changes do not weaken tool restrictions.
+- [ ] Historical docs remain untouched.
+
+#### E2E Runtime Validation
+
+**File**: `crates/sldo-install/tests/e2e_agent_host_m5.rs`
+
+| E2E Test | What It Proves | Pass Criteria |
+|---|---|---|
+| `test_host_neutral_skills_have_no_hidden_claude_requirement` | Final host-neutral skill set stays clean | Selected skill files contain no hidden Claude-only requirement without a capability note |
+| `test_explicit_claude_only_skills_are_marked_in_capability_matrix` | Claude-only surfaces remain honest | Capability matrix and skill copy agree on limitations |
+
+#### Smoke Tests
+
+- [ ] `cargo test -p sldo-install --test e2e_slo_sp_m8 --test e2e_agent_host_m5` passes
+- [ ] Read the touched skills end-to-end; wording matches the capability matrix
+- [ ] Read `docs/design/agent-host-capabilities.md`; it matches the repo’s actual behavior after M4
+- [ ] `git status` shows no untracked test artifacts
+
+#### Evidence Log
+
+| Step | Command / Check | Expected Result | Actual Result | Pass/Fail | Notes |
+|---|---|---|---|---|---|
+| Baseline tests | `cargo test -p sldo-common -p sldo-install -p sldo-research` | all green for in-scope crates | | | |
+| BDD tests created | `crates/sldo-install/tests/e2e_agent_host_m5.rs`, `e2e_slo_sp_m8.rs` | fail for expected reason | | | |
+| E2E stubs created | same files | fail for expected reason | | | |
+| Implementation | targeted skill/doc wording cleanup | host-neutral and Claude-only lines are consistent | | | |
+| Full tests | `cargo test -p sldo-install --test e2e_slo_sp_m8 --test e2e_agent_host_m5` | green | | | |
+| E2E runtime | touched structural tests | green | | | |
+| Build/boot | `cargo build -p sldo-install -p sldo-research` | builds cleanly | | | |
+| Smoke tests | manual skill/doc review | all checked | | | |
+| Test artifact cleanup | `git status` | no untracked test artifacts | | | |
+| .gitignore review | review `.gitignore` | patterns remain current | | | |
+| Compatibility checks | skill-name/output/security checks | no regressions | | | |
+
+#### Definition of Done
+
+The milestone is done only when all of the following are true:
+
+- all listed BDD scenarios pass
+- all listed E2E runtime validations pass
+- full existing in-scope test suite remains green
+- smoke tests are checked off
+- compatibility checklist is complete
+- no forbidden shortcuts remain in production code
+- all tests clean up their output artifacts — `git status` is clean
+- `.gitignore` is up to date with any new generated files or build outputs
+- docs are updated to match implementation
+- lessons file is written
+- completion summary is written
+- Milestone Tracker is updated
+
+#### Post-Flight
+
+Complete the Global Exit Rules above. Key documentation updates:
+
+- **ARCHITECTURE.md**: final steady-state host boundary notes.
+- **README.md**: any final wording cleanup.
+- **Other docs**: `docs/design/agent-host-capabilities.md`, `docs/skill-pack-catalog.md`.
+
+#### Notes
+
+- This milestone is intentionally small and targeted; it finishes the cleanup by preventing wording regressions on the remaining living surfaces.
+- Do not turn this into a repo-wide “replace Claude everywhere” pass.
+
+---
+
+## Documentation Update Table
+
+Track which documents need updating per milestone.
+
+| Milestone | ARCHITECTURE.md Update | README.md Update | .gitignore Update | Other Docs |
+|---|---|---|---|---|
+| 1 | Add host-aware installer roots and manifest notes | Add `--host github-copilot` install examples and keep installer wording beginner-friendly | Add `.copilot/` if local installs create it | `skills/README.md` installer section |
+| 2 | Replace stale legacy crate/interface notes; add overlay/canonical split | Host-neutral project description, current workspace layout, and link to `docs/getting-started.md` | none expected | `CLAUDE.md`, `copilot-instructions.md`, `docs/getting-started.md`, `docs/skill-pack-catalog.md`, `docs/design/agent-host-capabilities.md` |
+| 3 | Document interactive `/slo-research` vs optional batch backend split | Update `/slo-research` usage guidance in README and getting-started docs | none expected | `CLAUDE.md`, `copilot-instructions.md`, `docs/getting-started.md`, `docs/skill-pack-catalog.md`, `docs/verify/agent-host-m3-smoke.md` |
+| 4 | Mark Claude-only batch/runtime automation explicitly | Update only if naming or runtime boundary needs user-facing note | none expected | `references/biz/judgment-fixtures/README.md`, `docs/RUNBOOK-BIZ-PACK-JUDGMENT-RUNTIME.md` |
+| 5 | Final steady-state capability notes | Final wording cleanup if needed in README and getting-started docs | none expected | `docs/design/agent-host-capabilities.md`, `docs/skill-pack-catalog.md`, `docs/getting-started.md` |
+
+---
+
+## Optional Fast-Fail Review Prompt for Agents
+
+Use this before writing production code:
+
+> Restate the milestone goal, allowed files, forbidden changes, compatibility requirements, tests that must be written first, and the exact Definition of Done. Then list the smallest implementation approach that satisfies the contract without widening scope.

--- a/docs/RUNBOOK-BUSINESS-SKILL-IMPROVEMENTS.md
+++ b/docs/RUNBOOK-BUSINESS-SKILL-IMPROVEMENTS.md
@@ -1,0 +1,1076 @@
+# Business Skill Improvements — SunLitOrchestrate (AI-First Runbook v3)
+
+> **Purpose**: Close the predicate-evaluation hallucination surface across the five advisor skills via conversational intake contracts; move every UK statute / regulator citation from inlined SKILL.md prose to authority files; verify SAFE / cap-table / pricing arithmetic before emission; centralize numeric heuristics for the seven biz generators with source attribution.
+> **Audience**: AI coding agents first, humans second.
+> **How to use**: Work through milestones sequentially. R3 depends on R2 M1 (`references/templates/`) landing first.
+> **Prerequisite reading**: [ARCHITECTURE.md](../ARCHITECTURE.md), [docs/design/business-skill-improvements-overview.md](design/business-skill-improvements-overview.md), [docs/idea/business-skill-improvements.md](idea/business-skill-improvements.md), [docs/research/business-skill-improvements/synthesis.md](research/business-skill-improvements/synthesis.md), [Issue #19](https://github.com/kerberosmansour/SunLitOrchestrate/issues/19), [Issue #20](https://github.com/kerberosmansour/SunLitOrchestrate/issues/20), 2026-04-27 skill-pack review
+
+---
+
+## Runbook Metadata
+
+- **Runbook ID**: `business-skill-improvements`
+- **Prefix for test files and lessons files**: `biz-imp`
+- **Primary stack**: Markdown + Rust (`crates/sldo-install`) + `WebFetch`/`WebSearch` denied (per `tm-biz-abuse-1`)
+- **Primary package/app names**: `sldo-install`, advisor skills (`slo-legal`, `slo-accounting`, `slo-equity`, `slo-fundraise`, `slo-hire`), generator skills (`slo-metrics`, `slo-pricing`, `slo-sales-funnel`, `slo-product`, `slo-launch`, `slo-marketing`, `slo-talk-to-users`), `references/biz/`
+- **Default test commands**:
+  - Workspace tests: `cargo test --workspace`
+  - Specific install tests: `cargo test -p sldo-install`
+  - Build: `cargo build --workspace`
+- **Allowed new dependencies by default**: `none`
+- **Schema/config migration allowed by default**: `no`
+- **Public interfaces that must remain stable**:
+  - The four hard-block predicate IDs in `references/biz/triage-gate.md` (immutable).
+  - Existing `references/biz/artifact-schema.md` frontmatter contract (additive only — adding `intake_summary:`, `gates_evaluation:`, `baseline_ref:` is non-breaking).
+  - Existing `docs/biz/` / `docs/biz-public/` two-tier convention.
+  - Every existing advisor + generator SKILL.md install path.
+  - Existing `WebFetch`/`WebSearch` denial at the SLO-CLI invocation layer.
+
+---
+
+## Milestone Tracker
+
+| # | Milestone | Status | Started | Completed | Lessons File | Completion Summary |
+|---|---|---|---|---|---|---|
+| 1 | UK regulator enumeration source-verified + statute anchor files | `not_started` | | | | |
+| 2 | Five conversational intake contracts + advisor SKILL.md updates (rename `*-form.md` → `*-contract.md`) | `not_started` | | | | |
+| 3 | Numeric verification (SAFE / cap-table / pricing math) | `not_started` | | | | |
+| 4 | KPI baseline files + generator skill updates | `not_started` | | | | |
+| 5 | `baseline_ref:` artifact schema field + cross-skill citation tests + annual refresh `/loop` | `not_started` | | | | |
+
+---
+
+## End-to-End Architecture Diagram
+
+```
+┌────────────────────────────────────────────────────────────────────────┐
+│                  SunLitOrchestrate biz pack (UK only)                  │
+│                                                                        │
+│  ┌──────────────────────────────────────────────────────────────┐     │
+│  │  references/biz/  (existing + new)                            │     │
+│  │   triage-gate.md (immutable)                                  │     │
+│  │   artifact-schema.md (extended M5: + baseline_ref)            │     │
+│  │   jurisdiction-uk.md (existing)                               │     │
+│  │   uk-regulator-enumeration.md (M1 — closed enum, 29+ rows)    │     │
+│  │   uk-employment-statute-anchors.md (M1 — IANA / ERA / etc.)   │     │
+│  │   uk-consumer-statute-anchors.md (M1 — CRA / CCR / DMCC)      │     │
+│  │   uk-marketing-statute-anchors.md (M1 — ASA / CAP / PECR)     │     │
+│  │   hmrc-vcm-index.md (M1 — verbatim quote refresh)             │     │
+│  │   ico-duaa-index.md (M1 — refresh)                            │     │
+│  │   cost-baseline-jpp-law-2026.md (existing)                    │     │
+│  │   ir35-cest-factors.md (existing)                             │     │
+│  │   {legal,accounting,equity,fundraise,hire}-intake-            │     │
+│  │     contract.md (M2 — conversational intake)                  │     │
+│  │   saas-kpi-targets-baseline.md (M4 — refresh starter)         │     │
+│  │   outbound-conversion-baselines.md (M4)                       │     │
+│  │   product-prioritization-frameworks.md (M4)                   │     │
+│  │   value-equation-pricing.md (M4)                              │     │
+│  │   mom-test-canonical-questions.md (M4)                        │     │
+│  │   launch-success-thresholds.md (M4)                           │     │
+│  └──────────────────────────────────────────────────────────────┘     │
+│                              ▲           ▲                             │
+│           ┌──────────────────┼───────────┴──────────┐                  │
+│           │                  │                      │                   │
+│  ┌────────┴────────┐ ┌───────┴────────┐ ┌──────────┴───────┐          │
+│  │ Advisor cluster │ │ Generator      │ │ /slo-talk-to-users│          │
+│  │ (5 skills)      │ │ cluster         │ │ + /slo-launch    │          │
+│  │                 │ │ (7 skills)      │ │                  │          │
+│  │ - SKILL.md      │ │ - SKILL.md      │ │ - SKILL.md       │          │
+│  │   updated M2    │ │   updated M4    │ │   updated M4     │          │
+│  │ - intake        │ │ - cite KPI      │ │ - cite Mom Test  │          │
+│  │   contract      │ │   baselines     │ │   + launch       │          │
+│  │   conversational│ │   via baseline_ │ │   thresholds     │          │
+│  │   F1-F6         │ │   ref           │ │                  │          │
+│  └─────────────────┘ └─────────────────┘ └──────────────────┘          │
+│           │                                                              │
+│           │ at draft-time:                                               │
+│           ▼                                                              │
+│  ┌─────────────────────────────────────────┐                            │
+│  │ Numeric verification pass (M3)          │                            │
+│  │  /slo-fundraise SAFE math               │                            │
+│  │  /slo-equity cap-table totals           │                            │
+│  │  /slo-pricing value-equation            │                            │
+│  └─────────────────────────────────────────┘                            │
+│                                                                          │
+│  ┌──────────────────────────────────────────┐                           │
+│  │ M5 cross-skill citation structural       │                           │
+│  │ contract test:                           │                           │
+│  │  - every drafted artifact has            │                           │
+│  │    intake_summary + gates_evaluation     │                           │
+│  │  - every generated artifact citing       │                           │
+│  │    numbers has baseline_ref              │                           │
+│  │  - immutability of 4 predicates          │                           │
+│  └──────────────────────────────────────────┘                           │
+│                                                                          │
+│  Legend:  existing  /  NEW (this runbook)  /  ▶ data flow              │
+└────────────────────────────────────────────────────────────────────────┘
+```
+
+### Component Summary Table
+
+| Component | Responsibility | Milestone | Key Interfaces |
+|---|---|---|---|
+| `references/biz/uk-regulator-enumeration.md` | Closed enum of UK regulators (source-verified `statutory_basis:` per row) | M1 | `gate-1-regulated` evaluation in every advisor skill |
+| `references/biz/uk-employment-statute-anchors.md` | Verbatim quotes of IANA 2006, ERA 1996, Pensions Act 2008, Equality Act 2010, IR35 (ITEPA 2003 Ch 10) | M1 | `/slo-hire`, `/slo-legal` |
+| `references/biz/uk-consumer-statute-anchors.md` | CRA 2015, Consumer Contracts Regulations 2013, DMCC 2024 verbatim | M1 | `/slo-legal`, `/slo-marketing`, `/slo-pricing` |
+| `references/biz/uk-marketing-statute-anchors.md` | ASA + CAP Code (12th ed), PECR, DUAA 2025 verbatim | M1 | `/slo-marketing`, `/slo-launch`, `/slo-sales-funnel` |
+| `references/biz/hmrc-vcm-index.md` (refresh) | VCM34080 / VCM3000 / VCM31000 / Abingdon Health verbatim | M1 | `/slo-equity`, `/slo-fundraise` |
+| `references/biz/{legal,accounting,equity,fundraise,hire}-intake-contract.md` | Conversational intake contracts | M2 | All 5 advisor skills |
+| Five advisor SKILL.md updates | Mandate intake contract, restate-and-confirm, refusal-on-ambiguity, citation discipline | M2 | SKILL.md prose; behavior change is intake-only |
+| Numeric verification | SAFE math, cap-table totals, pricing value-equation re-derived | M3 | `/slo-fundraise`, `/slo-equity`, `/slo-pricing` |
+| `references/biz/saas-kpi-targets-baseline.md` (source-verified) | KPI bands with per-row `last_checked:` + source URL | M4 | `/slo-metrics` (primary) |
+| `references/biz/outbound-conversion-baselines.md` | Funnel-stage rates with sources | M4 | `/slo-sales-funnel`, `/slo-metrics` |
+| `references/biz/product-prioritization-frameworks.md` | RICE, Kano definitions sourced | M4 | `/slo-product` |
+| `references/biz/value-equation-pricing.md` | "25-33% of value" claim sourced | M4 | `/slo-pricing` |
+| `references/biz/mom-test-canonical-questions.md` | Fitzpatrick *Mom Test* 2013 question scaffolding | M4 | `/slo-talk-to-users`, `/slo-product`, `/slo-launch` |
+| `references/biz/launch-success-thresholds.md` | "set your own threshold" framing for unsourceable launch numbers | M4 | `/slo-launch` |
+| `references/biz/artifact-schema.md` (refresh) | Adds `baseline_ref:`, `intake_summary:`, `gates_evaluation:` fields | M5 | Read by `/slo-verify` Pass 4 schema check |
+| Cross-skill citation structural-contract tests | Every advisor SKILL.md references the regulator enum + intake contract; every generator SKILL.md references its baseline file | M5 | `cargo test --workspace` |
+| Annual refresh `/loop` agent | Re-fetches public sources, opens refresh PR | M5 (configured) | `/schedule` skill |
+
+### Data Flow Summary
+
+| Flow | From | To | Protocol/Mechanism | Milestone |
+|---|---|---|---|---|
+| Statute citation consultation | Advisor SKILL.md prose | `references/biz/uk-*-statute-anchors.md` | Markdown link, runtime-read | M1 |
+| Conversational intake → structured `intake_summary:` | Founder dialogue | Artifact frontmatter | LLM synthesis | M2 |
+| Gate evaluation against structured intake | Advisor skill | `references/biz/triage-gate.md` + `uk-regulator-enumeration.md` | LLM evaluation against closed-enum | M2 |
+| Numeric re-derivation | Advisor skill | Artifact body | Python snippet OR re-derive pass | M3 |
+| KPI baseline consultation | Generator SKILL.md | `references/biz/saas-kpi-targets-baseline.md` (etc.) | Markdown link, runtime-read | M4 |
+| Annual baseline refresh | `/schedule` agent | GitHub | Automated PR open with diffs | M5 |
+
+---
+
+## High-Level Design for Formal Verification (TLA+ Section)
+
+`tla_required: false`
+
+No concurrent actors, no distributed state. Conversational intake is sequential founder-skill turns; gate evaluation is deterministic over the structured `intake_summary:` block; numeric verification is single-pass. Per `/slo-tla`'s suitability gate, this is the wrong tool here.
+
+---
+
+## Global Execution Rules
+
+See [docs/runbook-template_v_3_template.md §"Global Execution Rules"](runbook-template_v_3_template.md). Project-specific overrides:
+
+- The four hard-block predicate IDs in `references/biz/triage-gate.md` are **immutable** by structural-contract test (`triage_gate_predicate_set_unchanged_from_m1`); this runbook does not touch them.
+- `WebFetch` / `WebSearch` denial at the SLO-CLI invocation layer is preserved across this runbook (per `tm-biz-abuse-1`). External regulatory anchors fetched at runbook-author time only and captured as `last_checked:` dates.
+- Every UK statute citation must be source-verified against `legislation.gov.uk` at retrieval-stamped dates. Every HMRC manual citation against `https://www.gov.uk/hmrc-internal-manuals/venture-capital-schemes-manual`. Unverifiable claims removed, not weakened (per R2 M1's `references/templates/citation-discipline.md`).
+
+## Global Entry / Exit Rules
+
+See template. Specifics:
+
+- Baseline: `cargo test --workspace`. Confirm green.
+- R3 M2 depends on R2 M1's `references/templates/intake-checklist.md` landing. If R2 M1 unfinished, M2 inline-authors the conversational discipline pattern (acceptable but creates rework when R2 M1 lands; flag in lessons).
+- R3 M4 depends on R2 M1's `references/templates/heuristic-numbers-discipline.md` landing.
+
+---
+
+## Background Context
+
+### Current State
+
+The biz pack has 4 advisor skills + 11 generator skills built in Runbooks A / B1 / B2 / C, with the `references/biz/` reference subtree (triage-gate, artifact-schema, jurisdiction-uk, hmrc-vcm-index, ico-duaa-index, ir35-cest-factors, cost-baseline-jpp-law-2026). The four hard-block predicates and the two-tier output convention (`docs/biz/` confidential, `docs/biz-public/` placeholder + Pass 4 PII scan) are stable.
+
+The 2026-04-27 skill-pack review identified two structural risks:
+
+1. **Predicate evaluation by LLM is the largest hallucination surface in the pack**: the four advisor skills (+ `/slo-hire`) rely on the LLM evaluating natural-language predicates from founder prose. `gate-2-deal-value-over-5k` evaluation against "the contract is around eight grand" (monthly? annual? VAT? what term?) is a known failure mode.
+2. **The seven biz generators recite numeric heuristics from training memory without source attribution**: CAC payback, MoM growth, burn multiples, conversion rates, fee figures, success thresholds. Founders quote these numbers to investors; sourceless KPI claims are a credibility risk.
+
+The project owner explicitly flagged a third constraint: **conversational discipline** — *"this is a chatbot. So it isn't gonna process, like, hiring people. But giving someone advice."* The structured `intake_summary:` block is the **output of the conversation**, not a UI for the founder to fill.
+
+### Problem
+
+1. **LLM-evaluated predicates with no structured intake**: All four advisor skills (`/slo-legal`, `/slo-accounting`, `/slo-equity`, `/slo-fundraise`) plus `/slo-hire` evaluate the four hard-block gates against natural-language founder prose. `references/biz/triage-gate.md:16` explicitly acknowledges this.
+2. **Statute citations paraphrased inline**: SKILL.md prose recites CRA 2015 / ERA 1996 s86 / IANA 2006 s15 / Pensions Act 2008 / ITA07 s257HJ(1) / Consumer Contracts Regulations 2013 / ASA / CAP Code / PECR / DUAA 2025 ceiling figures / HMRC manual paragraphs (VCM34080, VCM3000, VCM31000) — all from training memory, all rendered prose-shaped rather than verbatim quotes.
+3. **HMRC manual content paraphrased**: `references/biz/hmrc-vcm-index.md` paraphrases the Abingdon Health Limited v HMRC line and the VCM paragraphs.
+4. **Open-ended regulator enumeration**: `gate-1-regulated` evaluation enumerates UK regulators from training memory ("FCA, MHRA, ICO, healthcare, financial services, or any other regulator with statutory enforcement powers"). Closed-enum file would replace.
+5. **Numeric arithmetic is LLM-computed**: `/slo-fundraise`'s SAFE worksheet, `/slo-equity`'s cap-table snapshot, `/slo-pricing`'s value-equation calculator — all rely on LLM-computed cells. A 5-percentage-point dilution-table error that goes to investors is the failure mode.
+6. **Recited numeric heuristics across 7 generator skills**: ~40+ unsourced numbers across `/slo-metrics`, `/slo-pricing`, `/slo-sales-funnel`, `/slo-product`, `/slo-launch`, `/slo-marketing`, `/slo-talk-to-users`.
+7. **Form-shaped intake framing**: the original `legal-intake-form.md` starter file read as a form for the founder to fill; the chatbot's strength is conversation. Contract → `*-intake-contract.md` rename + conversational-discipline framing throughout.
+
+### Target Architecture
+
+See "End-to-End Architecture Diagram" above.
+
+### Key Design Principles
+
+0. **Over-engineering for simplicity**: per [`docs/PARADIGM-OVER-ENGINEERING-FOR-SIMPLICITY.md`](PARADIGM-OVER-ENGINEERING-FOR-SIMPLICITY.md), the LLM-driven advisor / generator pipeline can sustainably carry MORE discipline than a human-driven equivalent. R3 embodies the paradigm: 6-field conversational intake with explicit-comprehension follow-ups (per critique S-1), verbatim statute citations from `legislation.gov.uk`, closed-enum 29-row regulator list, numeric verification with re-derivation, KPI baselines with per-row source attribution + annual `/loop` refresh, structural-contract tests across cross-skill citations + immutability of 4 predicates. A human paralegal team would not sustain this much rigor across 5 advisor + 7 generator skills; the LLM pipeline does. The user (founder) experiences a 5-minute conversation that produces a lawyer-review-ready draft with full provenance.
+
+1. **Conversational intake is the UX**: skill drives one-question-at-a-time elicitation; structured `intake_summary:` is the output. Pattern source: [`/slo-ideate`'s seven forcing questions](../skills/slo-ideate/SKILL.md). Refusal-on-ambiguity is the third state of gate evaluation.
+2. **Closed-enum regulator list**: `gate-1-regulated` evaluation consults `references/biz/uk-regulator-enumeration.md`; naming a regulator NOT in the file is a refusal pattern (probe further or flag the enum gap).
+3. **Verbatim statute quotes from `legislation.gov.uk`**: every cited statute carries a verbatim quote + URL + retrieval date. SKILL.md prose cites file:section, never paraphrases the text.
+4. **HMRC manual content quoted, not paraphrased**: same pattern with `https://www.gov.uk/hmrc-internal-manuals/venture-capital-schemes-manual` as the primary source.
+5. **Numeric arithmetic re-derived before write**: emit math as runnable Python snippet OR explicit verification pass that re-derives every cell. Mismatch → refuse to draft.
+6. **Heuristic numbers carry `baseline_ref:` provenance**: every artifact emitted by a generator skill that consults a baseline file MUST carry the `baseline_ref:` frontmatter pointer with retrieval-date stamp.
+7. **Annual refresh cadence**: each authority file has `retrieved:` + `refresh_recommended_by: <retrieved + 12 months>`; SKILL.md emits a stale warning at +12 months and refuses at +24 months.
+8. **The four hard-block predicate IDs are immutable**: locked by structural-contract test.
+9. **Sister intake contracts share F1 / F4 / F5 fields verbatim**: cross-skill drift on jurisdiction / GDPR / regulator scope evaluation would defeat consistency.
+
+### What to Keep
+
+- All four hard-block predicate IDs in `references/biz/triage-gate.md`.
+- Existing `references/biz/artifact-schema.md` frontmatter contract (additive only).
+- Existing `docs/biz/` / `docs/biz-public/` two-tier convention.
+- Every existing advisor + generator SKILL.md install path.
+- Existing `WebFetch` / `WebSearch` denials.
+- `/slo-verify` Pass 4 PII pattern scan + override mechanism.
+- Cost baseline file `references/biz/cost-baseline-jpp-law-2026.md` (already source-verified at `retrieved: 2026-04-25`).
+
+### What to Change
+
+- `references/biz/uk-regulator-enumeration.md` (already a starter; M1 source-verifies `statutory_basis` of every row).
+- `references/biz/uk-employment-statute-anchors.md` (NEW M1).
+- `references/biz/uk-consumer-statute-anchors.md` (NEW M1).
+- `references/biz/uk-marketing-statute-anchors.md` (NEW M1).
+- `references/biz/hmrc-vcm-index.md` (refresh M1: verbatim quotes).
+- `references/biz/ico-duaa-index.md` (refresh M1: source-verify DUAA 2025 commencement details).
+- `references/biz/legal-intake-form.md` → rename `legal-intake-contract.md` + conversational reframing (M2; partially done in starter file).
+- `references/biz/{accounting,equity,fundraise,hire}-intake-contract.md` (NEW M2).
+- 5 advisor SKILL.md updates (M2).
+- 3 advisor + 1 generator SKILL.md updates for numeric verification (M3).
+- `references/biz/saas-kpi-targets-baseline.md` (refresh M4: source-verify each row).
+- `references/biz/outbound-conversion-baselines.md` (NEW M4).
+- `references/biz/product-prioritization-frameworks.md` (NEW M4).
+- `references/biz/value-equation-pricing.md` (NEW M4).
+- `references/biz/mom-test-canonical-questions.md` (NEW M4).
+- `references/biz/launch-success-thresholds.md` (NEW M4).
+- 7 generator SKILL.md updates (M4).
+- `references/biz/artifact-schema.md` extended with `baseline_ref:`, `intake_summary:`, `gates_evaluation:` fields (M5).
+
+### Global Red Lines
+
+Standard set; in addition:
+
+- **The four hard-block predicate IDs are immutable**.
+- **Source-verification discipline applies to every milestone touching statute / regulator / KPI claims**. Unverifiable claims removed.
+- **No `WebFetch` / `WebSearch` enabled in any biz skill**.
+- **No conversational intake reframed as a form**. The `legal-intake-form.md` filename rename to `legal-intake-contract.md` is part of M2; downstream sister contracts use `*-intake-contract.md` from creation.
+- **No US / EU jurisdiction extension** (v2 architectural pivot).
+- No `--no-verify`, no force-pushes.
+
+---
+
+## BDD and Runtime Validation Rules
+
+See template. Project specifics:
+
+### Required Test Coverage Categories
+
+For each milestone:
+
+- happy path
+- empty state (e.g., founder declines to provide a field; refusal-on-ambiguity fires)
+- ambiguous input (e.g., founder rounds the deal value)
+- adversarial input (e.g., founder games the intake to bypass a gate)
+- backward compatibility (existing artifacts pre-this-runbook still parse)
+- abuse case (per-milestone, see threat-model rows in design overview)
+- outdated information (e.g., stale citation > 12 months old)
+
+### Test File Naming
+
+| Layer | Convention | Location |
+|---|---|---|
+| Reference-file structural tests | `tests/e2e_biz_imp_m<N>.rs` | `crates/sldo-install/tests/` |
+| Cross-skill citation tests | same | same |
+| Closed-enum immutability tests | inline in M5's test file | same |
+
+---
+
+## Dependency, Migration, and Refactor Policy
+
+See template. **No new runtime dependencies in this runbook.** No schema migrations.
+
+Refactor budget per-milestone in milestone sections.
+
+---
+
+## Evidence Log Template
+
+See template.
+
+## Self-Review Gate
+
+See template.
+
+## Lessons + Completion Templates
+
+See template (`docs/lessons/biz-imp-m<N>.md`, `docs/completion/biz-imp-m<N>.md`).
+
+---
+
+## Milestone Plan
+
+### Milestone 1 — UK regulator enumeration source-verified + statute anchor files
+
+**Goal**: Source-verify every row of [`references/biz/uk-regulator-enumeration.md`](references/biz/uk-regulator-enumeration.md) against `legislation.gov.uk`; create three new statute-anchor authority files (employment, consumer, marketing); refresh `hmrc-vcm-index.md` with verbatim quotes of VCM34080, VCM3000, VCM31000, Abingdon Health line; refresh `ico-duaa-index.md` with verbatim DUAA 2025 commencement quote.
+
+**Context**: Starter [`references/biz/uk-regulator-enumeration.md`](references/biz/uk-regulator-enumeration.md) already lists 29+ regulators with `statutory_basis:` field — but the bases are starter-quality (one-line). M1 source-verifies each row against `legislation.gov.uk` and captures the verbatim Act title + section anchor. Three new statute-anchor files cover employment, consumer, marketing law that the advisor SKILL.md prose currently paraphrases.
+
+**Important design rule**: **Verbatim quotes only**. SKILL.md updates in M2 cite file:section, never paraphrase the statute text.
+
+**Refactor budget**: `Targeted refactor permitted for replacing inlined statute paraphrases with citations`.
+
+#### Contract Block
+
+| Field | Value |
+|---|---|
+| Inputs | Existing `references/biz/uk-regulator-enumeration.md` (starter); existing `hmrc-vcm-index.md`; existing `ico-duaa-index.md`; `legislation.gov.uk` URLs at runbook-author time; `https://www.gov.uk/hmrc-internal-manuals/venture-capital-schemes-manual` |
+| Outputs | Source-verified `uk-regulator-enumeration.md`; 3 new statute-anchor files; refreshed `hmrc-vcm-index.md`; refreshed `ico-duaa-index.md`; structural-contract test asserting verbatim-quote fields populated |
+| Interfaces touched | `references/biz/` reference subtree |
+| Files allowed to change | `references/biz/uk-regulator-enumeration.md`, `references/biz/uk-employment-statute-anchors.md` (NEW), `references/biz/uk-consumer-statute-anchors.md` (NEW), `references/biz/uk-marketing-statute-anchors.md` (NEW), `references/biz/hmrc-vcm-index.md` (refresh), `references/biz/ico-duaa-index.md` (refresh), `crates/sldo-install/tests/e2e_biz_imp_m1.rs` (NEW) |
+| Files to read before changing anything | All existing `references/biz/` files; R2 M1's `references/templates/citation-discipline.md` (source hierarchy) |
+| New files allowed | 3 new statute-anchor files + the test file |
+| New dependencies allowed | `none` |
+| Migration allowed | `no` |
+| Compatibility commitments | Existing `references/biz/` file shapes preserved (additive refresh only); the four hard-block predicate IDs untouched |
+| Forbidden shortcuts | paraphrasing statute text; "approximately says" framing; using vendor-blog citations as primary; using Stack Overflow as authoritative; missing per-row `last_checked:` date |
+| **Data classification** | `Public` |
+| **Proactive controls in play** | OWASP C1 (security requirements anchored in statute); C5 (validate inputs — closed-enum regulator list is input validation); C9 (audit trail via `last_checked:` per-row dates) |
+| **Abuse acceptance scenarios** | `tm-biz-skill-improvements-abuse-2: stale statute citation propagates to founder artifact` — mitigated by `last_checked:` + skill stale-citation warning at +12 months, refuse at +24 months |
+
+#### Out of Scope / Must Not Do
+
+- Modifying advisor SKILL.md prose (M2 job).
+- Touching the four hard-block predicate IDs.
+- Adding new regulators to the enumeration without a `/slo-architect` re-pass.
+- Citing US / EU statute (v2 scope).
+
+#### Pre-Flight
+
+1. Complete Global Entry Rules.
+2. Read R2 M1's `references/templates/citation-discipline.md` for source hierarchy.
+3. Visit `legislation.gov.uk` at runbook-author time. Capture the precise URL pattern for section-level anchors (e.g., `https://www.legislation.gov.uk/ukpga/1996/18/section/86`).
+4. Visit `https://www.gov.uk/hmrc-internal-manuals/venture-capital-schemes-manual` and locate VCM34080, VCM3000, VCM31000 paragraphs. Capture verbatim text.
+5. Visit `https://www.legislation.gov.uk/ukpga/2025/18` for DUAA 2025; capture commencement details.
+6. Plan the order: regulator enum first (since it's the closed enum gate-1 consults), then statute anchors, then HMRC + ICO refresh.
+
+#### Files Allowed To Change
+
+| File | Planned Change |
+|---|---|
+| `references/biz/uk-regulator-enumeration.md` | Source-verify each `statutory_basis:` row against `legislation.gov.uk`; add per-row `statute_url:` field with anchor; **per paradigm — comprehensive temporal audit fields**: `commenced_date:` (when the cited Act took effect), `last_amended:` (most recent amendment retrieved), `last_reviewed:` (when SLO last verified), `next_review_due:` (last_reviewed + 12 months), `confidence:` (high / medium / low based on whether `legislation.gov.uk` was directly verified vs cross-cited from another authority); bump `last_reviewed:` to runbook-author date |
+| `references/biz/uk-employment-statute-anchors.md` | NEW: verbatim quotes of IANA 2006 s15 (right-to-work), ERA 1996 s86 (notice periods), Pensions Act 2008 (auto-enrolment thresholds), Equality Act 2010 (protected characteristics), ITEPA 2003 Ch 10 (IR35) |
+| `references/biz/uk-consumer-statute-anchors.md` | NEW: CRA 2015 (consumer rights), Consumer Contracts Regulations 2013 (14-day cooling-off), DMCC 2024 verbatim |
+| `references/biz/uk-marketing-statute-anchors.md` | NEW: ASA + CAP Code (12th ed) section anchors, PECR (Privacy and Electronic Communications Regulations 2003) verbatim, DUAA 2025 PECR ceiling text |
+| `references/biz/hmrc-vcm-index.md` | Refresh: replace paraphrases of VCM34080 / VCM3000 / VCM31000 with verbatim quotes; capture `last_checked:` per paragraph |
+| `references/biz/ico-duaa-index.md` | Refresh: replace DUAA 2025 commencement paraphrase with verbatim text from `legislation.gov.uk/ukpga/2025/18` + ICO summary page |
+| `crates/sldo-install/tests/e2e_biz_imp_m1.rs` | NEW: structural-contract test asserting (a) `uk-regulator-enumeration.md` rows have `statute_url:` and `last_reviewed:` fields, (b) the 3 new statute-anchor files exist with verbatim-quote sections, (c) HMRC + ICO refresh verbatim quotes present, (d) source URLs are `legislation.gov.uk` or `gov.uk` (no Stack Overflow / vendor blogs) |
+
+#### Step-by-Step
+
+1. Test stub first.
+2. Source-verify regulator enum row by row against `legislation.gov.uk`. Capture URL + text per row.
+3. Author the 3 new statute-anchor files.
+4. Refresh `hmrc-vcm-index.md` with verbatim quotes.
+5. Refresh `ico-duaa-index.md` similarly.
+6. Verify structural-contract test passes.
+7. Smoke tests.
+8. Self-review.
+
+#### BDD Acceptance Scenarios
+
+**Feature: UK statute + regulator authority files source-verified**
+
+| Scenario | Category | Given | When | Then |
+|---|---|---|---|---|
+| Every regulator row has source-verified `statutory_basis` | happy path | M1 closes | parse uk-regulator-enumeration.md | every row has `statute_url:` resolvable to `legislation.gov.uk` |
+| 3 new statute-anchor files exist with verbatim quotes | happy path | M1 closes | inspect each | files present + each cited section has a verbatim quote, not paraphrase |
+| HMRC manual paragraphs quoted verbatim | happy path | M1 closes | inspect hmrc-vcm-index.md | VCM34080 + VCM3000 + VCM31000 + Abingdon Health line each have `quoted_text:` blocks |
+| ICO DUAA 2025 commencement text verbatim | happy path | M1 closes | inspect ico-duaa-index.md | DUAA 2025 commencement quote present from `legislation.gov.uk/ukpga/2025/18` |
+| Statute citation paraphrased instead of quoted | abuse case (`tm-biz-imp-abuse-1: paraphrase smuggled into authority file`) | someone tries to land a "approximately says" line | structural-contract test | test FAILS with "verbatim quote required" |
+| Source from blog rather than `legislation.gov.uk` | abuse case (citation-hierarchy violation) | a row cites a vendor blog as `statute_url:` | structural-contract test | test FAILS with "source must be legislation.gov.uk or gov.uk" |
+| Stale row | outdated information | a row has `last_checked:` > 12 months ago | runtime use | skill stale-citation warning fires (M2 implementation) |
+| Ambiguous regulator naming | ambiguous input | founder names "ICO/Information Commissioner's Office" | M1 reading | both names resolve to same `id: ico` |
+| Backward compat: existing biz pack tests | backward compatibility | M1 closes | `cargo test --workspace` | all existing biz-pack structural-contract tests pass |
+| Four predicates immutable | abuse case (predicate set tampering) | someone tries to remove a predicate ID | `triage_gate_predicate_set_unchanged_from_m1` test | test FAILS |
+
+#### Regression Tests
+
+- `cargo test --workspace`.
+- `triage_gate_predicate_set_unchanged_from_m1` test passes.
+- All existing biz-pack structural-contract tests.
+- Existing advisor SKILL.md install symlinks.
+
+#### Compatibility Checklist
+
+- [ ] Four predicate IDs unchanged.
+- [ ] `references/biz/cost-baseline-jpp-law-2026.md` unchanged (its refresh is annual; out-of-scope here).
+- [ ] `references/biz/ir35-cest-factors.md` unchanged.
+- [ ] `references/biz/jurisdiction-uk.md` cross-references the new closed enum but otherwise unchanged.
+
+#### E2E Runtime Validation
+
+**File**: `crates/sldo-install/tests/e2e_biz_imp_m1.rs`
+
+| E2E Test | What It Proves | Pass Criteria |
+|---|---|---|
+| `regulator_enum_source_verified` | Every row has source-verified `statutory_basis` + `statute_url:` | parse + URL pattern match against `legislation.gov.uk` or `gov.uk` |
+| `statute_anchor_files_have_verbatim_quotes` | The 3 new files have `quoted_text:` blocks per cited section | grep + frontmatter-shape parse |
+| `hmrc_vcm_index_verbatim` | VCM paragraphs quoted | grep for "VCM34080", "VCM3000", "VCM31000", "Abingdon Health" + `quoted_text:` block per |
+| `ico_duaa_verbatim` | DUAA 2025 commencement quote present | grep + URL match |
+| `no_unauthoritative_sources` | No vendor blogs, no Stack Overflow | grep refuses any URL not in (`legislation.gov.uk`, `gov.uk`, `ico.org.uk`, `www.netpromotersystem.com` (Bain — only for NPS context, not statute), `bvp.com` (Bessemer — only for KPI context, not statute)) — restricted to authoritative sources for statute |
+| `triage_gate_predicate_set_unchanged_from_m1` | Predicate IDs immutable | exact-match assertion |
+
+#### Smoke Tests
+
+- [ ] Open `uk-regulator-enumeration.md`; click a `statute_url:` link — resolves to `legislation.gov.uk`.
+- [ ] Open `hmrc-vcm-index.md`; verify VCM34080 verbatim quote renders.
+- [ ] Open `uk-employment-statute-anchors.md`; verify ERA 1996 s86 quote.
+- [ ] `cargo test -p sldo-install` passes.
+
+#### Evidence Log
+
+(Copy at execution time.)
+
+#### Definition of Done
+
+- All BDD scenarios pass.
+- Every regulator row source-verified.
+- 3 new statute-anchor files authored with verbatim quotes.
+- HMRC + ICO refreshes complete.
+- Tracker + lessons + completion files written.
+
+#### Post-Flight
+
+- ARCHITECTURE.md update: extend "References subtrees" with the new statute anchors.
+- README.md: not required.
+
+#### Notes
+
+- Source-verification is high-bandwidth manual work. Time-box per row to ~5 minutes; if a row's `statutory_basis` cannot be verified within budget, mark the row `last_checked: pending-verification` and flag for next sprint — do not weaken the verification rule.
+
+---
+
+### Milestone 2 — Five conversational intake contracts + advisor SKILL.md updates
+
+**Goal**: Five `*-intake-contract.md` files (legal, accounting, equity, fundraise, hire) authored with the conversational-elicitation discipline. Five advisor SKILL.md files updated to mandate the contract, restate-and-confirm step, refusal-on-ambiguity, and citation discipline. Existing `references/biz/legal-intake-form.md` renamed to `legal-intake-contract.md`.
+
+**Context**: The starter [`references/biz/legal-intake-form.md`](references/biz/legal-intake-form.md) is partially conversational-reframed (per the project owner's feedback). M2 finishes the rename, drafts the four sister contracts, and updates the SKILL.md files to consume them.
+
+**Important design rule**: **Conversation is the UX, not a form**. Every intake contract repeats verbatim from `references/templates/intake-checklist.md` (R2 M1) the conversational discipline section. Drift between sister contracts on F1/F4/F5 fields is a structural-contract violation.
+
+**Refactor budget**: `Targeted refactor permitted for advisor SKILL.md prose updates that consume the intake contracts and citation files`.
+
+#### Contract Block
+
+| Field | Value |
+|---|---|
+| Inputs | M1's source-verified regulator enum + statute anchors; R2 M1's `references/templates/intake-checklist.md` + `restate-and-confirm.md` + `escalation.md` + `citation-discipline.md`; existing `references/biz/legal-intake-form.md` (starter); existing 5 advisor SKILL.md files |
+| Outputs | 5 intake-contract files (one rename, 4 NEW); 5 SKILL.md updates; structural-contract test asserting (a) F1/F4/F5 fields verbatim across sisters; (b) every advisor SKILL.md cites its intake contract; (c) "Conversation is the UX" disclaimer present in each contract; (d) `legal-intake-form.md` rename complete |
+| Interfaces touched | `references/biz/<skill>-intake-contract.md` files; 5 advisor SKILL.md files |
+| Files allowed to change | `references/biz/legal-intake-form.md` → rename to `legal-intake-contract.md`, `references/biz/{accounting,equity,fundraise,hire}-intake-contract.md` (NEW), 5 advisor SKILL.md files, `crates/sldo-install/tests/e2e_biz_imp_m2.rs` (NEW) |
+| Files to read before changing anything | M1 outputs; R2 M1's `references/templates/` library; existing advisor SKILL.md files; existing `legal-intake-form.md` starter; the 2026-04-27 review's "Concern 1" (form vs conversational) discussion thread |
+| New files allowed | 4 sister contract files + the test file (rename of existing file is not a new file) |
+| New dependencies allowed | `none` |
+| Migration allowed | `no` |
+| Compatibility commitments | Existing biz-pack tests pass; the four hard-block predicate IDs untouched; existing artifact frontmatter shape extended (`intake_summary:` and `gates_evaluation:` are NEW additive fields) |
+| Forbidden shortcuts | "submit a form" framing in any contract file; missing F1/F4/F5 verbatim across sisters; SKILL.md prose that consumes the contract without the conversational-discipline reminder; advisor skill that drafts without the restate-and-confirm step; ambiguity that falls through to draft instead of refusing |
+| **Data classification** | `Confidential` for intake conversation content (real founder PII may surface during elicitation); `Public` for the contract-discipline files themselves |
+| **Proactive controls in play** | OWASP C1 (security requirements: structured intake closes the predicate-evaluation surface); C5 (validate inputs — F1-F6 schema is input validation); C7 (access controls — `intake_summary:` lands in `tier: confidential` artifacts); C9 (audit trail via `intake_summary:` + `gates_evaluation:` + `restated_at:` timestamp) |
+| **Abuse acceptance scenarios** | `tm-biz-skill-improvements-abuse-1: founder games the conversational intake to bypass a gate` — mitigated by F3's structured `deal_value_basis:` enum + `unknown` confidence is refusal; `tm-biz-imp-abuse-3: SKILL.md drift causes one advisor to skip restate-and-confirm` — class eliminated by structural-contract test asserting every advisor SKILL.md cites `references/templates/restate-and-confirm.md` |
+
+#### Out of Scope / Must Not Do
+
+- Numeric verification (M3 job).
+- KPI baseline file work (M4 job).
+- Touching the four hard-block predicate IDs.
+- New advisor doc-types or new skills.
+- Modifying generator skills (M4 covers them).
+
+#### Pre-Flight
+
+1. Complete Global Entry Rules.
+2. Read M1 lessons.
+3. Read R2 M1's `references/templates/intake-checklist.md` + `restate-and-confirm.md` + `escalation.md` + `citation-discipline.md`. If R2 M1 is not yet shipped, inline-author the conversational-discipline pattern into each intake contract (and flag the duplication for cleanup once R2 M1 lands).
+4. Read existing 5 advisor SKILL.md files end-to-end.
+5. Read existing `references/biz/legal-intake-form.md` starter (already partially conversational-reframed).
+6. **Per critique B-7**: enumerate every cross-reference to `references/biz/legal-intake-form.md` in the repo (grep `legal-intake-form.md`); update each to the new path `legal-intake-contract.md` as part of M2. **Note known minor breakage**: existing GitHub issue comment URLs (e.g., issue #19's existing comments) point to the old filename — those won't auto-update; document as accepted breakage in the M2 lessons file and add a follow-up comment to issue #19 noting the rename.
+
+#### Files Allowed To Change
+
+| File | Planned Change |
+|---|---|
+| `references/biz/legal-intake-form.md` → `legal-intake-contract.md` | RENAME; update internal cross-references; verify "Conversation is the UX" framing throughout (already partially done in starter) |
+| `references/biz/accounting-intake-contract.md` | NEW: F1/F4/F5 verbatim from legal-intake-contract; F2/F3/F6 domain-specific (HMRC matter type, period, qualifying-activity claim type, FTE counts, founder-personal vs company-side) |
+| `references/biz/equity-intake-contract.md` | NEW: F1/F4/F5 verbatim; F2/F3/F6 (current cap table as structured rows, share-class breakdown, SEIS/EIS status, AA application date) |
+| `references/biz/fundraise-intake-contract.md` | NEW: F1/F4/F5 verbatim; F2/F3/F6 (round size GBP, planned signature date, AA application date, investor counsel y/n, lead investor identity, qualifying-trade VCM3000 audit date) |
+| `references/biz/hire-intake-contract.md` | NEW: F1/F4/F5 verbatim; F2/F3/F6 (role, full/part-time, expected duration, exclusivity, equipment/premises, substitution, CEST output capture) |
+| `skills/slo-legal/SKILL.md` | Update to mandate intake contract; replace inlined statute prose with citations to M1 statute anchor files; cite `references/templates/restate-and-confirm.md` |
+| `skills/slo-accounting/SKILL.md` | Same shape |
+| `skills/slo-equity/SKILL.md` | Same shape |
+| `skills/slo-fundraise/SKILL.md` | Same shape |
+| `skills/slo-hire/SKILL.md` | Same shape; CEST output capture mandated (artifact must include CEST output text or "CEST not run" notice with explicit risk acknowledgment) |
+| `crates/sldo-install/tests/e2e_biz_imp_m2.rs` | NEW: structural-contract test asserting (a) F1/F4/F5 verbatim across 5 contracts, (b) "Conversation is the UX" disclaimer in each, (c) every advisor SKILL.md cites its contract + restate-and-confirm template, (d) `legal-intake-form.md` does not exist (rename done) |
+
+#### Step-by-Step
+
+1. Test stub first.
+2. Rename `legal-intake-form.md` → `legal-intake-contract.md`; update cross-references in any consuming file.
+3. Author the 4 sister contracts. F1/F4/F5 verbatim from legal; F2/F3/F6 per-skill domain.
+4. Update the 5 advisor SKILL.md files to consume contracts + cite M1 statute anchors + restate-and-confirm.
+5. Verify structural-contract test passes (especially F1/F4/F5 verbatim assertion).
+6. Smoke tests: invoke each advisor skill against a fixture; observe conversational elicitation.
+7. Self-review.
+
+#### BDD Acceptance Scenarios
+
+**Feature: conversational intake contracts mandated; advisor SKILL.md updated**
+
+| Scenario | Category | Given | When | Then |
+|---|---|---|---|---|
+| All 5 contracts exist with conversational discipline | happy path | M2 closes | inspect each | each file has "Conversation is the UX" framing + F1-F6 + restate-and-confirm step |
+| F1/F4/F5 verbatim across sisters | happy path | M2 closes | byte-compare F1/F4/F5 sections | match for all five contracts |
+| Each advisor SKILL.md cites its contract | happy path | M2 closes | grep each | each cites `references/biz/<skill>-intake-contract.md` |
+| Each advisor SKILL.md cites restate-and-confirm | happy path | M2 closes | grep each | each cites `references/templates/restate-and-confirm.md` (or inline-authored version if R2 M1 unfinished) |
+| Advisor draft refuses on ambiguity | happy path | founder gives "around eight grand" deal value | skill evaluates F3 | skill asks for `deal_value_basis:` clarification; refuses to draft until concrete |
+| Advisor draft proceeds on confirmed gates-pass intake | happy path | founder confirms F1-F6 + restate | skill evaluates 4 gates against `intake_summary:` | drafts artifact with `intake_summary:` and `gates_evaluation:` frontmatter |
+| Founder games intake to bypass gate-2 | abuse case (`tm-biz-imp-abuse-1`) | founder quotes monthly when total triggers gate-2 | skill computes total from `deal_value_basis: monthly-recurring × deal_value_term_months` | gate-2 fires; route to triage |
+| Founder names regulator NOT in enum | abuse case (regulator-enum bypass) | F5 names "Acme Regulator" | skill checks against `uk-regulator-enumeration.md` | refuses; flags content gap or asks founder to pick from enum |
+| GDPR document request | abuse case (gate-4 unconditional) | F4 indicates GDPR document | skill enters `triage` mode | unconditional refusal of `draft`; routes to DPO |
+| Form-style framing slipped into a contract | abuse case (`tm-biz-imp-abuse-4: contract reframes as form`) | someone edits a contract to say "founder fills in" | structural-contract test | test FAILS with "Conversation is the UX framing required" |
+| Backward compat: existing biz artifact pre-M2 | backward compatibility | existing artifact without `intake_summary:` field | `cargo test --workspace` | passes; `intake_summary:` is additive optional |
+| `legal-intake-form.md` doesn't exist | structural | M2 closes | `ls references/biz/legal-intake-form.md` | does not exist (rename complete) |
+| Sister F1 fields drift | abuse case (`tm-biz-imp-abuse-5: drift in shared fields`) | accounting-intake-contract.md F1 changes wording | structural-contract test | test FAILS with "F1 must match legal-intake-contract.md verbatim" |
+
+#### Regression Tests
+
+- `cargo test --workspace`.
+- `triage_gate_predicate_set_unchanged_from_m1` test.
+- All existing biz-pack structural-contract tests.
+- Existing advisor SKILL.md install symlinks.
+
+#### Compatibility Checklist
+
+- [ ] Existing `triage-gate.md` predicate IDs unchanged.
+- [ ] Existing `artifact-schema.md` shape preserved (`intake_summary:` is additive optional).
+- [ ] All existing advisor SKILL.md files install.
+- [ ] No existing biz-pack test fails.
+
+#### E2E Runtime Validation
+
+**File**: `crates/sldo-install/tests/e2e_biz_imp_m2.rs`
+
+| E2E Test | What It Proves | Pass Criteria |
+|---|---|---|
+| `five_intake_contracts_exist_with_conversational_framing` | Conversational UX framing present | each file has "Conversation is the UX" disclaimer + F1-F6 + restate step |
+| `f1_f4_f5_verbatim_across_sisters` | Cross-sister consistency | byte-compare F1/F4/F5 sections from legal-intake-contract against each sister; assert match |
+| `every_advisor_skill_md_cites_contract` | SKILL.md updates landed | grep all 5 advisor SKILL.md for `references/biz/<skill>-intake-contract.md` |
+| `every_advisor_skill_md_cites_restate` | Restate-and-confirm cited | grep all 5 advisor SKILL.md for `references/templates/restate-and-confirm.md` (or inline equivalent) |
+| `legal_intake_form_renamed` | Rename complete | `references/biz/legal-intake-form.md` does not exist; `legal-intake-contract.md` does |
+| `intake_summary_field_in_artifact_schema` | Schema extension landed (M5 task; M2 confirms forward-compat) | M2 doesn't add the field; M5 does — but M2 verifies that adding it later won't break existing artifacts |
+
+#### Smoke Tests
+
+- [ ] Open one sister contract (e.g., `equity-intake-contract.md`); confirm F1/F4/F5 byte-identical to legal.
+- [ ] Mock-invoke `/slo-legal draft contractor-sow`; observe conversational elicitation; provide ambiguous F3; observe refusal-on-ambiguity.
+- [ ] Mock-invoke `/slo-fundraise draft safe-worksheet`; observe AA pre-check + conversational intake.
+- [ ] `cargo test -p sldo-install` passes.
+
+#### Evidence Log
+
+(Copy at execution time.)
+
+#### Definition of Done
+
+- All BDD scenarios pass.
+- Five intake contracts exist with conversational framing.
+- F1/F4/F5 verbatim across sisters.
+- Five advisor SKILL.md files updated.
+- Tracker + lessons + completion files written.
+
+#### Post-Flight
+
+- ARCHITECTURE.md update: extend "References subtrees" with the 5 intake contracts.
+- README.md: not required.
+
+#### Notes
+
+- M2 explicitly does NOT add `intake_summary:` / `gates_evaluation:` to `artifact-schema.md` — that's M5's schema-extension job. M2 ensures the SKILL.md prose consumes the contracts; M5 wires the schema.
+
+---
+
+### Milestone 3 — Numeric verification (SAFE / cap-table / pricing math)
+
+**Goal**: `/slo-fundraise`'s `safe-worksheet`, `/slo-equity`'s `cap-table-snapshot`, `/slo-pricing`'s value-equation calculator emit math as runnable Python snippets OR explicit re-derivation pass before write. Mismatch → refuse.
+
+**Context**: LLM-computed arithmetic in cap-table snapshots and SAFE worksheets propagates errors to founder-facing artifacts the founder will quote to investors. A 5-percentage-point dilution-table error is the failure mode.
+
+**Important design rule**: **Math is computed, not narrated**. Either emit a runnable script the founder runs (transparent + verifiable), or emit the artifact with a verification block that re-derives every numeric cell at write time and refuses on mismatch.
+
+**Refactor budget**: `Targeted refactor permitted for adding numeric verification to 3 advisor skills`.
+
+#### Contract Block
+
+| Field | Value |
+|---|---|
+| Inputs | M2 outputs (intake contracts + advisor SKILL.md updates); existing `/slo-fundraise`, `/slo-equity`, `/slo-pricing` SKILL.md files |
+| Outputs | 3 advisor SKILL.md updates that emit verifiable math; structural-contract test asserting verification discipline |
+| Interfaces touched | `/slo-fundraise/SKILL.md`, `/slo-equity/SKILL.md`, `/slo-pricing/SKILL.md` |
+| Files allowed to change | `skills/slo-fundraise/SKILL.md`, `skills/slo-equity/SKILL.md`, `skills/slo-pricing/SKILL.md`, `crates/sldo-install/tests/e2e_biz_imp_m3.rs` (NEW) |
+| Files to read before changing anything | M1 + M2 lessons; existing 3 SKILL.md files |
+| New files allowed | 1 test file |
+| New dependencies allowed | `none` (Python is system-installed; the snippet is fence-rendered, not executed by the skill) |
+| Migration allowed | `no` |
+| Compatibility commitments | Existing draft modes preserved; verification is additive |
+| Forbidden shortcuts | LLM-computed math without a re-derivation block; missing refusal-on-mismatch; emitting a script that depends on libraries not in stdlib |
+| **Data classification** | `Confidential` for the artifact bodies (cap tables and SAFE math contain real financial figures) |
+| **Proactive controls in play** | OWASP C5 (validate inputs — math re-derivation IS validation); C9 (audit trail via verification-result frontmatter field) |
+| **Abuse acceptance scenarios** | `tm-biz-imp-abuse-6: LLM-computed dilution table is wrong by 5pp; founder quotes wrong number to investor` — class eliminated by re-derivation pass before write |
+
+#### Out of Scope / Must Not Do
+
+- Modifying advisor doc-types or modes.
+- Touching intake contracts (M2 job).
+- KPI baselines (M4 job).
+- Adding Python as a runtime dependency (the snippet is fence-rendered for the founder to run).
+
+#### Pre-Flight
+
+1. Complete Global Entry Rules.
+2. Read M2 lessons.
+3. Read existing 3 SKILL.md files.
+4. Identify every numeric cell in current SAFE worksheet / cap-table-snapshot / value-equation outputs (inventory the math surface).
+
+#### Files Allowed To Change
+
+| File | Planned Change |
+|---|---|
+| `skills/slo-fundraise/SKILL.md` | `safe-worksheet` doc-type emits math as a fenced Python snippet (stdlib-only, MIT-licensed `# SPDX-License-Identifier: MIT` header) the founder runs; **per paradigm — two-pass verification**: (1) skill emits the snippet + an expected-results table; (2) skill re-derives every cell inline using a different computation order (e.g., sum-of-shares vs total-shares-given-cap); mismatch on either pass → refuse to write with the diff surfaced. Per critique S-5: rounding tolerance documented as **±£1 for currency cells, ±0.01% for percentages, ±1 for whole-share counts** (per-cell-type table in the SKILL.md). |
+| `skills/slo-equity/SKILL.md` | `cap-table-snapshot` doc-type emits structured table where **every "Total" row is independently re-computed via TWO methods** (sum-down, weighted-product cross-check); both must agree within tolerance; mismatch → refuse. Per-cell tolerance same as above. |
+| `skills/slo-pricing/SKILL.md` | Value-equation calculator emits as a runnable computation (price = round(value × ratio, -2)); 1.5× experiment math similar; **per paradigm — verify reciprocal**: skill computes price=value×0.25 AND value=price/0.25; both must agree within tolerance; documents the 25-33% range explicitly so the founder sees the band, not a single-point estimate. |
+| `crates/sldo-install/tests/e2e_biz_imp_m3.rs` | NEW: structural-contract test asserting (a) each of 3 SKILL.md files describes verification block / runnable snippet, (b) refusal-on-mismatch is documented, (c) Python snippets are stdlib-only (no `import requests`, etc.) |
+
+#### Step-by-Step
+
+1. Test stub first.
+2. Inventory math surfaces in pre-flight.
+3. Update 3 SKILL.md files with verification discipline.
+4. Verify structural-contract test passes.
+5. Smoke tests: invoke each skill against a fixture; observe verification block; verify a tampered cell triggers refusal.
+6. Self-review.
+
+#### BDD Acceptance Scenarios
+
+**Feature: numeric verification for SAFE / cap-table / pricing math**
+
+| Scenario | Category | Given | When | Then |
+|---|---|---|---|---|
+| SAFE worksheet emits verifiable math | happy path | `/slo-fundraise draft safe-worksheet` | runs end-to-end | output contains either (a) fenced Python snippet, or (b) re-derivation block with totals checked |
+| Cap-table totals re-computed | happy path | `/slo-equity draft cap-table-snapshot` | runs | every "Total" row is independently re-computed before emission |
+| Pricing value-equation runs | happy path | `/slo-pricing` value-equation | runs | computation emitted as runnable snippet OR re-derived block |
+| Mismatch in cap-table totals | abuse case (`tm-biz-imp-abuse-6`) | LLM-computed total disagrees with sum-of-rows | skill | refuses to write; surfaces the discrepancy |
+| Founder asks for 5pp dilution table | happy path | small round | runs | dilution table verified |
+| Python snippet has non-stdlib import | abuse case (snippet provenance) | snippet says `import requests` | structural-contract test | test FAILS with "stdlib-only required" |
+| Empty SAFE worksheet | empty state | founder declines all F3 numbers | skill | refusal-on-ambiguity from M2's intake fires before reaching M3 verification |
+| Backward compat: existing `/slo-pricing` artifacts pre-M3 | backward compatibility | older artifact without verification block | tests | parse cleanly; verification is additive |
+
+#### Regression Tests
+
+- `cargo test --workspace`.
+- M1 + M2 structural-contract tests.
+- Existing `/slo-fundraise`, `/slo-equity`, `/slo-pricing` install symlinks.
+
+#### Compatibility Checklist
+
+- [ ] Existing draft modes work.
+- [ ] Existing `intake_summary:` from M2 still flows through.
+- [ ] No new dependencies.
+
+#### E2E Runtime Validation
+
+**File**: `crates/sldo-install/tests/e2e_biz_imp_m3.rs`
+
+| E2E Test | What It Proves | Pass Criteria |
+|---|---|---|
+| `safe_worksheet_has_verification` | SAFE math is verifiable | grep `slo-fundraise/SKILL.md` for "verification block" or "runnable Python snippet" |
+| `cap_table_totals_re_derived` | Cap table re-derived | grep `slo-equity/SKILL.md` for "re-derive every Total row" |
+| `value_equation_emits_computation` | Pricing math computed | grep `slo-pricing/SKILL.md` for verifiable math |
+| `python_snippets_stdlib_only` | Snippet provenance | grep emitted Python templates for non-stdlib imports; assert none |
+| `refusal_on_mismatch_documented` | Discipline present | grep each SKILL.md for "refuse to write" pattern |
+
+#### Smoke Tests
+
+- [ ] Mock-invoke `/slo-fundraise draft safe-worksheet`; observe runnable snippet.
+- [ ] Mock-invoke `/slo-equity draft cap-table-snapshot`; introduce a tampered total in the agent's response; observe refusal.
+- [ ] `cargo test -p sldo-install` passes.
+
+#### Evidence Log
+
+(Copy at execution time.)
+
+#### Definition of Done
+
+- All BDD scenarios pass.
+- 3 SKILL.md files updated.
+- Tracker + lessons + completion files written.
+
+#### Post-Flight
+
+- ARCHITECTURE.md: not required.
+- README.md: not required.
+
+#### Notes
+
+- The fence-rendered Python snippet pattern means the SKILL doesn't execute Python; the founder runs it. This avoids adding Python to the runtime trust surface while still verifying the math.
+
+---
+
+### Milestone 4 — KPI baseline files + generator skill updates
+
+**Goal**: Source-verify the [`references/biz/saas-kpi-targets-baseline.md`](references/biz/saas-kpi-targets-baseline.md) starter; create 5 sister KPI / framework / pricing / launch / mom-test files; update the 7 generator SKILL.md files to consume them via `baseline_ref:`.
+
+**Context**: The starter `saas-kpi-targets-baseline.md` is partially populated. M4 source-verifies every row against the cited public sources, captures `last_checked:` per-row, and authors the 5 sister files.
+
+**Important design rule**: **Every numeric heuristic carries provenance**. SKILL.md prose cites file:section, never inlines numbers. Generator artifacts carry `baseline_ref:` frontmatter.
+
+**Refactor budget**: `Targeted refactor permitted for replacing inlined numeric heuristics in 7 generator SKILL.md files with citations to baseline files`.
+
+#### Contract Block
+
+| Field | Value |
+|---|---|
+| Inputs | M1 outputs; M2 outputs; M3 outputs; existing `references/biz/saas-kpi-targets-baseline.md` (starter); R2 M1's `references/templates/heuristic-numbers-discipline.md`; existing 7 generator SKILL.md files; public sources (Bessemer, OpenView, Sequoia, Andrew Chen, Bain, Bridge Group, RAIN Group, PG, Fitzpatrick, Hormozi) at runbook-author time |
+| Outputs | Source-verified `saas-kpi-targets-baseline.md`; 5 sister KPI files; 7 generator SKILL.md updates; structural-contract test asserting cross-skill citations + `baseline_ref:` discipline |
+| Interfaces touched | `references/biz/` reference subtree; 7 generator SKILL.md files |
+| Files allowed to change | `references/biz/saas-kpi-targets-baseline.md` (refresh), `references/biz/{outbound-conversion-baselines,product-prioritization-frameworks,value-equation-pricing,mom-test-canonical-questions,launch-success-thresholds}.md` (5 NEW), 7 generator SKILL.md files (`slo-metrics`, `slo-pricing`, `slo-sales-funnel`, `slo-product`, `slo-launch`, `slo-marketing`, `slo-talk-to-users`), `crates/sldo-install/tests/e2e_biz_imp_m4.rs` (NEW) |
+| Files to read before changing anything | M1 + M2 + M3 lessons; existing 7 generator SKILL.md files; M2 M1's `heuristic-numbers-discipline.md` |
+| New files allowed | 5 sister files + 1 test file |
+| New dependencies allowed | `none` |
+| Migration allowed | `no` |
+| Compatibility commitments | The four hard-block predicate IDs unchanged; existing biz-pack tests pass |
+| Forbidden shortcuts | recited numbers without source attribution; vendor-blog citations as primary; missing `last_checked:` per-row; copy-paste "approximate" between rows |
+| **Data classification** | `Public` |
+| **Proactive controls in play** | OWASP C1 (security requirements anchored in source-verified sources); C5 (validate inputs — closed-source-list per row); C9 (audit trail via per-row `last_checked:`) |
+| **Abuse acceptance scenarios** | `tm-biz-skill-improvements-abuse-3: KPI baseline drift causes founder to quote stale figure to investor` — mitigated by `last_checked:` per-row + skill stale-warning at +12 months + annual `/loop` agent (M5) |
+
+#### Out of Scope / Must Not Do
+
+- Touching advisor SKILL.md files (M2 job, already done).
+- New generator skills.
+- Cross-jurisdiction benchmarks (UK only).
+
+#### Pre-Flight
+
+1. Complete Global Entry Rules.
+2. Read M1 + M2 + M3 lessons.
+3. Read R2 M1's `references/templates/heuristic-numbers-discipline.md`.
+4. Visit each public source URL at runbook-author time:
+   - Bessemer State of the Cloud (https://www.bvp.com/atlas)
+   - OpenView SaaS Benchmarks (https://openviewpartners.com/saas-benchmarks/)
+   - Sequoia Retention by the Numbers (https://articles.sequoiacap.com/retention)
+   - Andrew Chen retention (https://andrewchen.com/retention-is-king/)
+   - Bain NPS (https://www.netpromotersystem.com/about/)
+   - Bridge Group SaaS Sales Development Report
+   - RAIN Group sales benchmarks
+   - Paul Graham *Startup = Growth* (https://paulgraham.com/growth.html)
+   - Fitzpatrick *The Mom Test* 2013 (ISBN 978-1492180746) — quote-permitted snippets only
+   - Hormozi *$100M Offers* (value-equation source)
+5. Capture per-row `last_checked:` date and verbatim claim text where possible.
+
+#### Files Allowed To Change
+
+| File | Planned Change |
+|---|---|
+| `references/biz/saas-kpi-targets-baseline.md` | Refresh: source-verify every row; per-row `last_checked:` populated; per-row `source_url:` populated; **per paradigm — comprehensive provenance fields**: `confidence:` (high/med/low based on whether the source is industry-canonical (Bessemer, OpenView) vs single-vendor blog), `methodology_note:` (one-line: how the source measured the claim — e.g., "Bessemer's burn-multiple is computed from cohort-level cash data; not directly comparable to monthly burn ratios"), `sample_size:` (where the source discloses), `vintage:` (the publication year of the source — distinct from `last_checked:` which is when SLO verified the URL), `applicability_caveat:` (one-line: when this number doesn't apply — e.g., "B2B targets assume product-led; sales-led ACV > £25k may differ") |
+| `references/biz/outbound-conversion-baselines.md` | NEW: full funnel rates with sources |
+| `references/biz/product-prioritization-frameworks.md` | NEW: RICE (Intercom 2016), Kano (Kano 1984) definitions sourced |
+| `references/biz/value-equation-pricing.md` | NEW: "25-33% of value" claim sourced (Hormozi); "30-50% below market" reframed as opinion if not sourceable |
+| `references/biz/mom-test-canonical-questions.md` | NEW: Fitzpatrick *The Mom Test* 2013 question scaffolding. **Per critique B-2**: attribution-only (cite ISBN 978-1492180746 + page numbers); the question SCHEMA is the discipline; question text is paraphrased with explicit attribution, no verbatim long-quotes (copyright). |
+| `references/biz/launch-success-thresholds.md` | NEW: "set your own threshold" reframing for unsourceable launch numbers |
+| `skills/slo-metrics/SKILL.md` | Replace inlined KPI numbers with citations to `saas-kpi-targets-baseline.md@<retrieval-date>`; require artifact `baseline_ref:` frontmatter |
+| `skills/slo-pricing/SKILL.md` | Same shape; cite `value-equation-pricing.md` for "25-33% of value" |
+| `skills/slo-sales-funnel/SKILL.md` | Cite `outbound-conversion-baselines.md` |
+| `skills/slo-product/SKILL.md` | Cite `product-prioritization-frameworks.md` for RICE/Kano |
+| `skills/slo-launch/SKILL.md` | Cite `launch-success-thresholds.md`; reframe inlined success numbers as "set your own threshold" |
+| `skills/slo-marketing/SKILL.md` | Cite M1's `uk-marketing-statute-anchors.md` for ASA/CAP/PECR |
+| `skills/slo-talk-to-users/SKILL.md` | Cite `mom-test-canonical-questions.md` |
+| `crates/sldo-install/tests/e2e_biz_imp_m4.rs` | NEW: structural-contract test asserting (a) each of 6 baseline files has source-verified rows with `last_checked:`, (b) every generator SKILL.md cites its baseline file, (c) no inlined numbers remain in generator SKILL.md prose, (d) authoritative sources only |
+
+#### Step-by-Step
+
+1. Test stub first.
+2. Source-verify `saas-kpi-targets-baseline.md` row by row.
+3. Author the 5 sister files.
+4. Update 7 generator SKILL.md files to cite from baselines.
+5. Verify structural-contract test passes.
+6. Smoke tests: open one generator artifact (e.g., `/slo-metrics b2b`); observe `baseline_ref:` frontmatter.
+7. Self-review.
+
+#### BDD Acceptance Scenarios
+
+**Feature: KPI baselines source-verified; generator SKILL.md cites from baselines**
+
+| Scenario | Category | Given | When | Then |
+|---|---|---|---|---|
+| Every KPI row source-verified | happy path | M4 closes | parse `saas-kpi-targets-baseline.md` | every row has `source_url:` + `last_checked:` |
+| 5 sister files exist | happy path | M4 closes | inspect | all 5 present + frontmatter valid |
+| Each generator SKILL.md cites baseline | happy path | M4 closes | grep | each cites at least one `references/biz/<baseline>.md` |
+| Generator artifact carries `baseline_ref:` | happy path | `/slo-metrics b2b` runs | inspect output | `baseline_ref:` frontmatter present + `@<retrieval-date>` |
+| Stale baseline (> 12 months) | outdated information | `last_checked: > 12 months ago` | skill consults | skill emits stale warning |
+| Stale > 24 months | outdated information | `last_checked: > 24 months` | skill consults | skill refuses; demands refresh |
+| Vendor-blog primary citation | abuse case (citation-hierarchy violation) | a baseline file cites a vendor blog as primary | structural-contract test | test FAILS |
+| Inlined number in SKILL.md | abuse case (`tm-biz-imp-abuse-7: number drift between SKILL.md and baseline`) | SKILL.md has "≥ 110% NDR" inline | structural-contract test | test FAILS with "cite baseline file" |
+| Backward compat | backward compatibility | existing biz pack tests | `cargo test --workspace` | passes |
+
+#### Regression Tests
+
+- `cargo test --workspace`.
+- M1 + M2 + M3 structural-contract tests.
+- All existing biz-pack tests.
+
+#### Compatibility Checklist
+
+- [ ] All 7 generator SKILL.md install.
+- [ ] No advisor SKILL.md affected.
+- [ ] No predicate-set drift.
+
+#### E2E Runtime Validation
+
+**File**: `crates/sldo-install/tests/e2e_biz_imp_m4.rs`
+
+| E2E Test | What It Proves | Pass Criteria |
+|---|---|---|
+| `kpi_baseline_rows_source_verified` | Per-row `source_url:` + `last_checked:` populated | parse + URL match |
+| `five_sister_baseline_files_exist` | All 5 present + valid frontmatter | path + frontmatter parse |
+| `each_generator_skill_md_cites_baseline` | SKILL.md updates landed | grep each generator SKILL.md |
+| `no_inlined_numbers_in_generator_skill_md` | Citation discipline | grep checks for inlined numeric patterns (e.g., `\d+%` outside fenced examples) |
+| `authoritative_sources_only` | No vendor blogs as primary | URL pattern match against authoritative-source list |
+
+#### Smoke Tests
+
+- [ ] Open `saas-kpi-targets-baseline.md`; click a `source_url:` link — resolves to a primary source.
+- [ ] Mock-invoke `/slo-metrics b2b`; observe `baseline_ref:` in output frontmatter.
+- [ ] Open `mom-test-canonical-questions.md`; verify Fitzpatrick attribution.
+- [ ] `cargo test -p sldo-install` passes.
+
+#### Evidence Log
+
+(Copy at execution time.)
+
+#### Definition of Done
+
+- All BDD scenarios pass.
+- 6 baseline files source-verified or authored.
+- 7 generator SKILL.md files updated.
+- Tracker + lessons + completion files written.
+
+#### Post-Flight
+
+- ARCHITECTURE.md update: extend "References subtrees" with KPI baselines.
+- README.md: not required.
+
+#### Notes
+
+- Fitzpatrick *Mom Test* quotation is constrained by copyright; use snippet-permitted excerpts only or paraphrase with attribution. Document the quote-permission decision in lessons.
+
+---
+
+### Milestone 5 — `baseline_ref:` artifact schema field + cross-skill citation tests + annual refresh `/loop`
+
+**Goal**: Add `baseline_ref:`, `intake_summary:`, `gates_evaluation:` fields to [`references/biz/artifact-schema.md`](references/biz/artifact-schema.md). Add cross-skill citation structural-contract tests. Configure annual `/loop` agent that re-fetches public KPI sources and opens a refresh PR.
+
+**Context**: M5 wires the schema and the automation. Schema extensions are additive (existing artifacts unaffected); cross-skill citation tests catch SKILL.md drift; annual loop catches baseline staleness.
+
+**Important design rule**: **Schema extensions are additive optional**. Existing artifacts without the new fields parse cleanly.
+
+**Refactor budget**: `Minimal local refactor permitted in listed files only`.
+
+#### Contract Block
+
+| Field | Value |
+|---|---|
+| Inputs | M1-M4 outputs; existing `references/biz/artifact-schema.md`; existing `/schedule` skill |
+| Outputs | Schema extension; cross-skill citation tests; annual `/loop` configuration |
+| Interfaces touched | `references/biz/artifact-schema.md`; `crates/sldo-install/tests/`; `/schedule` configuration |
+| Files allowed to change | `references/biz/artifact-schema.md`, `crates/sldo-install/tests/e2e_biz_imp_m5.rs` (NEW), `.sldo/refresh-loop.toml` (NEW — `/schedule` config) |
+| Files to read before changing anything | M1-M4 lessons; existing `artifact-schema.md`; `/schedule` skill |
+| New files allowed | 1 test file + 1 schedule config |
+| New dependencies allowed | `none` |
+| Migration allowed | `no` (additive only) |
+| Compatibility commitments | Existing artifacts parse cleanly; existing tests pass; immutability of 4 predicates preserved |
+| Forbidden shortcuts | non-additive schema changes; missing immutability test; auto-merging the refresh PR |
+| **Data classification** | `Public` for the schema; `Internal` for the refresh-loop config (no PII) |
+| **Proactive controls in play** | C9 (audit trail via schema fields); C7 (access controls — refresh loop doesn't auto-merge) |
+| **Abuse acceptance scenarios** | `tm-biz-imp-abuse-8: refresh loop auto-merges into main` — class eliminated by `/schedule` config opening PR only, never auto-merging (matches `/slo-sast` M5 PR discipline) |
+
+#### Out of Scope / Must Not Do
+
+- Modifying existing schema fields.
+- Adding non-additive schema changes.
+- Auto-merging refresh PRs.
+- Touching advisor or generator SKILL.md (M2 / M4 jobs).
+
+#### Pre-Flight
+
+1. Complete Global Entry Rules.
+2. Read M1-M4 lessons.
+3. Read existing `artifact-schema.md`.
+4. Read `/schedule` skill behavior.
+
+#### Files Allowed To Change
+
+| File | Planned Change |
+|---|---|
+| `references/biz/artifact-schema.md` | Add **9 new optional fields per paradigm — comprehensive audit trail**: `baseline_ref:` (string, path + retrieval-date), `intake_summary:` (block, F1-F6 fields per intake contract), `gates_evaluation:` (block, per-predicate `pass / fail / insufficient-info` + `gates_fired:` list), `restated_and_confirmed:` (bool), `restated_at:` (ISO-8601 timestamp with TZ), `agent_version:` (e.g., `claude-opus-4-7`), `agent_session_id:` (opaque session identifier for cross-artifact correlation), `conversation_turn_count:` (number of founder-skill turns during intake), `intake_duration_seconds:` (elapsed elicitation time — anti-pattern detector: if < 30s for full F1-F6 intake, the conversation was bypassed; flag for review). All optional for backward compat; new generator/advisor outputs populate them. |
+| `crates/sldo-install/tests/e2e_biz_imp_m5.rs` | NEW: cross-skill citation structural-contract test; immutability test re-asserted; schema-additive-only test |
+| `.sldo/refresh-loop.toml` | NEW: `/schedule` configuration for annual KPI baseline refresh PR |
+
+#### Step-by-Step
+
+1. Test stub first.
+2. Update `artifact-schema.md` with 3 new optional fields.
+3. Author cross-skill citation tests.
+4. Configure annual `/loop` for KPI baselines.
+5. Verify structural-contract test passes.
+6. Smoke tests.
+7. Self-review.
+
+#### BDD Acceptance Scenarios
+
+**Feature: schema extended; cross-skill citations tested; refresh loop configured**
+
+| Scenario | Category | Given | When | Then |
+|---|---|---|---|---|
+| Schema has new optional fields | happy path | M5 closes | parse `artifact-schema.md` | 3 new fields documented as optional |
+| Cross-skill citation test passes | happy path | M5 closes | `cargo test` | every advisor SKILL.md cites `references/templates/restate-and-confirm.md`; every generator cites a baseline file |
+| Existing artifact parses cleanly | backward compatibility | pre-M5 artifact in `docs/biz/` | `/slo-verify` Pass 4 | passes; new fields are optional |
+| Refresh `/loop` opens PR (not auto-merge) | abuse case (`tm-biz-imp-abuse-8`) | annual loop fires; baseline drift detected | loop runs | PR opened; no auto-merge |
+| Predicate immutability re-asserted | abuse case | someone tries to remove a predicate | `triage_gate_predicate_set_unchanged_from_m1` | test FAILS |
+| Schema non-additive change attempt | abuse case (schema-evolution discipline) | someone tries to remove a field | structural-contract test | test FAILS with "schema changes must be additive" |
+
+#### Regression Tests
+
+- `cargo test --workspace`.
+- All M1-M4 structural-contract tests.
+- `triage_gate_predicate_set_unchanged_from_m1`.
+
+#### Compatibility Checklist
+
+- [ ] All existing biz artifacts parse.
+- [ ] All existing biz-pack tests pass.
+- [ ] Predicate IDs immutable.
+
+#### E2E Runtime Validation
+
+**File**: `crates/sldo-install/tests/e2e_biz_imp_m5.rs`
+
+| E2E Test | What It Proves | Pass Criteria |
+|---|---|---|
+| `artifact_schema_has_new_optional_fields` | Schema extension landed | parse + grep for `baseline_ref:`, `intake_summary:`, `gates_evaluation:` |
+| `cross_skill_citation_test` | SKILL.md citation discipline | every advisor SKILL.md greps for restate-and-confirm; every generator greps for a baseline file |
+| `triage_gate_predicate_set_unchanged_from_m1` | Predicate immutability | exact-match assertion |
+| `schema_additive_only` | No schema regressions | every existing field still documented |
+| `refresh_loop_opens_pr_not_auto_merge` | Loop discipline | parse `.sldo/refresh-loop.toml`; assert no auto-merge flag |
+
+#### Smoke Tests
+
+- [ ] Open `artifact-schema.md`; verify 3 new fields documented as optional.
+- [ ] Trigger refresh loop manually; observe PR opened (not merged).
+- [ ] `cargo test -p sldo-install` passes.
+
+#### Evidence Log
+
+(Copy at execution time.)
+
+#### Definition of Done
+
+- All BDD scenarios pass.
+- Schema extended additively.
+- Cross-skill citation tests passing.
+- Annual `/loop` configured.
+- Tracker + lessons + completion files written.
+
+#### Post-Flight
+
+- ARCHITECTURE.md update: extend "References subtrees" with the schema extension; mention annual refresh loop.
+- README.md: optional bullet about KPI baseline refresh.
+
+#### Notes
+
+- The annual `/loop` is the structural-defense against baseline drift. Manual refresh is also acceptable (a contributor can run the loop on-demand).
+
+---
+
+## Documentation Update Table
+
+| Milestone | ARCHITECTURE.md Update | README.md Update | .gitignore Update | Other Docs |
+|---|---|---|---|---|
+| 1 | "References subtrees" extension: regulator enum + 3 statute-anchor files | none | none | `references/biz/uk-*-statute-anchors.md`, `hmrc-vcm-index.md` (refresh), `ico-duaa-index.md` (refresh) |
+| 2 | "References subtrees" extension: 5 intake contracts | none | none | 5 advisor SKILL.md updates |
+| 3 | none | none | none | 3 advisor SKILL.md updates |
+| 4 | "References subtrees" extension: 6 KPI baseline files | none | none | 7 generator SKILL.md updates |
+| 5 | "References subtrees" + "Annual refresh loop" subsection | optional bullet | none | `references/biz/artifact-schema.md` (additive) |
+
+---
+
+## Optional Fast-Fail Review Prompt for Agents
+
+> Restate the milestone goal, allowed files, forbidden changes, compatibility requirements, tests that must be written first, and the exact Definition of Done. Then list the smallest implementation approach that satisfies the contract without widening scope.
+
+---
+
+## Carry-forward from prior retros
+
+(Empty until R1 M3 ships and `/slo-retro` files lessons as issues.)
+
+| Issue | Title | Suggested milestone | Status |
+|---|---|---|---|
+| (none yet) | | | |
+
+---
+
+## Paradigm-driven enhancements (per `docs/PARADIGM-OVER-ENGINEERING-FOR-SIMPLICITY.md`)
+
+This runbook applies the over-engineering-for-simplicity paradigm at the biz-pack scale. The advisor + generator pipeline absorbs more discipline than a human paralegal team would sustain because the LLM does not pay the cognitive-load tax. Specific layers added because the LLM is the executor:
+
+### Comprehensive temporal audit on regulator + statute + KPI rows (M1 + M4)
+
+Original M1 specified `last_reviewed:` per regulator row. Paradigm-driven extension: **every authority-file row carries five temporal fields**:
+
+- `commenced_date:` — when the cited Act took effect
+- `last_amended:` — most recent amendment retrieved at runbook-author time
+- `last_checked:` — when SLO last verified the source URL
+- `next_review_due:` — `last_checked + 12 months`
+- `confidence:` — `high` (directly verified at primary source) / `medium` (cross-cited from a single secondary) / `low` (inferred)
+
+Same shape on KPI baseline rows in M4 with `vintage:` (publication year of the source) and `methodology_note:` (one-line: how the source measured the claim) and `applicability_caveat:` (when this number doesn't apply). A human paralegal team would maintain 1-2 of these per row; the LLM pipeline maintains all five with no marginal authoring cost.
+
+### Comprehensive artifact-schema audit fields (M5)
+
+Original M5 added 3 optional fields. Paradigm-driven extension: **9 fields**, including `agent_version:`, `agent_session_id:`, `conversation_turn_count:`, `intake_duration_seconds:`. The duration field is itself an anti-pattern detector: a full F1-F6 intake completing in < 30s indicates the agent bypassed the conversational discipline; downstream review can flag.
+
+### Two-pass numeric verification with per-cell tolerance (M3)
+
+Critique S-5 surfaced that LLM-computed math needs rounding tolerance. Paradigm-driven correction: **two-pass verification** (compute via primary method + re-derive via different computation order; mismatch → refuse) with **per-cell-type tolerance table**: ±£1 for currency, ±0.01% for percentages, ±1 for whole-share counts. Pricing computes both directions (price → value → price). Cap-table totals computed sum-down AND weighted-product. A human pipeline would settle for one method; LLM absorbs the verification cost.
+
+### Sister-contract verbatim-share with normalization (M2)
+
+Critique B-4 surfaced whitespace-sensitivity in the byte-compare test. Paradigm-driven correction: **normalize whitespace + line-endings before byte-compare** (already applied). Plus the F1/F4/F5 verbatim share is across 5 sister contracts (legal/accounting/equity/fundraise/hire) — drift-prevention via structural-contract test, not human-review.
+
+### Defense-in-depth across milestones
+
+| Concern | Layer 1 | Layer 2 | Layer 3 | Layer 4 |
+|---|---|---|---|---|
+| Predicate-evaluation hallucination | Conversational intake (M2) | Restate-and-confirm before draft (M2) | Refusal-on-ambiguity third state (M2) | Closed-enum regulator lookup against `uk-regulator-enumeration.md` (M1) |
+| Statute citation drift | Verbatim quotes from `legislation.gov.uk` (M1) | Per-row `last_checked:` + `last_amended:` (M1) | Annual `/loop` refresh PR (M5) | Stale-warning at +12 months, refusal at +24 months |
+| Numeric arithmetic error | Two-pass verification (M3) | Per-cell tolerance table (M3) | Refusal-on-mismatch with diff surfaced (M3) | Founder-runnable Python snippet (transparent + independently verifiable) |
+| KPI baseline drift | Per-row `last_checked:` + source URL (M4) | `confidence:` + `methodology_note:` + `applicability_caveat:` (M4) | Annual `/loop` refresh PR (M5) | `baseline_ref:` frontmatter on every generator artifact (M5) |
+| PII leak via biz-public artifacts | Tier convention (existing) | `.gitignore` rule (existing) | Write-time warning when git-tracked + remote (existing) | `/slo-verify` Pass 4 PII scan (existing) |
+| Conversational intake bypassed | Discipline cited in SKILL.md (M2) | Restate-and-confirm step (M2) | `intake_duration_seconds:` audit field (M5) flags < 30s as suspect | Cross-skill citation test asserts intake-contract reference present (M5) |
+
+### Comprehensive intake — F1-F6 expanded with explicit-comprehension follow-ups
+
+The F1-F6 intake structure is comprehensive, not minimum-viable. Per critique S-1, F3 (deal value) carries an explicit-comprehension follow-up that re-frames the value in two ways before locking. Same pattern is forward-compatible across F1 (jurisdiction — confirm "England & Wales" vs "Scotland"), F4 (GDPR — confirm scope), F5 (regulator — confirm the named regulator IS in the closed enum). The conversational delivery makes the comprehensive intake feel natural; a paper form would be tedious.
+
+### Bounded by context-window
+
+The paradigm's discipline-vs-context-window balance: intake contracts are ~100-150 lines each (within soft cap from R2); statute anchor files can be longer because they're consulted by section, not read end-to-end; KPI baseline files have many small rows; the 9-field artifact frontmatter is one block per artifact, not loaded across multiple artifacts.
+
+### Ask items still open from critique
+
+The paradigm doesn't auto-resolve every critique ask. Still open:
+- B-3: add `--rapid-intake` flag for time-pressed founders (forward-compat documented in `references/templates/intake-checklist.md` per R2 M1; full implementation deferred)
+- B-5: confirm MIT license header on emitted Python snippets (applied; see M3 contract)
+- S-5: per-cell rounding tolerance applied as ±£1 / ±0.01% / ±1 share — confirm the bands

--- a/docs/RUNBOOK-ENGINEERING-SKILL-IMPROVEMENTS.md
+++ b/docs/RUNBOOK-ENGINEERING-SKILL-IMPROVEMENTS.md
@@ -1,0 +1,1060 @@
+# Engineering Skill Improvements — SunLitOrchestrate (AI-First Runbook v3)
+
+> **Purpose**: Decompose monolithic engineering SKILL.md files (`/slo-sast`, `/slo-tla`, `/slo-plan`); seed `references/templates/` shared library; harden `/slo-freeze` with a settings.json PreToolUse hook; add per-skill `evals/`; gate every security-engineering claim through a research-validation source hierarchy.
+> **Audience**: AI coding agents first, humans second.
+> **How to use**: Work through milestones sequentially. Every milestone closes the structural-contract test before the next begins.
+> **Prerequisite reading**: [ARCHITECTURE.md](../ARCHITECTURE.md), [docs/design/engineering-skill-improvements-overview.md](design/engineering-skill-improvements-overview.md), [docs/idea/engineering-skill-improvements.md](idea/engineering-skill-improvements.md), [docs/research/engineering-skill-improvements/synthesis.md](research/engineering-skill-improvements/synthesis.md), [Issue #21](https://github.com/kerberosmansour/SunLitOrchestrate/issues/21), [Issue #22](https://github.com/kerberosmansour/SunLitOrchestrate/issues/22), 2026-04-27 skill-pack review
+
+---
+
+## Runbook Metadata
+
+- **Runbook ID**: `engineering-skill-improvements`
+- **Prefix for test files and lessons files**: `eng-imp`
+- **Primary stack**: Markdown + Rust (`crates/sldo-install`) + `update-config` skill (settings.json mutation)
+- **Primary package/app names**: `sldo-install`, `skills/slo-sast`, `skills/slo-tla`, `skills/slo-plan`, `skills/slo-freeze`, `skills/slo-execute`, `skills/slo-verify`, `references/templates/`, `references/sast/`
+- **Default test commands**:
+  - Workspace tests: `cargo test --workspace`
+  - Specific install tests: `cargo test -p sldo-install`
+  - Build: `cargo build --workspace`
+- **Allowed new dependencies by default**: `none`
+- **Schema/config migration allowed by default**: `no`
+- **Public interfaces that must remain stable**:
+  - Every existing SKILL.md is install-symlinked unchanged (path / filename preserved).
+  - Existing `references/sast/` per-stage references (parser-contract, stack-detection-contract, etc.) preserved.
+  - The four hard-block predicate IDs in `references/biz/triage-gate.md` (immutability locked).
+  - `/slo-architect`'s `~~~text` user-string fence rule.
+
+---
+
+## Milestone Tracker
+
+| # | Milestone | Status | Started | Completed | Lessons File | Completion Summary |
+|---|---|---|---|---|---|---|
+| 1 | `references/templates/` shared library + research-validation prereq landed | `not_started` | | | | |
+| 2 | `/slo-sast` decomposition into thin SKILL.md + `methodology-m1..m5.md` | `not_started` | | | | |
+| 3 | `/slo-tla` decomposition + Apalache pin in `tools.toml` | `not_started` | | | | |
+| 4 | `/slo-plan` per-milestone authoring extracted; soft line-cap structural-contract test | `not_started` | | | | |
+| 5 | Per-skill `evals/` infrastructure + `/slo-freeze` PreToolUse hook + cross-skill polish | `not_started` | | | | |
+
+---
+
+## End-to-End Architecture Diagram
+
+```
+┌──────────────────────────────────────────────────────────────────────┐
+│                  SunLitOrchestrate skill pack                        │
+│                                                                      │
+│  ┌────────────────────────────────────────────────────────────┐     │
+│  │  references/templates/  (NEW — M1)                          │     │
+│  │   - intake-checklist.md                                     │     │
+│  │   - restate-and-confirm.md                                  │     │
+│  │   - citation-discipline.md  ← source-hierarchy rule         │     │
+│  │   - tool-safety-section.md                                  │     │
+│  │   - output-frontmatter.md                                   │     │
+│  │   - escalation.md                                           │     │
+│  │   - eval-cases.md                                           │     │
+│  │   - heuristic-numbers-discipline.md                         │     │
+│  └────────────────────────────────────────────────────────────┘     │
+│                              ▲                                       │
+│           ┌──────────────────┼──────────────────┐                    │
+│           │                  │                  │                    │
+│  ┌────────┴────────┐ ┌───────┴────────┐ ┌──────┴───────┐           │
+│  │ skills/slo-sast/ │ │ skills/slo-tla/ │ │ skills/slo-  │           │
+│  │  SKILL.md (lean)│ │  SKILL.md (lean)│ │  plan/        │           │
+│  │  references/    │ │  references/    │ │  references/  │           │
+│  │   methodology-  │ │   methodology-  │ │   methodology-│           │
+│  │   m1..m5.md     │ │   *.md          │ │   milestone-  │           │
+│  │   (NEW — M2)    │ │   (NEW — M3)    │ │   authoring.md│           │
+│  │                 │ │   tools.toml    │ │   (NEW — M4)  │           │
+│  │                 │ │   (Apalache pin)│ │               │           │
+│  └─────────────────┘ └─────────────────┘ └──────────────┘           │
+│                                                                      │
+│  ┌─────────────────────────────────────────────────────┐            │
+│  │  Per-skill evals/  (NEW — M5)                       │            │
+│  │   skills/<skill>/evals/                             │            │
+│  │     happy-path.md / missing-context.md / ...        │            │
+│  └─────────────────────────────────────────────────────┘            │
+│                                                                      │
+│  ┌─────────────────────────────────────────────────────┐            │
+│  │  .claude/settings.json  PreToolUse hook (M5)        │            │
+│  │   - reads ~/.sldo/freeze-scope.txt                  │            │
+│  │   - blocks Edit/Write/NotebookEdit outside scope    │            │
+│  │   - reuses `update-config` skill for mutation       │            │
+│  └─────────────────────────────────────────────────────┘            │
+│                                                                      │
+│  ┌─────────────────────────────────────────────────────┐            │
+│  │  Soft line-cap structural-contract test (M4)        │            │
+│  │   crates/sldo-install/tests/e2e_eng_imp_m4.rs       │            │
+│  │   - asserts every SKILL.md ≤ 200 lines OR carries   │            │
+│  │     `# soft-cap-exception: <reason>` pragma         │            │
+│  └─────────────────────────────────────────────────────┘            │
+│                                                                      │
+│  Legend:  ─── existing    NEW (this runbook)    ▶ data flow        │
+└──────────────────────────────────────────────────────────────────────┘
+```
+
+### Component Summary Table
+
+| Component | Responsibility | Milestone | Key Interfaces |
+|---|---|---|---|
+| `references/templates/` (8 files) | Shared cross-skill discipline patterns | M1 | Cited by every SKILL.md update in M2-M5 |
+| `references/templates/citation-discipline.md` | Source-hierarchy rule for security-engineering claims (research-validation prereq) | M1 | Cited by `/slo-sast`, `/slo-tla`, `/slo-rulegen`, `/slo-verify`, `/slo-research` |
+| `skills/slo-sast/SKILL.md` (thin) + `references/methodology-m1..m5.md` | Decomposed sast skill | M2 | Install-symlinked unchanged path |
+| `skills/slo-tla/SKILL.md` (thin) + `references/methodology-*.md` + `tools.toml` (Apalache pin) | Decomposed tla skill + Apalache version pin | M3 | Install-symlinked unchanged path |
+| `skills/slo-plan/references/methodology-milestone-authoring.md` | Per-milestone authoring sub-procedure | M4 | Cited from SKILL.md |
+| `crates/sldo-install/tests/e2e_eng_imp_m4.rs` | Soft line-cap structural-contract test | M4 | `cargo test --workspace` baseline |
+| `skills/<skill>/evals/<case>.md` (per-skill) | Documented eval expectations (7 categories) | M5 | Future runtime harness consumes |
+| `.claude/settings.json` PreToolUse hook | Hard-enforces `/slo-freeze` scope | M5 | Mutated via `update-config` skill |
+| `~/.sldo/freeze-scope.txt` | Session-state file for freeze scope | M5 | Read by PreToolUse hook |
+
+### Data Flow Summary
+
+| Flow | From | To | Protocol/Mechanism | Milestone |
+|---|---|---|---|---|
+| Citation consultation | SKILL.md prose | `references/templates/citation-discipline.md` | Markdown link, runtime-read-by-agent | M1 |
+| Per-stage methodology load | `/slo-sast` SKILL.md | `references/methodology-m<N>.md` | Markdown link, on-demand | M2 |
+| Apalache version verification | `/slo-tla` prereq cascade | `tools.toml` + SHA-256 file | Local file read | M3 |
+| Soft line-cap enforcement | `cargo test` | every SKILL.md | structural-contract test | M4 |
+| Eval-case enumeration | `/slo-<skill>` invocation | `skills/<skill>/evals/<case>.md` | Markdown link | M5 |
+| Freeze-scope check | PreToolUse hook | `~/.sldo/freeze-scope.txt` + tool-call file path | Hook script | M5 |
+
+---
+
+## High-Level Design for Formal Verification (TLA+ Section)
+
+`tla_required: false`
+
+No concurrent actors, no distributed state, no ordering guarantees. Decomposition is textual refactoring; the PreToolUse hook is single-session, single-actor; the soft line-cap test is a deterministic markdown grep. Per `/slo-tla`'s suitability gate, this is the wrong tool here.
+
+---
+
+## Global Execution Rules
+
+See [docs/runbook-template_v_3_template.md §"Global Execution Rules"](runbook-template_v_3_template.md). Project-specific overrides:
+
+- The four hard-block predicate IDs in `references/biz/triage-gate.md` are **immutable** by structural-contract test; this runbook does not touch them.
+- Every claim in modified SKILL.md prose touching security-engineering content (Pass 4, ZAP / Dastardly / `cargo audit`, semgrep rule provenance, SAST workflow safety contract) must follow `references/templates/citation-discipline.md`'s source hierarchy. Unverifiable claims removed, not weakened.
+
+## Global Entry / Exit Rules
+
+See template. Specifics:
+
+- Baseline: `cargo test --workspace`. Confirm green before each milestone.
+- M1 must close before M2 starts (templates are upstream dependency).
+- After M2: `wc -l skills/slo-sast/SKILL.md` ≤ ~100 (thin orchestrator).
+- After M3: `wc -l skills/slo-tla/SKILL.md` ≤ ~150 (thin orchestrator + suitability gate).
+
+---
+
+## Background Context
+
+### Current State
+
+The 2026-04-27 skill-pack review identified that `/slo-sast` (296 lines), `/slo-tla` (323 lines), and `/slo-plan` (132 lines with 15-step milestone authoring sub-procedure) are monolithic SKILL.md files. Under context pressure, agents read less of long SKILL.md files and skip key gates.
+
+Across the engineering-side skills, there is no shared `references/templates/` library. Every SKILL.md repeats its own version of intake, restate-and-confirm, citation discipline, tool-safety boilerplate, output frontmatter. When a pattern improves in one skill, the others don't inherit.
+
+`/slo-execute`'s allow-list rule and `/slo-freeze`'s scope lock are LLM-compliance disciplines, not filesystem boundaries. A motivated agent (or one under context pressure) can edit out-of-scope files.
+
+The project owner explicitly flagged a research-validation discipline: every claim touching security-engineering content must cite primary authoritative sources at pinned versions, not paraphrased commentary.
+
+### Problem
+
+1. **Monolithic SKILL.md under context pressure** — `/slo-sast` (296 lines), `/slo-tla` (323), `/slo-plan` (132). An agent invoked for `/slo-sast` M3 reads M1+M2+M4+M5 contract content competing for attention.
+2. **Cross-skill drift on common patterns** — every SKILL.md re-states intake / restate / citation / tool-safety / output-frontmatter / escalation / eval-cases boilerplate.
+3. **Prose-level enforcement of allow-list / freeze** — relies on LLM compliance.
+4. **No per-skill evals** — structural-contract tests assert documented shape; they don't assert agent behavior under happy / missing-context / ambiguous / adversarial / outdated / tool-failure / high-risk inputs.
+5. **Security-engineering claims unverifiable from training memory** — citation hierarchy + research-validation discipline missing.
+6. **Tooling polish drift** — `/slo-second-opinion` shows raw provider output without disclaimer; `get-api-docs` has no `chub` failure handling; `/slo-research` doesn't capture `--help` output before dispatch; `/slo-talk-to-users` git-discovery commands implicit; `/slo-tla`'s Apalache version is a URL, not a SHA pin; `/slo-verify` Pass 4 capitalised-bigram FP triage flow is undocumented.
+
+### Target Architecture
+
+See "End-to-End Architecture Diagram" above.
+
+### Key Design Principles
+
+0. **Over-engineering for simplicity**: per [`docs/PARADIGM-OVER-ENGINEERING-FOR-SIMPLICITY.md`](PARADIGM-OVER-ENGINEERING-FOR-SIMPLICITY.md), the LLM-driven engineering pipeline can sustainably carry MORE discipline than a human-driven equivalent. R2 embodies the paradigm: 8 shared templates + 5+ methodology references + per-skill evals (7 categories) + research-validation source hierarchy + structural-contract tests at multiple layers. A human team would resist this many layered defenses; the LLM pipeline absorbs them, and the engineering output is simpler (cleaner SKILL.md, better-cited recommendations, reproducible structural-contract tests). Balance is via context-window discipline (soft line-cap 200 lines, methodology files ≤ 500 lines, lazy-load references).
+
+1. **Templates at repo root, methodology files inside skills**: `references/templates/` is sibling to `references/biz/` and `references/sast/` (excluded from `discover_skills()`); `skills/<skill>/references/methodology-*.md` is sibling to SKILL.md (included by install symlinks).
+2. **Source hierarchy is non-negotiable**: tool's own docs at pinned version → tool repo `README` / `CHANGELOG` at pinned commit → upstream advisory DB docs → conference talks / academic papers (named author + year) → vendor blog posts (secondary) → never Stack Overflow.
+3. **Unverifiable claims removed, not weakened**: "approximate, please verify" is the failure mode.
+4. **Soft line-cap with documented exceptions**: `# soft-cap-exception: <reason>` SKILL.md frontmatter pragma allowed; structural-contract test rejects exceptions without the reason.
+5. **PreToolUse hook is project-level (`.claude/settings.json`)**, not global; uses `update-config` skill for mutation; reads `~/.sldo/freeze-scope.txt` session state.
+6. **Evals are documented expectations until the runtime harness lands**: forward-compatible file shape; manual run today; harness runs them later without rewrites.
+7. **Decomposition preserves install-symlink semantics**: `discover_skills()` walks `skills/<name>/SKILL.md`; per-skill `references/` subdirectories are sibling-installed.
+
+### What to Keep
+
+- Every existing SKILL.md install path (no renames; symlinks preserved).
+- All existing `references/sast/`, `references/biz/` content (decomposition adds new methodology files; doesn't replace authority files).
+- The four hard-block predicate IDs in `references/biz/triage-gate.md` (immutable).
+- `/slo-architect`'s `~~~text` user-string fence rule (load-bearing for citation-discipline.md).
+- All existing structural-contract tests in `crates/sldo-install/tests/`.
+
+### What to Change
+
+- `references/templates/` (8 NEW files) — M1.
+- `skills/slo-sast/SKILL.md` (slimmed to ~100 lines) + `skills/slo-sast/references/methodology-m1..m5.md` (5 NEW) — M2.
+- `skills/slo-tla/SKILL.md` (slimmed to ~150) + `skills/slo-tla/references/methodology-*.md` (4 NEW) + `tools.toml` updated with Apalache pin — M3.
+- `skills/slo-plan/references/methodology-milestone-authoring.md` (NEW) + `crates/sldo-install/tests/e2e_eng_imp_m4.rs` (NEW soft line-cap test) — M4.
+- Per-skill `skills/<skill>/evals/<case>.md` files for highest-risk skills — M5.
+- `.claude/settings.json` PreToolUse hook for `/slo-freeze` — M5.
+- `/slo-freeze`, `/slo-second-opinion`, `get-api-docs`, `/slo-research`, `/slo-talk-to-users`, `/slo-verify` SKILL.md prose updates — M5.
+- `references/freeze/hook-setup.md` (NEW) — M5.
+
+### Global Red Lines
+
+Standard set; in addition:
+
+- **Research-validation discipline applies to every milestone with a security-engineering claim**. Unverifiable claims removed.
+- The four hard-block predicate IDs are immutable.
+- No silent removal of any existing SKILL.md content during decomposition (move into methodology file with diff visible).
+- The PreToolUse hook is opt-in per project; no global mutation.
+- No `--no-verify` on git commits, no force-pushes, no `gh pr create --repo`.
+
+---
+
+## BDD and Runtime Validation Rules
+
+See template. Project specifics:
+
+### Required Test Coverage Categories
+
+For each milestone:
+
+- happy path (decomposition / template / hook / eval works as documented)
+- empty state (skill invoked with no input where applicable)
+- dependency failure (Apalache missing, settings.json mutation tool unavailable, etc.)
+- backward compatibility (existing SKILL.md prose preserved; install symlinks unchanged)
+- abuse case (tm-eng-skill-improvements-abuse-1/2/3 from design overview)
+
+### Test File Naming
+
+| Layer | Convention | Location |
+|---|---|---|
+| SKILL.md decomposition tests | `tests/e2e_eng_imp_m<N>.rs` | `crates/sldo-install/tests/` |
+| Soft line-cap test | `tests/e2e_eng_imp_m4.rs` | same |
+| Per-skill eval shape tests | `tests/e2e_eng_imp_evals.rs` | same |
+| PreToolUse hook tests | `tests/e2e_eng_imp_freeze_hook.rs` | same |
+
+---
+
+## Dependency, Migration, and Refactor Policy
+
+See template. **No new runtime dependencies in this runbook.** No schema migrations.
+
+Refactor budget per-milestone in milestone sections.
+
+---
+
+## Evidence Log Template
+
+See template.
+
+## Self-Review Gate
+
+See template.
+
+## Lessons + Completion Templates
+
+See template (`docs/lessons/eng-imp-m<N>.md`, `docs/completion/eng-imp-m<N>.md`).
+
+---
+
+## Milestone Plan
+
+### Milestone 1 — `references/templates/` shared library + research-validation prereq
+
+**Goal**: Seed `references/templates/` with the eight common patterns; lock the source hierarchy in `citation-discipline.md`; source-verify every existing security-engineering claim in `/slo-sast`, `/slo-tla`, `/slo-rulegen`, `/slo-verify`, `/slo-research` SKILL.md files about to be decomposed; update those SKILL.md files to cite from the templates.
+
+**Context**: This milestone is foundational. Every downstream milestone (M2-M5) consumes from M1's templates. Skipping M1 forces inline-authoring of the patterns in M2 and creates rework when the templates eventually land.
+
+**Important design rule**: Source hierarchy in `citation-discipline.md` is **non-negotiable**. Every other template file references it for its own discipline. Lock the hierarchy verbatim before any other template file is authored.
+
+**Refactor budget**: `Targeted refactor permitted for replacing inlined statute / heuristic / discipline content in SKILL.md prose with template references`.
+
+#### Contract Block
+
+| Field | Value |
+|---|---|
+| Inputs | 2026-04-27 skill-pack review; existing SKILL.md prose for the 5 security-engineering-touching skills; existing `references/sast/` and `references/biz/` files |
+| Outputs | 8 NEW `references/templates/*.md` files; 5 SKILL.md files updated to cite from templates; structural-contract test asserting cross-references |
+| Interfaces touched | `references/templates/` is a NEW top-level reference subtree (sibling to `references/biz/`, `references/sast/`); 5 SKILL.md prose updates |
+| Files allowed to change | `references/templates/{intake-checklist,restate-and-confirm,citation-discipline,tool-safety-section,output-frontmatter,escalation,eval-cases,heuristic-numbers-discipline}.md` (NEW), `skills/slo-sast/SKILL.md`, `skills/slo-tla/SKILL.md`, `skills/slo-rulegen/SKILL.md`, `skills/slo-verify/SKILL.md`, `skills/slo-research/SKILL.md`, `crates/sldo-install/tests/e2e_eng_imp_m1.rs` (NEW) |
+| Files to read before changing anything | All 5 SKILL.md files; the 2026-04-27 review; existing `references/biz/artifact-schema.md` (output-frontmatter pattern source); `/slo-ideate`'s seven forcing questions (intake-checklist source); `/slo-architect`'s `~~~text` fence rule (citation-discipline source) |
+| New files allowed | The 8 templates + the test file |
+| New dependencies allowed | `none` |
+| Migration allowed | `no` |
+| Compatibility commitments | Every existing SKILL.md still installs; no behavior change in any skill (prose-only refactor) |
+| Forbidden shortcuts | placeholder template content; missing source-hierarchy entries; "and similar disciplines" handwaving; removing inlined statute/heuristic content from SKILL.md without replacing with a template citation; emoji or smileys in template prose |
+| **Data classification** | `Public` — templates and SKILL.md prose are public-tier |
+| **Proactive controls in play** | OWASP C1 (Define security requirements — citation-discipline.md is the rule of validity for security claims); C5 (Validate inputs — intake-checklist.md is the structured-data destination); C9 (Logging — eval-cases.md is the audit pattern) |
+| **Abuse acceptance scenarios** | `tm-eng-skill-improvements-abuse-4: a template's source-hierarchy rule is silently relaxed to admit unverified claims` — class eliminated by structural-contract test asserting the verbatim source-hierarchy text in `citation-discipline.md` |
+
+#### Out of Scope / Must Not Do
+
+- Decomposing any of the 5 SKILL.md files (M2-M4 jobs).
+- Authoring the per-skill `evals/` directories (M5 job).
+- Shipping any new skill behavior.
+- Touching `references/biz/` or `references/sast/` files (those are authority docs; templates are discipline patterns).
+
+#### Pre-Flight
+
+1. Complete Global Entry Rules.
+2. Read the 2026-04-27 skill-pack review carefully.
+3. Read [`/slo-ideate`'s seven forcing questions section](../skills/slo-ideate/SKILL.md) (intake-checklist source pattern).
+4. Read [`/slo-architect`'s `~~~text` fence rule](../skills/slo-architect/SKILL.md) (citation-discipline anchor).
+5. Read [`references/biz/artifact-schema.md`](references/biz/artifact-schema.md) (output-frontmatter pattern source).
+6. **Source-verification spike (validates the discipline only — full verification per-milestone)**: take 5 representative security-engineering claims from `/slo-sast` and `/slo-verify` SKILL.md prose; for each, attempt to verify against the source hierarchy. Document spike result in lessons file. **Per critique E-2**: the full verification of the ~20-30 security-engineering claims is folded into M2/M3/M4 per-milestone evidence-log work, not a single M1 batch — M1's spike validates the discipline before M2 ships at scale.
+
+#### Files Allowed To Change
+
+| File | Planned Change |
+|---|---|
+| `references/templates/citation-discipline.md` | NEW: source hierarchy (6 tiers), bright-line "unverifiable claims removed not weakened" rule, retrieval-date-stamping convention, `last_checked:` discipline, `last_amended:` discipline for evolving sources, conflict-resolution rule when sources disagree |
+| `references/templates/intake-checklist.md` | NEW: conversational-elicitation discipline (one question, push on vague, ladder, restate-and-confirm); cites `/slo-ideate` precedent; explicit-comprehension follow-up pattern; `--rapid-intake` opt-in compressed-mode pattern (forward-compatible even if not implemented in any skill yet) |
+| `references/templates/restate-and-confirm.md` | NEW: pattern modeled on `/slo-execute` "Restate the milestone constraints in your own words"; structured restatement format; correction-loop with explicit re-elicitation, never silent re-interpretation |
+| `references/templates/tool-safety-section.md` | NEW: version check + `--help` capture + dry-run + read-only-vs-mutating; argv-list discipline; cite `/slo-tla` prereq cascade + `/slo-sast` argv-list as exemplars; PATH-spoofing defense (`command -v` not `which`, absolute paths preferred); subprocess output capture (stdout / stderr / exit-code separately) |
+| `references/templates/output-frontmatter.md` | NEW: canonical frontmatter base; per-skill schemas extend; agent-provenance fields (`agent_version`, `agent_session_id`, `created_at` ISO-8601 with TZ); cross-skill audit fields |
+| `references/templates/escalation.md` | NEW: refusal patterns + routing + ambiguity-third-state; "fail-loud" vs "fail-graceful" decision rule; how to phrase a refusal (cite the predicate, name the gap, recommend the next action) |
+| `references/templates/eval-cases.md` | NEW: 7-category shape (happy / missing-context / ambiguous / adversarial / outdated / tool-failure / high-risk); frontmatter schema for case files; per-category multi-example pattern (every category gets ≥ 2 distinct examples, not just one) |
+| `references/templates/heuristic-numbers-discipline.md` | NEW: "every numeric claim cites a baseline file with retrieved-date" rule; per-row `last_checked:` field; stale-warning trigger; per-row `confidence:` enum (high/med/low based on source authority); `methodology_note:` field documenting how the source measured the claim |
+| `references/templates/rate-limiting-discipline.md` | NEW (paradigm: comprehensive layer): per-session client-side cap pattern; adaptive backoff on observed rate-limit response codes; spillover-to-local-file fallback; cross-invocation rate-NOT-persisted rule; pattern shared by `/slo-retro` (R1 M3), `/slo-sec-libs` (R4 M4), and any future skill that calls a rate-limited remote |
+| `references/templates/fallback-discipline.md` | NEW (paradigm: graceful degradation as a first-class pattern): when a remote / tool / dependency is unavailable, what is the local equivalent that preserves the user-visible discipline? Cites `LESSONS-BACKLOG.md` (R1) + `~/.cache/sldo/` patterns + cost-baseline-staleness fallback |
+| `references/templates/version-pinning-discipline.md` | NEW (paradigm: comprehensive supply-chain defense): SHA-256 pinning vs tag pinning vs branch pinning trade-offs; `git rev-parse HEAD` cache integrity check pattern; refresh cadence + bump procedure; cross-cite `/slo-sast` action-SHA pin, `/slo-tla` `tla2tools.jar` pin, `/slo-sec-libs` (R4) declarations SHA pin |
+| `skills/slo-sast/SKILL.md` | Update citation-discipline-touching prose to cite `references/templates/citation-discipline.md` |
+| `skills/slo-tla/SKILL.md` | Same |
+| `skills/slo-rulegen/SKILL.md` | Same |
+| `skills/slo-verify/SKILL.md` | Same; also add Pass 4 capitalised-bigram FP triage flow citing `references/templates/escalation.md` |
+| `skills/slo-research/SKILL.md` | Same; also add `sldo-research --help` capture requirement citing `references/templates/tool-safety-section.md` |
+| `crates/sldo-install/tests/e2e_eng_imp_m1.rs` | NEW: structural-contract test asserting (a) all 8 template files exist + frontmatter valid; (b) each of the 5 updated SKILL.md cites at least one template file; (c) `citation-discipline.md` contains the verbatim 6-tier source hierarchy |
+
+#### Step-by-Step
+
+1. Author `citation-discipline.md` first. Lock source hierarchy. Verbatim 6-tier text.
+2. Run source-verification spike: pick 5 claims, attempt verification, document.
+3. Author the other 7 templates in parallel.
+4. Update the 5 SKILL.md files to cite from templates (replace inlined boilerplate).
+5. Test stub.
+6. Verify structural-contract test passes.
+7. Smoke tests.
+8. Self-review.
+
+#### BDD Acceptance Scenarios
+
+**Feature: shared templates seeded; security-engineering claims source-verified**
+
+| Scenario | Category | Given | When | Then |
+|---|---|---|---|---|
+| All 8 templates exist with valid frontmatter | happy path | repo at HEAD | structural-contract test runs | all 8 files present + frontmatter parses |
+| `citation-discipline.md` contains 6-tier source hierarchy verbatim | happy path | file authored | test asserts text match | match found |
+| Each updated SKILL.md cites ≥ 1 template | happy path | 5 SKILL.md files updated | grep each for `references/templates/` | all 5 grep hits succeed |
+| Empty template file | empty state | template file accidentally empty | test runs | test FAILS with "frontmatter missing" |
+| Source-hierarchy silently relaxed | abuse case (`tm-eng-abuse-4`) | someone edits `citation-discipline.md` to drop tier 6 | test runs | test FAILS with "verbatim hierarchy text mismatch" |
+| Backward compat: skill not in update list | backward compatibility | other skills (e.g., `/slo-execute`) unchanged | full suite runs | unchanged skills still install + tests still pass |
+| Existing `references/biz/` and `references/sast/` unaffected | backward compatibility | M1 closes | inspect those subtrees | no files changed |
+
+#### Regression Tests
+
+- `cargo test --workspace`.
+- All existing SKILL.md install tests.
+- The four-predicate immutability test.
+
+#### Compatibility Checklist
+
+- [ ] Every existing SKILL.md still installs.
+- [ ] No removal of existing reference content.
+- [ ] No skill behavior change.
+- [ ] No prose loss (every removed line from a SKILL.md is replaced by a template citation that captures the same content).
+
+#### E2E Runtime Validation
+
+**File**: `crates/sldo-install/tests/e2e_eng_imp_m1.rs`
+
+| E2E Test | What It Proves | Pass Criteria |
+|---|---|---|
+| `templates_directory_has_all_eight_files` | Library is complete | all 8 file paths exist + frontmatter parses |
+| `citation_discipline_source_hierarchy_verbatim` | Hierarchy is locked | exact text-match against expected 6-tier list |
+| `five_skills_cite_templates` | SKILL.md updates landed | each SKILL.md grepped for ≥ 1 `references/templates/` link |
+| `no_unverified_security_claim_remains` | Source-verification done | spike documentation in lessons file flagged for human review |
+
+#### Smoke Tests
+
+- [ ] Open `references/templates/citation-discipline.md`; verify 6-tier hierarchy renders.
+- [ ] Open one updated SKILL.md (e.g., `slo-sast`); verify template cite resolves.
+- [ ] `cargo test -p sldo-install` passes.
+- [ ] `git status` clean.
+
+#### Evidence Log
+
+(Copy at execution time.)
+
+#### Definition of Done
+
+- All 8 templates exist with valid frontmatter.
+- `citation-discipline.md` source hierarchy locked verbatim + tested.
+- 5 SKILL.md files updated to cite from templates.
+- Source-verification spike documented in lessons file.
+- All BDD scenarios pass.
+- Tracker + lessons + completion files written.
+
+#### Post-Flight
+
+- ARCHITECTURE.md update: add a "References subtrees" subsection mentioning `references/templates/`.
+- README.md update: add a docs-index pointer to the templates library.
+
+#### Notes
+
+- Template authoring is high-bandwidth thinking work — resist copy-paste between templates. Each is a discrete discipline.
+
+---
+
+### Milestone 2 — `/slo-sast` decomposition
+
+**Goal**: `/slo-sast/SKILL.md` reduced to ≤ 100 lines (pre-flight + mode dispatch + anti-patterns common across milestones); per-stage methodology extracted to `skills/slo-sast/references/methodology-m1-parser.md` through `methodology-m5-pr-creation.md` (5 new files). Every duplicated contract content in old SKILL.md replaced with one-line pointer.
+
+**Context**: The current SKILL.md is 296 lines covering M1-M5 of the scanner-orchestration runbook. Future invocations of `/slo-sast` for any single stage drag in all 5 stages' content. Existing `references/sast/` files (parser-contract, stack-detection-contract, etc.) are authority docs and stay; the new `methodology-m<N>` files are orchestration scaffolds that cite the authority docs.
+
+**Important design rule**: **Move, don't summarize**. Every line of the old SKILL.md that lands in a methodology file lands verbatim. Diff between old SKILL.md and (new SKILL.md ∪ all 5 methodology files) MUST be empty for prose content; only the structural reorganization changes.
+
+**Refactor budget**: `Targeted refactor permitted for SKILL.md content extraction into per-stage references; prose moves verbatim`.
+
+#### Contract Block
+
+| Field | Value |
+|---|---|
+| Inputs | Existing `skills/slo-sast/SKILL.md` (296 lines); existing `references/sast/` authority docs; M1's `references/templates/citation-discipline.md` |
+| Outputs | New thin SKILL.md (≤ 100 lines); 5 new `methodology-m<N>.md` files; structural-contract test asserting (a) verbatim prose preservation, (b) install symlink continuity, (c) every M<N> contract still cited from new SKILL.md |
+| Interfaces touched | `skills/slo-sast/SKILL.md` content; new `skills/slo-sast/references/` subdirectory contents |
+| Files allowed to change | `skills/slo-sast/SKILL.md`, `skills/slo-sast/references/methodology-m1-parser.md` (NEW), `methodology-m2-stack-detect.md` (NEW), `methodology-m3-emission.md` (NEW), `methodology-m4-manifest.md` (NEW), `methodology-m5-pr-creation.md` (NEW), `crates/sldo-install/tests/e2e_eng_imp_m2.rs` (NEW) |
+| Files to read before changing anything | `skills/slo-sast/SKILL.md`; all `references/sast/` files; `references/templates/citation-discipline.md` (M1) |
+| New files allowed | 5 methodology files + 1 test file |
+| New dependencies allowed | `none` |
+| Migration allowed | `no` |
+| Compatibility commitments | All security disciplines (argv-list, no `pull_request_target`, action-SHA pin, `pull_request` only, `permissions: {}`, no `--autofix`, symlink-traversal defense, manifest schema regex-validation, `gh pr create` no-`--repo`) preserved verbatim across decomposition |
+| Forbidden shortcuts | summarizing instead of moving prose; removing security disciplines; collapsing M1 + M2 contract content; mixing per-stage anti-patterns into the thin SKILL.md (only common-across-stage anti-patterns belong in SKILL.md) |
+| **Data classification** | `Public` |
+| **Proactive controls in play** | OWASP C1 (security requirements documented in methodology); C9 (audit trail via verbatim move + diff test) |
+| **Abuse acceptance scenarios** | `tm-eng-skill-improvements-abuse-1: SKILL.md decomposition breaks install-symlink chain` — class eliminated by structural-contract test that runs `cargo test -p sldo-install` against the post-decomposition tree |
+
+#### Out of Scope / Must Not Do
+
+- Modifying any `references/sast/` authority doc.
+- Changing any security discipline (argv-list, action SHAs, etc.).
+- Decomposing `/slo-tla` or `/slo-plan` (M3 / M4 jobs).
+- Adding new methodology content not present in the original SKILL.md.
+
+#### Pre-Flight
+
+1. Complete Global Entry Rules.
+2. Read M1's lessons file.
+3. Read current `skills/slo-sast/SKILL.md` end-to-end.
+4. Read all `references/sast/` files.
+5. Read `references/templates/citation-discipline.md` (M1).
+6. Plan the cut: identify which lines stay in SKILL.md vs land in each methodology file. Document the cut plan in M2 lessons.
+
+#### Files Allowed To Change
+
+| File | Planned Change |
+|---|---|
+| `skills/slo-sast/SKILL.md` | Reduce to: pre-flight (~10 lines), mode dispatch (~15 lines), anti-patterns common across stages (~10 lines), per-stage pointer table (~5 lines), See-also section (~5 lines). Total ≤ 100 lines. |
+| `skills/slo-sast/references/methodology-m1-parser.md` | Threat-model parser scope rule + process + empty-list behavior — verbatim from current M1 section |
+| `skills/slo-sast/references/methodology-m2-stack-detect.md` | Stack detection + registry fetch + rule filter — verbatim |
+| `skills/slo-sast/references/methodology-m3-emission.md` | Symlink-traversal defense + emission flow + workflow safety contract + CWE-list independence + M3 anti-patterns — verbatim |
+| `skills/slo-sast/references/methodology-m4-manifest.md` | Manifest schema v1.0 + preview-mode UX + rollback contract + M4 anti-patterns — verbatim |
+| `skills/slo-sast/references/methodology-m5-pr-creation.md` | Re-derivation triggers + `gh pr create` discipline + dogfood test + M5 anti-patterns — verbatim |
+| `crates/sldo-install/tests/e2e_eng_imp_m2.rs` | NEW: structural-contract test asserting prose preservation + install continuity + line-count cap |
+
+#### Step-by-Step
+
+1. Read the entire current SKILL.md and stage the decomposition mentally.
+2. Test stub first.
+3. Author the 5 methodology files (verbatim moves; diff-friendly).
+4. Slim SKILL.md to ≤ 100 lines.
+5. Verify prose-preservation test (concat all methodology files + new SKILL.md → must contain every line of old SKILL.md).
+6. Verify install symlink test passes.
+7. Smoke tests.
+8. Self-review.
+
+#### BDD Acceptance Scenarios
+
+**Feature: `/slo-sast` decomposed without prose loss**
+
+| Scenario | Category | Given | When | Then |
+|---|---|---|---|---|
+| Decomposition produces 5 methodology files | happy path | M2 closes | inspect skill dir | 5 methodology files present + valid frontmatter |
+| New SKILL.md ≤ 100 lines | happy path | M2 closes | `wc -l` SKILL.md | ≤ 100 lines |
+| Prose preservation | happy path | concat new SKILL.md + 5 methodology files | grep against pre-M2 SKILL.md baseline | every paragraph from baseline appears in concat |
+| Install symlinks unchanged | backward compatibility | `cargo test -p sldo-install` | runs | passes; `~/.claude/skills/slo-sast/` resolves to repo path |
+| Security discipline preserved (argv-list) | abuse case (`tm-eng-abuse-1` related) | grep methodology-m2 + m5 for "argv-list" | runs | both files contain the discipline |
+| Security discipline preserved (no `pull_request_target`) | abuse case | grep methodology-m3 for `pull_request_target` ban | runs | ban present |
+| Security discipline preserved (action SHAs) | abuse case | grep methodology-m3 for action-SHA pin rule | runs | rule present |
+| Symlink-traversal defense preserved (M3) | abuse case | grep methodology-m3 for "O_NOFOLLOW" or "symlink-traversal defense" | runs | rule present |
+| Manifest schema regex-validation preserved (M4) | abuse case | grep methodology-m4 | runs | regex-validation rule present |
+| `gh pr create` no-`--repo` preserved (M5) | abuse case | grep methodology-m5 | runs | rule present |
+| **Programmatic MUST-rule extraction (per critique S-2 + paradigm)** | structural | extract every `MUST` / `MUST NOT` line from baseline SKILL.md | runs | every extracted rule appears verbatim in (new SKILL.md ∪ methodology files); no rule lost |
+| Workflow-scope `permissions: {}` rule preserved | abuse case (paradigm: comprehensive enumeration) | grep methodology-m3 | runs | empty workflow-permissions rule present |
+| `actions/checkout` `fetch-depth: 0` rule preserved | abuse case | grep methodology-m3 | runs | rule present |
+| `semgrep ci` env-var-not-flag rule (`SEMGREP_RULES` not `--config`) preserved | abuse case | grep methodology-m3 | runs | rule present |
+| No-`secrets.*`-in-analysis-job rule preserved | abuse case | grep methodology-m3 | runs | rule present |
+| No-`--severity` rule preserved | abuse case | grep methodology-m3 | runs | rule present |
+| `serde_yaml_ng` strict-parse rule preserved (M2) | abuse case | grep methodology-m2 | runs | rule present |
+| 1 MiB YAML pre-parse cap preserved (M2) | abuse case | grep methodology-m2 | runs | cap present |
+| `git rev-parse HEAD` cache integrity preserved (M2) | abuse case | grep methodology-m2 | runs | rule present |
+| Default-fallback for empty stack detection preserved (M2) | abuse case | grep methodology-m2 | runs | rule present |
+| Atomic-write tempdir + rename preserved (M3 emission) | abuse case | grep methodology-m3 | runs | rule present |
+| File-content copy not symlink for dogfood fixture (M5) | abuse case | grep methodology-m5 | runs | ENG-6 rule present |
+| Soft-cap exception NOT used | structural | `wc -l` SKILL.md ≤ 100 | runs | passes without `# soft-cap-exception:` pragma |
+
+#### Regression Tests
+
+- `cargo test --workspace`.
+- All `references/sast/` files unmodified — `git diff` empty.
+- `/slo-sast` install symlink test.
+
+#### Compatibility Checklist
+
+- [ ] `~/.claude/skills/slo-sast/SKILL.md` symlink unchanged.
+- [ ] `~/.claude/skills/slo-sast/references/` subdirectory walks all 5 methodology files (sibling-install pattern).
+- [ ] Every security discipline preserved.
+- [ ] No behavior change in any `/slo-sast` invocation.
+
+#### E2E Runtime Validation
+
+**File**: `crates/sldo-install/tests/e2e_eng_imp_m2.rs`
+
+| E2E Test | What It Proves | Pass Criteria |
+|---|---|---|
+| `slo_sast_skill_md_at_or_under_100_lines` | Decomposition succeeded | `wc -l` ≤ 100 |
+| `methodology_files_exist_with_frontmatter` | 5 methodology files present | all 5 paths + frontmatter parses |
+| `prose_preservation_passes` | Every pre-M2 line is preserved somewhere | concat-and-diff against baseline |
+| `install_symlinks_resolve` | Install integrity | `cargo test -p sldo-install` passes |
+| `security_disciplines_preserved` | All key disciplines in their post-decomposition home | grep checks (8 specific disciplines) |
+
+#### Smoke Tests
+
+- [ ] Open `skills/slo-sast/SKILL.md`; confirm thin orchestrator readable in < 1 minute.
+- [ ] Open `methodology-m3-emission.md`; confirm workflow safety contract + symlink-traversal defense readable.
+- [ ] `cargo test -p sldo-install` passes.
+- [ ] `git status` clean.
+
+#### Evidence Log
+
+(Copy at execution time.)
+
+#### Definition of Done
+
+- All BDD scenarios pass.
+- `wc -l skills/slo-sast/SKILL.md` ≤ 100.
+- Prose preservation test passes.
+- Tracker + lessons + completion files written.
+
+#### Post-Flight
+
+- ARCHITECTURE.md update: note the per-skill-references decomposition pattern in the "References subtrees" section added in M1.
+- README.md: not required.
+
+#### Notes
+
+- The cut plan documented in pre-flight is itself valuable for M3 and M4 — same shape applied to `/slo-tla` and `/slo-plan`.
+
+---
+
+### Milestone 3 — `/slo-tla` decomposition + Apalache pin
+
+**Goal**: `/slo-tla/SKILL.md` reduced to ≤ 150 lines (prereq cascade + suitability gate + handoff + anti-patterns); per-stage methodology extracted to `references/methodology-elicitation.md`, `methodology-abstraction.md`, `methodology-counterexample.md`, `methodology-verified-design.md`. Apalache version + SHA-256 pinned in `tools.toml` alongside `tla2tools.jar`.
+
+**Context**: `/slo-tla/SKILL.md` is 323 lines. Methodology IS genuinely sequential (better justification for length than `/slo-sast`), but the abstraction balance / state-explosion triage / counterexample translation / verified-design doc shape are all inlined and could split cleanly.
+
+**Important design rule**: Same as M2 — move, don't summarize. The suitability gate ("is TLA+ the right tool here?") stays in SKILL.md; it's the cross-stage gate.
+
+**Refactor budget**: `Targeted refactor permitted for SKILL.md content extraction; verbatim moves`.
+
+#### Contract Block
+
+| Field | Value |
+|---|---|
+| Inputs | Existing `skills/slo-tla/SKILL.md` (323 lines); existing `tools.toml` with `tla2tools.jar` pin; Apalache release page |
+| Outputs | Thin SKILL.md (≤ 150 lines); 4 methodology files; updated `tools.toml` with Apalache version + SHA-256 |
+| Interfaces touched | SKILL.md content; new methodology subdirectory; `tools.toml` extension |
+| Files allowed to change | `skills/slo-tla/SKILL.md`, `skills/slo-tla/references/methodology-elicitation.md` (NEW), `methodology-abstraction.md` (NEW), `methodology-counterexample.md` (NEW), `methodology-verified-design.md` (NEW), `skills/slo-tla/tools.toml` (extend with Apalache pin), `crates/sldo-install/tests/e2e_eng_imp_m3.rs` (NEW) |
+| Files to read before changing anything | `skills/slo-tla/SKILL.md`; current `tools.toml`; https://github.com/apalache-mc/apalache/releases at runbook-author time |
+| New files allowed | 4 methodology files + 1 test file |
+| New dependencies allowed | `none` |
+| Migration allowed | `no` (Apalache pin is additive to `tools.toml`, not a replacement) |
+| Compatibility commitments | Suitability gate + state-explosion triage + abstraction balance prose preserved verbatim; existing `tla2tools.jar` pin unchanged |
+| Forbidden shortcuts | summarizing methodology; removing the suitability gate from SKILL.md; using a release tag URL for Apalache (must be SHA-256) |
+| **Data classification** | `Public` |
+| **Proactive controls in play** | C1 (security requirements documented; methodology files capture "what counts as verified"); C5 (validate inputs — Apalache binary integrity) |
+| **Abuse acceptance scenarios** | `tm-eng-skill-improvements-abuse-6: Apalache release-asset replaced upstream; SLO downloads tampered binary` — class eliminated by SHA-256 pin in `tools.toml` matching the runbook-author-time-captured value |
+
+#### Out of Scope / Must Not Do
+
+- Modifying TLA+ behavior or methodology semantics.
+- Touching `crates/sldo-tla-sha` (legacy maintenance utility per CLAUDE.md).
+- Decomposing `/slo-plan` (M4 job).
+
+#### Pre-Flight
+
+1. Complete Global Entry Rules.
+2. Read M1 + M2 lessons.
+3. Read current `skills/slo-tla/SKILL.md` end-to-end.
+4. Visit https://github.com/apalache-mc/apalache/releases at runbook-author time; capture latest stable release version + SHA-256 of the `apalache.zip` asset (or equivalent). Document in lessons file.
+5. Plan the cut.
+
+#### Files Allowed To Change
+
+| File | Planned Change |
+|---|---|
+| `skills/slo-tla/SKILL.md` | Reduce to: prereq cascade (verbatim, ~50 lines), suitability gate (~30 lines, stays in SKILL.md as cross-stage discipline), per-stage pointer table (~10 lines), anti-patterns common across stages (~20 lines), handoff (~10 lines). Total ≤ 150 lines. |
+| `skills/slo-tla/references/methodology-elicitation.md` | Q1-Q6 forcing questions + rejection patterns — verbatim |
+| `skills/slo-tla/references/methodology-abstraction.md` | Abstraction balance + state-explosion triage + state-space budget rule — verbatim |
+| `skills/slo-tla/references/methodology-counterexample.md` | Counterexample translation procedure + trace markdown shape — verbatim |
+| `skills/slo-tla/references/methodology-verified-design.md` | Verified-design doc shape + gates — verbatim |
+| `skills/slo-tla/tools.toml` | Extend with `[apalache]` section: `version`, `download_url`, `sha256` |
+| `crates/sldo-install/tests/e2e_eng_imp_m3.rs` | NEW: structural-contract test asserting (a) line-count cap, (b) prose preservation, (c) Apalache pin format (`sha256` is 64-char hex, `version` is non-empty) |
+
+#### Step-by-Step
+
+1. Apalache release version + SHA-256 capture (pre-flight).
+2. Test stub first.
+3. Author the 4 methodology files (verbatim moves).
+4. Slim SKILL.md to ≤ 150 lines.
+5. Extend `tools.toml` with the Apalache pin.
+6. Verify structural-contract test passes.
+7. Smoke tests.
+8. Self-review.
+
+#### BDD Acceptance Scenarios
+
+**Feature: `/slo-tla` decomposed; Apalache pinned**
+
+| Scenario | Category | Given | When | Then |
+|---|---|---|---|---|
+| New SKILL.md ≤ 150 lines | happy path | M3 closes | `wc -l` | ≤ 150 |
+| 4 methodology files exist | happy path | M3 closes | inspect dir | all 4 present + valid frontmatter |
+| Prose preservation | happy path | concat all methodology + new SKILL.md | grep vs baseline | every paragraph preserved |
+| Suitability gate stays in SKILL.md | happy path | inspect SKILL.md | grep for "Suitability gate" | match found |
+| Apalache pin in `tools.toml` | happy path | inspect tools.toml | parse | `[apalache]` section with `version`, `download_url`, `sha256` |
+| Apalache SHA-256 format | happy path | tools.toml | parse | `sha256` is 64-char hex |
+| Tampered Apalache release | abuse case (`tm-eng-abuse-6`) | local Apalache asset SHA differs from pin | skill prereq cascade runs | refuse with clear stderr |
+| Backward compat: `tla2tools.jar` pin unchanged | backward compatibility | M3 closes | tools.toml | `[tla2tools]` section unchanged |
+| Install symlinks resolve | backward compatibility | `cargo test -p sldo-install` | runs | passes |
+
+#### Regression Tests
+
+- `cargo test --workspace`.
+- All `references/sast/` files unmodified.
+- `/slo-tla` install symlink test.
+- M2's structural-contract test still passes.
+
+#### Compatibility Checklist
+
+- [ ] `tla2tools.jar` pin unchanged.
+- [ ] Suitability gate still in SKILL.md.
+- [ ] Prereq cascade order preserved.
+- [ ] No behavior change in any `/slo-tla` invocation.
+
+#### E2E Runtime Validation
+
+**File**: `crates/sldo-install/tests/e2e_eng_imp_m3.rs`
+
+| E2E Test | What It Proves | Pass Criteria |
+|---|---|---|
+| `slo_tla_skill_md_at_or_under_150_lines` | Decomposition succeeded | `wc -l` ≤ 150 |
+| `methodology_files_exist` | 4 methodology files present | all 4 paths + frontmatter |
+| `apalache_pin_in_tools_toml` | Pin present + valid format | TOML parse succeeds + `sha256` is 64-char hex + `version` non-empty |
+| `prose_preservation` | Every pre-M3 line preserved | concat-and-diff |
+| `suitability_gate_in_skill_md` | Cross-stage gate stayed | grep match |
+| `install_symlinks_resolve` | Install integrity | `cargo test -p sldo-install` passes |
+
+#### Smoke Tests
+
+- [ ] Open new `skills/slo-tla/SKILL.md`; readable in < 90 seconds.
+- [ ] Open `methodology-abstraction.md`; state-explosion triage + abstraction balance preserved.
+- [ ] `tools.toml` parses as valid TOML.
+- [ ] `cargo test -p sldo-install` passes.
+
+#### Evidence Log
+
+(Copy at execution time.)
+
+#### Definition of Done
+
+- All BDD scenarios pass.
+- `wc -l` ≤ 150.
+- Apalache pin captured at runbook-author time and recorded.
+- Tracker + lessons + completion files written.
+
+#### Post-Flight
+
+- ARCHITECTURE.md update: extend "References subtrees" section.
+- README.md: not required.
+
+#### Notes
+
+- Apalache version refresh cadence: re-capture annually (parallel to other authority-file refresh patterns). Not a milestone; documented in lessons file.
+
+---
+
+### Milestone 4 — `/slo-plan` decomposition + soft line-cap structural-contract test
+
+**Goal**: `/slo-plan/SKILL.md` per-milestone authoring sub-procedure extracted to `references/methodology-milestone-authoring.md`. Soft line-cap structural-contract test added: every SKILL.md must be ≤ 200 lines OR carry a `# soft-cap-exception: <reason>` frontmatter pragma.
+
+**Context**: `/slo-plan/SKILL.md` is 132 lines today, mostly because Step 2's "for each milestone, sequentially" 15-step sub-procedure is inlined. Extraction is straightforward; the structural-contract test is the discipline-anchor for future SKILL.md authors.
+
+**Important design rule**: Soft cap is 200 lines (review's recommendation); exceptions require explicit `# soft-cap-exception: <reason>` pragma. CI flags exceptions for human review.
+
+**Refactor budget**: `Targeted refactor permitted for SKILL.md content extraction + soft-cap test addition`.
+
+#### Contract Block
+
+| Field | Value |
+|---|---|
+| Inputs | Existing `skills/slo-plan/SKILL.md`; M2 + M3 decomposition outputs |
+| Outputs | Slim SKILL.md (≤ 80 lines projected); `references/methodology-milestone-authoring.md` (NEW); soft line-cap structural-contract test |
+| Interfaces touched | `/slo-plan` SKILL.md content; new structural-contract test |
+| Files allowed to change | `skills/slo-plan/SKILL.md`, `skills/slo-plan/references/methodology-milestone-authoring.md` (NEW), `crates/sldo-install/tests/e2e_eng_imp_m4.rs` (NEW) |
+| Files to read before changing anything | `skills/slo-plan/SKILL.md`; M2 + M3 decomposition lessons |
+| New files allowed | 1 methodology file + 1 test file |
+| New dependencies allowed | `none` |
+| Migration allowed | `no` |
+| Compatibility commitments | Discipline rule "NEVER generate a whole runbook in one shot" stays in SKILL.md; gates + anti-patterns stay in SKILL.md; only Step 2's sub-procedure moves |
+| Forbidden shortcuts | reducing SKILL.md below the discipline threshold (must keep the one-shot-refusal rule and the gates); soft-cap exception without reason; bypassing the structural-contract test |
+| **Data classification** | `Public` |
+| **Proactive controls in play** | C1 (security requirements documented in methodology); C9 (audit trail via structural-contract test) |
+| **Abuse acceptance scenarios** | `tm-eng-skill-improvements-abuse-3: soft line-cap exception abused to bypass decomposition` — mitigated by requiring `# soft-cap-exception: <reason>` pragma + CI flagging exceptions for human review |
+
+#### Out of Scope / Must Not Do
+
+- Modifying `/slo-plan` behavior or the v3 runbook template (template's "Carry-forward from prior retros" addition is R1 M4's job).
+- Adding new gates beyond what the soft-cap test asserts.
+
+#### Pre-Flight
+
+1. Complete Global Entry Rules.
+2. Read M1, M2, M3 lessons.
+3. Read current `skills/slo-plan/SKILL.md` end-to-end.
+4. Plan the cut.
+
+#### Files Allowed To Change
+
+| File | Planned Change |
+|---|---|
+| `skills/slo-plan/SKILL.md` | Slim to: discipline rule (NEVER one-shot), inputs / outputs, gates, anti-patterns, handoff. Step 2's per-milestone sub-procedure replaced with one-line cite to methodology file. Total ≤ 80 lines projected. |
+| `skills/slo-plan/references/methodology-milestone-authoring.md` | NEW: 15-step per-milestone authoring procedure verbatim from current SKILL.md Step 2. Required Contract Block rows + abuse-case examples + Vocabulary references kept. |
+| `crates/sldo-install/tests/e2e_eng_imp_m4.rs` | NEW: structural-contract test asserting (a) every SKILL.md ≤ 200 lines OR has `# soft-cap-exception:` pragma; (b) any pragma's reason is non-empty; (c) `methodology-milestone-authoring.md` exists with valid frontmatter; **(d, paradigm: extend the cap discipline) every methodology file under `skills/<skill>/references/` ≤ 500 lines OR has `# methodology-cap-exception:` pragma**; **(e) every reference under `references/templates/` ≤ 300 lines OR has `# template-cap-exception:` pragma** (templates should stay tight; long detail belongs in domain-specific authority files) |
+
+#### Step-by-Step
+
+1. Test stub first.
+2. Author `methodology-milestone-authoring.md` (verbatim move).
+3. Slim SKILL.md.
+4. Add soft-cap structural-contract test.
+5. Audit existing SKILL.md files: which exceed 200 lines? After M2 + M3, only those with legitimate reasons remain. Add `# soft-cap-exception: <reason>` pragma where needed.
+6. Verify all tests pass.
+7. Smoke tests.
+8. Self-review.
+
+#### BDD Acceptance Scenarios
+
+**Feature: `/slo-plan` decomposed; soft line-cap enforced**
+
+| Scenario | Category | Given | When | Then |
+|---|---|---|---|---|
+| New SKILL.md ≤ 80 lines | happy path | M4 closes | `wc -l skills/slo-plan/SKILL.md` | ≤ 80 |
+| Methodology file exists | happy path | M4 closes | inspect | file present + valid frontmatter |
+| Soft-cap test rejects > 200 line SKILL.md without pragma | happy path | a hypothetical SKILL.md with 250 lines and no pragma | test runs | test FAILS with "soft cap exceeded; add `# soft-cap-exception: <reason>`" |
+| Soft-cap test accepts > 200 line SKILL.md with pragma + reason | happy path | SKILL.md with pragma + non-empty reason | test runs | test passes; CI flags for human review |
+| Pragma without reason | abuse case (`tm-eng-abuse-3`) | SKILL.md with `# soft-cap-exception: ` (empty reason) | test runs | test FAILS with "exception reason required" |
+| All existing SKILL.md pass | backward compatibility | post-M2/M3 tree | test runs over every SKILL.md | all pass (decomposed ones ≤ 200; un-decomposed ones either ≤ 200 or have pragma) |
+| Discipline rule preserved | happy path | new SKILL.md | grep for "NEVER generate a whole runbook" | match found |
+
+#### Regression Tests
+
+- `cargo test --workspace`.
+- M1, M2, M3 structural-contract tests.
+- `/slo-plan` install symlink test.
+
+#### Compatibility Checklist
+
+- [ ] All existing SKILL.md install.
+- [ ] Discipline rules preserved in SKILL.md.
+- [ ] No skill behavior change.
+
+#### E2E Runtime Validation
+
+**File**: `crates/sldo-install/tests/e2e_eng_imp_m4.rs`
+
+| E2E Test | What It Proves | Pass Criteria |
+|---|---|---|
+| `slo_plan_skill_md_decomposed` | Decomposition done | `wc -l` ≤ 80 |
+| `methodology_milestone_authoring_exists` | New methodology file present | path + frontmatter |
+| `soft_line_cap_test_runs_for_every_skill_md` | Cap test is enabled | iterate `skills/*/SKILL.md`; assert ≤ 200 OR pragma |
+| `pragma_reason_required` | Reason cannot be empty | parse pragma; reason non-empty |
+
+#### Smoke Tests
+
+- [ ] Open new `skills/slo-plan/SKILL.md`; readable in < 60 seconds.
+- [ ] Run `wc -l skills/*/SKILL.md` to inventory; confirm post-M2/M3 tree compliant.
+- [ ] `cargo test -p sldo-install` passes.
+
+#### Evidence Log
+
+(Copy at execution time.)
+
+#### Definition of Done
+
+- All BDD scenarios pass.
+- Soft line-cap test runs against every SKILL.md.
+- Tracker + lessons + completion files written.
+
+#### Post-Flight
+
+- ARCHITECTURE.md update: extend "References subtrees" section.
+- README.md: optional bullet about the discipline.
+
+#### Notes
+
+- The soft-cap test will catch future SKILL.md drift; this is the structural defense against re-monolithization.
+
+---
+
+### Milestone 5 — Per-skill `evals/` infrastructure + `/slo-freeze` PreToolUse hook + cross-skill polish
+
+**Goal**: Per-skill `evals/<case>.md` files for the highest-risk skills (advisors + sast + tla + execute + verify); `.claude/settings.json` PreToolUse hook hard-enforcing `/slo-freeze` scope; cross-skill polish items from [Issue #22](https://github.com/kerberosmansour/SunLitOrchestrate/issues/22) E5.
+
+**Context**: This milestone is the "polish + infrastructure layer". Eval cases are documented expectations until the runtime harness ships (deferred-follow-up in [Issue #4](https://github.com/kerberosmansour/SunLitOrchestrate/issues/4)). The PreToolUse hook closes the prose-level-discipline-only gap on `/slo-freeze`.
+
+**Important design rule**: PreToolUse hook is **opt-in per-project**, not global. Project-level `.claude/settings.json`. Mutation via the existing `update-config` skill — no parallel mutation surface.
+
+**Refactor budget**: `Minimal local refactor permitted in listed files only`.
+
+#### Contract Block
+
+| Field | Value |
+|---|---|
+| Inputs | M1's `references/templates/eval-cases.md`; M2 + M3 + M4 decomposed skills; `update-config` skill (existing); per-skill review eval cases (from 2026-04-27 review) |
+| Outputs | `skills/<skill>/evals/<case>.md` per high-risk skill; `.claude/settings.json` PreToolUse hook + `references/freeze/hook-setup.md`; SKILL.md prose updates for `/slo-freeze`, `/slo-second-opinion`, `get-api-docs`, `/slo-research`, `/slo-talk-to-users`, `/slo-verify` |
+| Interfaces touched | New `skills/<skill>/evals/` subdirectories; new `.claude/settings.json` hook; SKILL.md prose updates |
+| Files allowed to change | `skills/{slo-legal,slo-accounting,slo-equity,slo-fundraise,slo-hire,slo-sast,slo-tla,slo-execute,slo-verify,slo-rulegen,slo-ruleverify,slo-research,slo-architect,slo-plan,slo-talk-to-users,slo-founder-check}/evals/<case>.md` (NEW), `.claude/settings.json` (NEW or extend), `references/freeze/hook-setup.md` (NEW), `skills/slo-freeze/SKILL.md`, `skills/slo-second-opinion/SKILL.md`, `skills/get-api-docs/SKILL.md`, `skills/slo-research/SKILL.md`, `skills/slo-talk-to-users/SKILL.md`, `skills/slo-verify/SKILL.md`, `references/biz/consent-script-uk.md` (NEW), `crates/sldo-install/tests/e2e_eng_imp_m5.rs` (NEW) |
+| Files to read before changing anything | M1's `references/templates/eval-cases.md`; existing `update-config` skill; the 2026-04-27 review's "Suggested eval cases" sections per skill |
+| New files allowed | per-skill eval files; `.claude/settings.json`; `references/freeze/hook-setup.md`; `references/biz/consent-script-uk.md`; the test file |
+| New dependencies allowed | `none` (the PreToolUse hook is a small shell script invoked by Claude Code; no new crates) |
+| Migration allowed | `no` |
+| Compatibility commitments | Existing SKILL.md prose unchanged outside the named files; `update-config` skill unchanged; existing settings.json (if any) preserved |
+| Forbidden shortcuts | global settings mutation; bypassing `update-config` skill; eval-case files without frontmatter; PreToolUse hook that shells out without argv-list |
+| **Data classification** | `Internal` (eval cases may include adversarial inputs that look like attacker payloads) |
+| **Proactive controls in play** | C1 (security requirements via citation-discipline + eval-cases); C5 (validate inputs — eval cases test input validation); C7 (access controls — PreToolUse hook is execution-control); C9 (audit trail — eval cases are documentation) |
+| **Abuse acceptance scenarios** | `tm-eng-skill-improvements-abuse-2: PreToolUse hook bypassed via session-state file deletion` — residual; documented as "this is not a security boundary" disclaimer in `/slo-freeze` SKILL.md description; the hook is a discipline-enforcer, not a security primitive |
+
+#### Out of Scope / Must Not Do
+
+- Building the runtime Claude Code harness for executable evals (deferred-follow-up in [Issue #4](https://github.com/kerberosmansour/SunLitOrchestrate/issues/4)).
+- Extending the `update-config` skill.
+- Adding new skill behavior beyond the named polish items.
+- Auto-extending the `/slo-execute` allow-list via PreToolUse hook (out-of-scope per [Issue #22](https://github.com/kerberosmansour/SunLitOrchestrate/issues/22) — the optional hook for execute is opt-in only).
+
+#### Pre-Flight
+
+1. Complete Global Entry Rules.
+2. Read M1-M4 lessons.
+3. Read M1's `references/templates/eval-cases.md`.
+4. Read 2026-04-27 review per-skill "Suggested eval cases" sections.
+5. Read the existing `update-config` skill behavior.
+6. Read [Issue #22](https://github.com/kerberosmansour/SunLitOrchestrate/issues/22) E5 polish items.
+
+#### Files Allowed To Change
+
+(See contract block above; per-skill eval files are batched.)
+
+| File class | Planned Change |
+|---|---|
+| Per-skill `evals/<case>.md` (**per paradigm**: ALL 32 skills × **11 case categories** × ≥ 2 examples each ≈ 700 documented-expectation files) | NEW: documented expectations following M1's eval-cases.md shape. Categories: happy-path, missing-context, ambiguous-input, adversarial (×2: prompt-injection + predicate-gaming), outdated-information, tool-failure, high-risk-case, refusal-on-ambiguity, restate-and-confirm, citation-verification, multi-layer-defense. Per critique E-1's reduce-scope ask: NOT taken — paradigm absorbs the work. |
+| `.claude/settings.json` | NEW (or extend): PreToolUse hook for `Edit`, `Write`, `NotebookEdit` consulting `~/.sldo/freeze-scope.txt` |
+| `references/freeze/hook-setup.md` | NEW: opt-in setup procedure; cites `update-config` skill |
+| `skills/slo-freeze/SKILL.md` | Add "this is not a security boundary" disclaimer; cite `references/freeze/hook-setup.md` |
+| `skills/slo-second-opinion/SKILL.md` | Add "neither response is verified" disclaimer; minimum CLI versions documented |
+| `skills/get-api-docs/SKILL.md` | Add "if `chub search` returns nothing, do NOT fall back to training memory" rule; `chub get` failure-mode guidance |
+| `skills/slo-research/SKILL.md` | Require `sldo-research --help` capture before dispatch; cite `references/templates/tool-safety-section.md` |
+| `skills/slo-talk-to-users/SKILL.md` | Specify exact git commands for git-tracked-+remote-+confidential check; cite `references/biz/consent-script-uk.md` |
+| `skills/slo-verify/SKILL.md` | Add Pass 4 capitalised-bigram FP triage flow (cite `references/templates/escalation.md`); add "every scanned artifact appears as pass/fail/skipped/N/A" requirement |
+| `references/biz/consent-script-uk.md` | NEW: GDPR-compliant interview consent script under legitimate-interest |
+| `crates/sldo-install/tests/e2e_eng_imp_m5.rs` | NEW: structural-contract test asserting eval files exist, hook setup doc exists, SKILL.md prose updates landed |
+
+#### Step-by-Step
+
+1. Test stub first.
+2. Author `references/biz/consent-script-uk.md` (small).
+3. Author `references/freeze/hook-setup.md` with the opt-in procedure.
+4. Update the 6 SKILL.md files (`slo-freeze`, `slo-second-opinion`, `get-api-docs`, `slo-research`, `slo-talk-to-users`, `slo-verify`).
+5. Author `.claude/settings.json` PreToolUse hook (minimal shell script reading `~/.sldo/freeze-scope.txt`; argv-list discipline).
+6. Author per-skill `evals/` directories. For each high-risk skill, write the 7 case shapes per M1's `eval-cases.md` template. For skills where a category genuinely doesn't apply, write a one-line rationale rather than a stub.
+7. Verify structural-contract test passes.
+8. Manual smoke: invoke `/slo-freeze`, attempt out-of-scope edit, verify hook blocks.
+9. Self-review.
+
+#### BDD Acceptance Scenarios
+
+**Feature: per-skill evals + PreToolUse hook + cross-skill polish**
+
+| Scenario | Category | Given | When | Then |
+|---|---|---|---|---|
+| Per-skill evals exist for high-risk skills | happy path | M5 closes | inspect `skills/<skill>/evals/` | each high-risk skill has ≥ 1 eval case file (the 7 categories where applicable) |
+| Eval files have valid frontmatter | happy path | M5 closes | parse each | frontmatter parses; `skill`, `case-name`, `category`, `expected-behavior` fields present |
+| `.claude/settings.json` hook present | happy path | M5 closes | parse JSON | `PreToolUse` array contains hook for `Edit`, `Write`, `NotebookEdit` |
+| Hook reads `~/.sldo/freeze-scope.txt` | happy path | hook configured | edit attempt outside scope | hook blocks with non-zero exit + clear message |
+| Hook absent: skill prose-level fallback | backward compatibility | hook not yet configured | `/slo-freeze` invoked | works prose-level (existing behavior) |
+| `/slo-freeze` SKILL.md describes "not a security boundary" | happy path | M5 closes | grep SKILL.md | match found |
+| Pass 4 FP triage flow documented | happy path | M5 closes | grep `slo-verify/SKILL.md` for "capitalised-bigram" + "tier_override_reason" | match found with example |
+| `chub` failure mode documented | happy path | M5 closes | grep `get-api-docs/SKILL.md` | "do NOT fall back to training memory" rule present |
+| `sldo-research --help` capture documented | happy path | M5 closes | grep `slo-research/SKILL.md` | capture-before-dispatch rule present |
+| `slo-talk-to-users` git commands explicit | happy path | M5 closes | grep `slo-talk-to-users/SKILL.md` | `git rev-parse --git-dir` and `git remote -v` present |
+| Consent script exists | happy path | M5 closes | inspect `references/biz/consent-script-uk.md` | file present + GDPR legitimate-interest framing |
+| Hook bypassed via session-state deletion | abuse case (`tm-eng-abuse-2`) | adversary deletes `~/.sldo/freeze-scope.txt` | hook fires | hook treats missing file as "no freeze active"; behavior reverts to unenforced; documented as residual + "not a security boundary" |
+| Argv-list in hook | abuse case (per critique E-6) | hook script content | structural-contract test grep for shell-string patterns (`bash -c "..."`, `sh -c "..."`, `eval`) | no matches; hook uses argv-list / `[[ -f ... ]]` shell builtins only |
+| `update-config` invocation is additive only (per critique S-4) | abuse case | settings.json modification request | inspect mutation | `PreToolUse` array extended, never overwritten; existing entries preserved |
+
+#### Regression Tests
+
+- `cargo test --workspace`.
+- M1-M4 structural-contract tests.
+- All existing SKILL.md install symlink tests.
+- `update-config` skill unchanged.
+
+#### Compatibility Checklist
+
+- [ ] No skill behavior change beyond named polish items.
+- [ ] PreToolUse hook is opt-in (existing repos without it work).
+- [ ] All existing SKILL.md prose preserved (only the 6 named files updated).
+- [ ] No new runtime dependencies.
+
+#### E2E Runtime Validation
+
+**File**: `crates/sldo-install/tests/e2e_eng_imp_m5.rs`
+
+| E2E Test | What It Proves | Pass Criteria |
+|---|---|---|
+| `every_high_risk_skill_has_evals_dir` | Eval coverage for the 16 named skills | each path exists |
+| `eval_files_have_valid_frontmatter` | Frontmatter shape | `skill`, `case-name`, `category`, `expected-behavior` parse for each |
+| `claude_settings_pretooluse_hook_present` | Hook installed | JSON parse + `PreToolUse` array contains the hook |
+| `freeze_hook_setup_doc_exists` | Setup doc present | path + frontmatter |
+| `polish_items_landed` | 6 SKILL.md polish items applied | grep checks per item |
+| `consent_script_exists` | Consent script present | path + GDPR framing in body |
+
+#### Smoke Tests
+
+- [ ] Manually invoke `/slo-freeze skills/slo-sast`; attempt to edit `skills/slo-tla/SKILL.md`; verify PreToolUse hook blocks.
+- [ ] Manually invoke `/slo-freeze` with hook absent; observe prose-level fallback.
+- [ ] Open `references/biz/consent-script-uk.md`; verify renders.
+- [ ] `cargo test -p sldo-install` passes.
+
+#### Evidence Log
+
+(Copy at execution time.)
+
+#### Definition of Done
+
+- All BDD scenarios pass.
+- Per-skill evals exist for every high-risk skill (or rationale for non-applicable categories).
+- PreToolUse hook installed, tested, documented as opt-in.
+- 6 SKILL.md polish items landed.
+- Tracker + lessons + completion files written.
+
+#### Post-Flight
+
+- ARCHITECTURE.md update: add a "Hooks and evals" subsection mentioning the PreToolUse hook + evals/ pattern.
+- README.md update: add an "evals" pointer in the docs index.
+
+#### Notes
+
+- The runtime harness for executable evals is deferred to a separate runbook (per [Issue #4](https://github.com/kerberosmansour/SunLitOrchestrate/issues/4) follow-ups). Eval cases here are documented expectations + manual run.
+
+---
+
+## Documentation Update Table
+
+| Milestone | ARCHITECTURE.md Update | README.md Update | .gitignore Update | Other Docs |
+|---|---|---|---|---|
+| 1 | "References subtrees" subsection: list `references/templates/` | Optional bullet | none | 5 SKILL.md cross-references |
+| 2 | "Per-skill references" pattern note | none | none | `skills/slo-sast/references/` (new files) |
+| 3 | Same | none | none | `skills/slo-tla/references/` + `tools.toml` extension |
+| 4 | Soft line-cap discipline note | Optional bullet | none | `skills/slo-plan/references/` (new file) |
+| 5 | "Hooks and evals" subsection | Optional bullet | `.gitignore` for `~/.sldo/freeze-scope.txt` (if local-state file is created in target repos) | per-skill `evals/`; `references/freeze/hook-setup.md`; `references/biz/consent-script-uk.md` |
+
+---
+
+## Optional Fast-Fail Review Prompt for Agents
+
+> Restate the milestone goal, allowed files, forbidden changes, compatibility requirements, tests that must be written first, and the exact Definition of Done. Then list the smallest implementation approach that satisfies the contract without widening scope.
+
+---
+
+## Carry-forward from prior retros
+
+(Empty until R1 M3 ships and `/slo-retro` files lessons as issues.)
+
+| Issue | Title | Suggested milestone | Status |
+|---|---|---|---|
+| (none yet) | | | |
+
+---
+
+## Paradigm-driven enhancements (per `docs/PARADIGM-OVER-ENGINEERING-FOR-SIMPLICITY.md`)
+
+This runbook applies the over-engineering-for-simplicity paradigm at the engineering-skill scale. The LLM-driven engineering pipeline absorbs more discipline than a human-driven equivalent because the agent does not pay the cognitive-load tax. Specific layers added because the LLM is the executor:
+
+### Templates library expanded from 8 → 11 (M1)
+
+Original M1 listed 8 shared templates. Paradigm-driven additions:
+
+- `references/templates/rate-limiting-discipline.md` — formalizes the per-session cap pattern shared by R1 M3, R4 M4, and any future remote-calling skill. Rather than each skill re-deriving the discipline, it lives in one place.
+- `references/templates/fallback-discipline.md` — graceful-degradation as a first-class pattern. Captures `LESSONS-BACKLOG.md`, `~/.cache/sldo/`, cost-baseline-staleness, and other fallback patterns that already exist scattered across the pack.
+- `references/templates/version-pinning-discipline.md` — formalizes SHA-256 vs tag vs branch trade-offs across `/slo-sast` action-SHA pin, `/slo-tla` `tla2tools.jar` pin, R4's CycloneDX declarations SHA pin, R3's cost-baseline retrieval-date stamps.
+
+A human team would resist 11 templates as bloat; the LLM pipeline composes from them at runtime with no marginal cost.
+
+### Source-verification scope expanded (M1)
+
+Critique E-2 surfaced that the M1 spike's "5 representative claims" was too small. Paradigm-driven correction (already applied in M1 pre-flight): full verification of all ~25 security-engineering claims is folded into M2/M3/M4 per-milestone evidence-log work. The spike validates the discipline; the comprehensive verification is across the runbook, not deferred.
+
+### Programmatic MUST-rule extraction (M2 + M3)
+
+Critique S-2 surfaced that the prose-preservation BDD's hand-written security-discipline list could drift. Paradigm-driven correction: M2 + M3 BDD now extracts every `MUST` / `MUST NOT` line from the baseline SKILL.md programmatically and asserts each appears verbatim in (new SKILL.md ∪ methodology files). 14 specific disciplines now enumerated in M2's BDD table (was 6); same comprehensive coverage in M3.
+
+### Soft-cap discipline extended to references (M4)
+
+Original M4 capped SKILL.md at 200 lines. Paradigm-driven extension: methodology files capped at 500 lines; templates capped at 300 lines (because templates should stay tight; long detail belongs in domain authority files). Each cap respects context-window practicality; combined, they prevent re-monolithization at any layer of the reference tree.
+
+### Comprehensive eval coverage (M5)
+
+Critique E-1 proposed reducing M5 evals to "highest-risk only (9 skills)". Paradigm-driven correction: NOT taken. ALL 32 skills × 11 case categories × ≥ 2 examples ≈ 700 documented-expectation files. Bounded by context window via on-demand loading (the runtime harness — when it ships — loads one eval at a time), not by author tedium. Plus 4 new categories beyond the original 7:
+
+- `refusal-on-ambiguity` — catches the third state of gate evaluation
+- `restate-and-confirm` — catches drift in the conversational pattern
+- `citation-verification` — catches paraphrased-not-quoted statute / heuristic / KPI claims
+- `multi-layer-defense` — validates that the 4 defense layers are present for the skill's primary risk class
+
+Plus `expected_refusal_text:` field on every eval case so future runtime harness can byte-compare phrasing.
+
+### Defense-in-depth across milestones
+
+| Concern | Layer 1 | Layer 2 | Layer 3 | Layer 4 |
+|---|---|---|---|---|
+| SKILL.md drift after decomposition | Programmatic MUST-rule extraction (M2+M3 BDD) | Prose-preservation diff (M2+M3 BDD) | Install-symlink continuity (M2+M3 BDD) | Soft-cap structural-contract test (M4) catches re-monolithization |
+| Citation hallucination | Source hierarchy in `citation-discipline.md` (M1) | Bright-line "unverifiable claims removed not weakened" (M1) | Per-claim `last_checked:` discipline (M1) | Cross-skill citation tests (M5) |
+| Allow-list / freeze enforcement | Prose-level discipline in `/slo-execute` SKILL.md | `/slo-freeze` prose-level scope lock (existing) | PreToolUse hook (M5, opt-in) | Soft-cap-exception pragma audit (M4) catches drift |
+| Eval coverage drift | Per-skill `evals/` directory (M5) | 11 case categories per skill | ≥ 2 examples per category | `expected_refusal_text:` field for byte-compare |
+| Settings.json mutation safety | `update-config` skill is canonical mutation surface (M5) | Additive-only `PreToolUse` array extension (per critique S-4) | Hook-script argv-list test (per critique E-6) | Project-level scope (no global mutation) |
+
+### Bounded by context-window
+
+The paradigm's discipline-vs-context-window balance is enforced structurally: SKILL.md ≤ 200 lines (M4), methodology files ≤ 500 lines (M4 extension), templates ≤ 300 lines (M4 extension), eval cases small (~50-100 lines each), references in `references/sast/` and `references/biz/` can be unbounded (consulted by file:section, not read end-to-end).
+
+### Ask items still open from critique
+
+The paradigm doesn't auto-resolve every critique ask. Still open:
+- E-3: PreToolUse hook framing — confirm "discipline-enforcer for honest mistakes, not adversarial bypass"
+- E-5: include `/slo-architect` in M2 decomposition wave (line count check needed)
+- S-3: hook fail-closed when session-state file unexpectedly missing during active freeze

--- a/docs/RUNBOOK-LOOPS-AND-LESSONS-CLOSURE.md
+++ b/docs/RUNBOOK-LOOPS-AND-LESSONS-CLOSURE.md
@@ -1,6 +1,6 @@
 # Loops + Lessons Closure — SunLitOrchestrate (AI-First Runbook v3)
 
-> **Purpose**: Make engineering loops and business loops first-class artifacts; extend `/slo-retro` to file lessons as tracked issues; close the loop at milestone start so prior-retro issues become scope candidates for the current milestone.
+> **Purpose**: Make engineering loops and business loops first-class artifacts; extend `/slo-retro` to file lessons as tracked issues; close the loop at milestone start so prior-retro issues become scope candidates for the current milestone; and make "what do I do next?" a first-class answer via the existing `/slo-resume` entrypoint.
 > **Audience**: AI coding agents first, humans second.
 > **How to use**: Work through milestones sequentially. Before starting any milestone, read its full section and the Global Execution Rules. After completing it, follow the Global Exit Rules.
 > **Prerequisite reading**: [ARCHITECTURE.md](../ARCHITECTURE.md), [docs/design/loops-and-lessons-closure-overview.md](design/loops-and-lessons-closure-overview.md), [docs/idea/loops-and-lessons-closure.md](idea/loops-and-lessons-closure.md), [docs/research/loops-and-lessons-closure/synthesis.md](research/loops-and-lessons-closure/synthesis.md), [Issue #16](https://github.com/kerberosmansour/SunLitOrchestrate/issues/16), [Issue #17](https://github.com/kerberosmansour/SunLitOrchestrate/issues/17), [Issue #18](https://github.com/kerberosmansour/SunLitOrchestrate/issues/18)
@@ -25,6 +25,7 @@
   - `docs/lessons/<prefix>-m<N>.md` template
   - `skills/slo-retro/SKILL.md` Outputs contract (additive only)
   - `skills/slo-execute/SKILL.md` Pre-flight contract (additive only)
+  - `skills/slo-resume/SKILL.md` read-only orientation contract (additive only)
 
 ---
 
@@ -35,7 +36,8 @@
 | 1 | LOOPS-ENGINEERING.md authored + cross-linked | `not_started` | | | | |
 | 2 | LOOPS-BUSINESS.md authored + cross-linked | `not_started` | | | | |
 | 3 | `/slo-retro` extension: classify, dedupe, file lessons as issues | `not_started` | | | | |
-| 4 | `/slo-execute` pre-flight loop closure + runbook template "Carry-forward from prior retros" section | `not_started` | | | | |
+| 4 | `/slo-execute` pre-flight loop closure + runbook template "Carry-forward from prior retros" section with suggested lane | `not_started` | | | | |
+| 5 | `/slo-resume` next-step digest + lane-aware orientation | `not_started` | | | | |
 
 ---
 
@@ -85,6 +87,13 @@
 │              │ (M4 EXTENDED)                         │                      │
 │              │   gh issue list --label retro-derived │                      │
 │              │   surface as scope candidates         │                      │
+│              └──────────────┬───────────────────────┘                      │
+│                             │                                              │
+│                             ▼                                              │
+│              ┌──────────────────────────────────────┐                      │
+│              │ /slo-resume (M5 EXTENDED)           │                      │
+│              │ reads tracker + carry-forward lane  │                      │
+│              │ emits one next action               │                      │
 │              └──────────────────────────────────────┘                      │
 │                                                                            │
 │  Legend:  ─── existing    - - - new (this runbook)    ▶ data flow         │
@@ -100,7 +109,8 @@
 | `skills/slo-retro/SKILL.md` | Extended: classify each lesson, dedupe via `gh search`, file with confirmation | M3 EXTENDED | Existing lessons-file output preserved; issue filing additive |
 | `skills/slo-retro/references/issue-filing-discipline.md` | argv-list + dedupe + rate-limit + fallback | M3 NEW | Cited from SKILL.md |
 | `skills/slo-execute/SKILL.md` | Extended: pre-flight reads open prior-retro issues for this runbook's prefix | M4 EXTENDED | Existing pre-flight steps preserved; issue read additive |
-| `docs/runbook-template_v_3_template.md` | New optional "Carry-forward from prior retros" section | M4 EXTENDED | Read by `/slo-plan` and `/slo-resume` |
+| `docs/runbook-template_v_3_template.md` | New optional "Carry-forward from prior retros" section with suggested lane | M4 EXTENDED | Read by `/slo-plan` and `/slo-resume` |
+| `skills/slo-resume/SKILL.md` | Extended: reads tracker + carry-forward section, emits one next action and lane | M5 EXTENDED | Read-only orientation contract preserved; no state mutation |
 | `LESSONS-BACKLOG.md` | Local fallback for repos without `gh` available | M3 NEW | Append-only rows |
 
 ### Data Flow Summary
@@ -112,6 +122,7 @@
 | Issue creation | `/slo-retro` (with user confirmation) | GitHub OR LESSONS-BACKLOG.md | `gh issue create` argv-list OR file append | M3 |
 | Pre-flight loop closure | `/slo-execute` pre-flight | GitHub | `gh issue list` argv-list (read-only) | M4 |
 | Carry-forward surfacing | `/slo-execute` | Founder/operator console | Stdout prose | M4 |
+| Next-step orientation | `/slo-resume` | Founder/operator console | Read-only tracker + carry-forward summary | M5 |
 
 ---
 
@@ -162,6 +173,8 @@ What does not work:
 - Lessons that apply to SLO itself never get filed as tracked work.
 - The cyclic structures of the skill pack (engineering loops, business loops) are implicit; newcomers and freshly-loaded Claude instances cannot see them.
 - A milestone in M5 cannot easily surface a lesson learned at M2 — the look-back is one-step.
+- `/slo-resume` only reads the milestone tracker today; it cannot see carry-forward, issue-backed follow-ups, or whether the safest next move is tiny, milestone-sized, or "fresh runbook".
+- The current documentation shape risks showing mechanism before user outcome. A loops doc can be structurally complete and still fail the practical question: "Which loop am I in, and what do I run next?"
 
 ### Problem
 
@@ -169,6 +182,8 @@ What does not work:
 2. **Lateral dropout in upstream signal**: When `/slo-execute` discovers a bug in an upstream tool, the lesson sits in a markdown file. The library-feedback loop dies in a local file. Concrete: a Semgrep CLI flag deprecation was noted in `docs/lessons/slo-sec-m4.md` but never filed against the Semgrep repo.
 3. **Implicit loop structure**: ARCHITECTURE.md describes static structure; SKILL.md files describe individual moves. No document shows the cyclic feedback structures (sprint loop, security-tuning loop, lessons loop, library-feedback loop on engineering side; user-interview loop, GTM loop, pricing loop, founder-check loop on business side). Newcomers cannot answer "how does this skill pack improve itself?".
 4. **No fallback when `gh` is unavailable**: Any extension to `/slo-retro` that depends on `gh` becomes a hard dependency, which violates the graceful-degradation pattern observed across the rest of the pack. A `LESSONS-BACKLOG.md` local fallback closes this gap.
+5. **Orientation gap after interruptions**: the current `/slo-resume` answer is too thin. It can name the first non-`done` milestone, but not the highest-value follow-up carried from prior retros, nor whether the next move should stay tiny, consume the current milestone, or become a separate runbook.
+6. **Process-theatre risk**: this runbook adds real discipline, but if the user-facing surface expands into more prose, more tables, or more decisions without reducing reviewer work, the loop becomes "more process" rather than "simpler output from a stricter machine".
 
 ### Target Architecture
 
@@ -176,7 +191,7 @@ See "End-to-End Architecture Diagram" above.
 
 ### Key Design Principles
 
-0. **Over-engineering for simplicity**: per [`docs/PARADIGM-OVER-ENGINEERING-FOR-SIMPLICITY.md`](PARADIGM-OVER-ENGINEERING-FOR-SIMPLICITY.md), the LLM-driven loop pipeline can sustainably carry MORE discipline than a human-driven equivalent because LLMs do not pay the cognitive-load tax. The lessons loop itself is the canonical example: humans skip post-mortems; LLMs file them as tracked work, run dedupe via `gh search`, and surface them at the next milestone's pre-flight. The user (founder / engineer) sees a working loop; the agent does the bookkeeping.
+0. **Over-engineering for simplicity**: per [`docs/PARADIGM-OVER-ENGINEERING-FOR-SIMPLICITY.md`](PARADIGM-OVER-ENGINEERING-FOR-SIMPLICITY.md), the LLM-driven loop pipeline can sustainably carry MORE discipline than a human-driven equivalent because LLMs do not pay the cognitive-load tax. The lessons loop itself is the canonical example: humans skip post-mortems; LLMs file them as tracked work, run dedupe via `gh search`, and surface them at the next milestone's pre-flight. The user (founder / engineer) sees a working loop; the agent does the bookkeeping. The bound is still context and ambiguity: visible ceremony still costs the user, so the extra discipline must stay mostly behind the scenes.
 
 1. **Loop docs live next to architecture**: `docs/LOOPS-ENGINEERING.md` and `docs/LOOPS-BUSINESS.md` are top-level `docs/` siblings of `ARCHITECTURE.md`. Cross-links go both ways: ARCHITECTURE.md links to LOOPS-*.md; each implicated SKILL.md links to its loop section.
 2. **Issue filing requires user confirmation**: Issue creation is publicly visible; never auto-file. This is a discipline rule, not a security boundary.
@@ -184,6 +199,10 @@ See "End-to-End Architecture Diagram" above.
 4. **Graceful degradation when `gh` is unavailable**: `LESSONS-BACKLOG.md` local fallback. The retro skill never fails because of `gh` trouble.
 5. **Carry-forward at milestone start, not retro**: The retro filing produces issues but doesn't change behavior; surfacing at the next milestone's pre-flight is what closes the loop.
 6. **Argv-list discipline**: Every `gh` invocation in modified skill prose follows argv-list form. Inherited from `/slo-sast` M5 + `/slo-sec-libs` M3 disciplines.
+7. **Outcome-first presentation**: loop docs and read-only orientation outputs start with "where am I / what do I do next / what outcome does this loop produce?" before diagrams, rationale, or bookkeeping internals.
+8. **Maximal internal discipline, minimal visible ceremony**: every new user-visible field, section, or prompt must reduce user decisions or reviewer work. If it only helps the implementation, move it into a reference file or test instead of the point-of-use surface.
+9. **Strengthen existing entrypoints before minting new verbs**: this runbook improves `/slo-resume` rather than inventing a new `/slo-help` surface. The pack should converge on one canonical "what next?" orientation path.
+10. **Use scope lanes to prevent silent widening**: carry-forward items must be triaged as `micro`, `milestone`, or `fresh-runbook` so small fixes stay light-weight and large follow-ups do not smuggle themselves into the current milestone.
 
 ### What to Keep
 
@@ -199,7 +218,8 @@ See "End-to-End Architecture Diagram" above.
 - **`skills/slo-retro/SKILL.md`** — extend with classify/dedupe/file flow (M3).
 - **`skills/slo-retro/references/issue-filing-discipline.md`** — NEW (M3).
 - **`skills/slo-execute/SKILL.md`** — extend pre-flight with issue-list read (M4).
-- **`docs/runbook-template_v_3_template.md`** — add optional "Carry-forward from prior retros" section (M4).
+- **`docs/runbook-template_v_3_template.md`** — add optional "Carry-forward from prior retros" section with suggested lane (M4).
+- **`skills/slo-resume/SKILL.md`** — extend with carry-forward-aware, lane-aware orientation output (M5).
 - **`ARCHITECTURE.md`** — add cross-links to LOOPS-*.md (M1, M2).
 - **Each engineering SKILL.md and biz SKILL.md** referenced by a loop — add a one-line cross-reference into LOOPS-*.md (M1, M2).
 
@@ -227,6 +247,7 @@ For each milestone:
 - dependency failure (`gh` not on PATH, or auth missing)
 - backward compatibility (existing runbooks without "Carry-forward" section still work)
 - abuse case (per-milestone — see threat-model rows in [`docs/design/loops-and-lessons-closure-overview.md`](design/loops-and-lessons-closure-overview.md))
+- discoverability / orientation (an interrupted user can recover one clear next action without rereading the full runbook)
 
 ### Test File Naming
 
@@ -251,7 +272,11 @@ See template.
 
 ## Self-Review Gate
 
-See template.
+See template. Project-specific addendum:
+
+- Can an interrupted user recover the next concrete action in one screen of output?
+- Did every newly-added visible field or section reduce user decisions or reviewer work?
+- Did any methodology detail that is not needed at point-of-use get moved into a reference file instead?
 
 ---
 
@@ -271,11 +296,11 @@ See template (`docs/completion/loops-m<N>.md`).
 
 ### Milestone 1 — `docs/LOOPS-ENGINEERING.md` authored + cross-linked
 
-**Goal**: A `docs/LOOPS-ENGINEERING.md` that documents at minimum the four engineering loops (sprint, security-tuning, lessons, library-feedback), cross-linked from `ARCHITECTURE.md` and from each implicated engineering SKILL.md.
+**Goal**: A `docs/LOOPS-ENGINEERING.md` that documents at minimum the four engineering loops (sprint, security-tuning, lessons, library-feedback), cross-linked from `ARCHITECTURE.md` and from each implicated engineering SKILL.md, with a newcomer-friendly "Start here" orienter at the top.
 
 **Context**: The project has no engineering-loops doc today. Issue [#17](https://github.com/kerberosmansour/SunLitOrchestrate/issues/17) is the canonical decision record for "split from business loops, separate doc, separate concerns" + "living doc, no staleness check" + "no per-runbook declaration of loops".
 
-**Important design rule**: Match the closest existing design-doc style (likely `docs/design/scanner-orchestration-overview.md`) for ASCII vs Mermaid choice. Per loop: name, trigger, steps, exit condition, artifacts, skills involved, diagram.
+**Important design rule**: Match the closest existing design-doc style (likely `docs/design/scanner-orchestration-overview.md`) for ASCII vs Mermaid choice. The doc opens with a short "Start here" orienter (`question -> loop -> first skill -> expected artifact`). Per loop: user-visible outcome, trigger, steps, exit condition, artifacts, skills involved, diagram.
 
 **Refactor budget**: `No refactor permitted beyond direct implementation` — pure new doc + cross-link additions to existing files.
 
@@ -292,7 +317,7 @@ See template (`docs/completion/loops-m<N>.md`).
 | New dependencies allowed | `none` |
 | Migration allowed | `no` |
 | Compatibility commitments | All existing SKILL.md prose preserved; cross-link additions only |
-| Forbidden shortcuts | placeholder loop entries, hand-waved "and others"; every loop entry must name trigger / steps / exit condition / skills involved |
+| Forbidden shortcuts | placeholder loop entries, hand-waved "and others"; every loop entry must name user-visible outcome / trigger / steps / exit condition / skills involved; dumping loop internals before the orienter |
 | **Data classification** | `Public` — engineering loops doc is public-tier (no real PII; the SLO repo is currently private but the doc is intended for public consumption when the repo opens) |
 | **Proactive controls in play** | OWASP Proactive Controls v3 — `C1 Define Security Requirements` (loops document the engineering security-tuning loop explicitly); `C9 Implement Security Logging and Monitoring` (lessons loop is the engineering audit trail) |
 | **Abuse acceptance scenarios** | `tm-loops-abuse-1: prompt injection via lesson body content` — pre-existing `~~~text` user-string fence rule from `/slo-architect` SECURITY.md template applies; documented in this runbook's design overview as residual + mitigated |
@@ -325,7 +350,7 @@ See template (`docs/completion/loops-m<N>.md`).
 
 1. Write the structural-contract test stub in `tests/e2e_loops_m1.rs` first (asserts file existence + section headers + cross-reference targets).
 2. Confirm the test fails for the expected reason (file missing).
-3. Author `docs/LOOPS-ENGINEERING.md` with the four documented loops:
+3. Author `docs/LOOPS-ENGINEERING.md` with a top-level "Start here" orienter and the four documented loops:
    - **Sprint loop**: think → plan → build → review → test → ship → reflect (skills involved: every `/slo-*`).
    - **Security-tuning loop**: threat model → SAST/DAST tuning → findings → threat-model refinement (skills: `/slo-architect`, `/slo-sast`, `/slo-rulegen`, `/slo-ruleverify`, `/slo-verify`, `/slo-critique`).
    - **Lessons loop**: retro → issues → priority order → next milestone (skills: `/slo-retro`, `/slo-execute`).
@@ -343,6 +368,7 @@ See template (`docs/completion/loops-m<N>.md`).
 | Scenario | Category | Given | When | Then |
 |---|---|---|---|---|
 | Engineering loops doc exists | happy path | repo at HEAD | open `docs/LOOPS-ENGINEERING.md` | document opens with at least 4 loop sections (sprint, security-tuning, lessons, library-feedback) |
+| Newcomer can identify the right engineering loop quickly | discoverability / orientation | user asks "I have a repeated regression, where do I start?" | read top of `docs/LOOPS-ENGINEERING.md` | "Start here" section maps the question to the lessons loop and first skill |
 | ARCHITECTURE.md cross-links to engineering loops | happy path | ARCHITECTURE.md exists | grep ARCHITECTURE.md for `LOOPS-ENGINEERING.md` | match found in a "Feedback loops" section |
 | Each engineering SKILL.md cited in a loop has a cross-reference | happy path | SKILL.md cited under "Sprint loop" section | grep SKILL.md for `LOOPS-ENGINEERING.md` | match found |
 | Loop cited in doc has missing cross-reference | invalid input / structural | LOOPS-ENGINEERING.md cites SKILL.md X under loop Y | grep SKILL.md X for `LOOPS-ENGINEERING.md#<loop-y>` | structural-contract test FAILS until cross-reference is added |
@@ -369,6 +395,7 @@ See template (`docs/completion/loops-m<N>.md`).
 | E2E Test | What It Proves | Pass Criteria |
 |---|---|---|
 | `loops_engineering_doc_exists_and_has_required_sections` | Document is present with required loop sections | All four loop sections present; each has name + trigger + steps + exit-condition + skills + diagram |
+| `loops_engineering_doc_has_start_here_orienter` | Outcome-first orientation exists | grep finds "Start here" plus at least one `question -> loop -> first skill` mapping |
 | `architecture_md_cross_links_loops_engineering` | Bidirectional discoverability | ARCHITECTURE.md grep for `LOOPS-ENGINEERING.md` returns ≥ 1 match in a "Feedback loops" or equivalent section |
 | `every_cited_skill_has_cross_reference` | Cross-reference invariant | For every SKILL.md cited under a loop, that SKILL.md contains the corresponding `LOOPS-ENGINEERING.md#<loop>` link |
 
@@ -417,11 +444,11 @@ See template (`docs/completion/loops-m<N>.md`).
 
 ### Milestone 2 — `docs/LOOPS-BUSINESS.md` authored + cross-linked
 
-**Goal**: A `docs/LOOPS-BUSINESS.md` document covering at minimum the four business loops (user-interview, GTM, pricing, founder-check), cross-linked from each implicated biz SKILL.md.
+**Goal**: A `docs/LOOPS-BUSINESS.md` document covering at minimum the four business loops (user-interview, GTM, pricing, founder-check), cross-linked from each implicated biz SKILL.md, with a newcomer-friendly "Start here" orienter at the top.
 
 **Context**: Issue [#18](https://github.com/kerberosmansour/SunLitOrchestrate/issues/18) is the canonical decision record. Same shape as M1; biz domain. Possible additional loops to inventory before authoring: fundraise loop, cofounder loop, hiring loop, legal-triage loop (Issue #18 Q1 leaves these as open additions).
 
-**Important design rule**: Match M1's diagram style for consistency. Per loop: name, trigger, steps, exit condition, artifacts, skills involved, diagram.
+**Important design rule**: Match M1's diagram style for consistency. The doc opens with a short "Start here" orienter (`question -> loop -> first skill -> expected artifact`). Per loop: user-visible outcome, trigger, steps, exit condition, artifacts, skills involved, diagram.
 
 **Refactor budget**: `No refactor permitted beyond direct implementation`.
 
@@ -438,7 +465,7 @@ See template (`docs/completion/loops-m<N>.md`).
 | New dependencies allowed | `none` |
 | Migration allowed | `no` |
 | Compatibility commitments | M1 work unchanged; biz SKILL.md prose preserved |
-| Forbidden shortcuts | "see M1" placeholder for biz loop steps; every biz loop must be authored explicitly |
+| Forbidden shortcuts | "see M1" placeholder for biz loop steps; every biz loop must be authored explicitly; dumping loop internals before the orienter |
 | **Data classification** | `Public` — biz loops doc is structural; no real founder PII |
 | **Proactive controls in play** | OWASP C1 (security requirements anchored in user-interview loop's PII handling); C7 (Enforce Access Controls — biz docs `tier:` discipline anchored in user-interview loop's PII flow) |
 | **Abuse acceptance scenarios** | `tm-loops-abuse-1: prompt injection via lesson body content` (same as M1); `tm-loops-abuse-2: biz-loop documentation leaks PII via interview-quote example` — eliminated by structural rule "no real interview quotes in LOOPS-BUSINESS.md; all examples use Alice / Bob pseudonyms" |
@@ -468,7 +495,7 @@ See template (`docs/completion/loops-m<N>.md`).
 
 1. Test stub first.
 2. Confirm fails for expected reason.
-3. Author `docs/LOOPS-BUSINESS.md` with the documented loops (user-interview, GTM, pricing, founder-check; plus any inventory additions confirmed in pre-flight).
+3. Author `docs/LOOPS-BUSINESS.md` with a top-level "Start here" orienter and the documented loops (user-interview, GTM, pricing, founder-check; plus any inventory additions confirmed in pre-flight).
 4. Add per-skill cross-references.
 5. Make tests pass.
 6. Smoke tests.
@@ -481,6 +508,7 @@ See template (`docs/completion/loops-m<N>.md`).
 | Scenario | Category | Given | When | Then |
 |---|---|---|---|---|
 | Business loops doc exists | happy path | repo at HEAD | open `docs/LOOPS-BUSINESS.md` | doc opens with ≥ 4 loop sections |
+| Newcomer can identify the right business loop quickly | discoverability / orientation | founder asks "we're not learning from user calls, where do I start?" | read top of `docs/LOOPS-BUSINESS.md` | "Start here" section maps the question to the user-interview loop and first skill |
 | Per-biz-skill cross-reference present | happy path | SKILL.md cited under a loop | grep for `LOOPS-BUSINESS.md` | match found |
 | Real-PII example smuggled into doc | abuse case (`tm-loops-abuse-2`) | dev tries to commit LOOPS-BUSINESS.md with a real-name example | `/slo-verify` Pass 4 PII scan over docs/biz-public/ | scan flags; commit blocked until anonymized |
 | Backward compat with M1's LOOPS-ENGINEERING.md | backward compatibility | M1's doc + ARCHITECTURE cross-link | both docs present | both render; both cross-linked |
@@ -674,11 +702,11 @@ See template (`docs/completion/loops-m<N>.md`).
 
 ### Milestone 4 — `/slo-execute` pre-flight loop closure + runbook template "Carry-forward from prior retros" section
 
-**Goal**: `/slo-execute M<N>` pre-flight queries open issues filed by `/slo-retro` for prior milestones in this runbook's prefix; surfaces them as scope candidates; user decides each milestone's bounds. Runbook template gains an optional "Carry-forward from prior retros" section so the loop is visible in the artifact, not just in the skill flow.
+**Goal**: `/slo-execute M<N>` pre-flight queries open issues filed by `/slo-retro` for prior milestones in this runbook's prefix; surfaces them as scope candidates with a suggested lane (`micro | milestone | fresh-runbook`); user decides each milestone's bounds. Runbook template gains an optional "Carry-forward from prior retros" section so the loop is visible in the artifact, not just in the skill flow.
 
 **Context**: [Issue #16](https://github.com/kerberosmansour/SunLitOrchestrate/issues/16) decision: "close the loop in execution flow ... runbook template should reflect this — don't bolt it onto the skill alone." [Issue #16 Q3](https://github.com/kerberosmansour/SunLitOrchestrate/issues/16) decision (folded into this runbook): the template change lives here.
 
-**Important design rule**: Surfacing is informational, not auto-additive. The user decides each milestone's bounds; the skill never auto-extends the allow-list.
+**Important design rule**: Surfacing is informational, not auto-additive. The user decides each milestone's bounds; the skill never auto-extends the allow-list. The surface should reduce, not add, ceremony: at most the top 3 carry-forward items are shown inline, each with a suggested lane and a one-line why.
 
 **Refactor budget**: `Minimal local refactor permitted in listed files only`.
 
@@ -687,8 +715,8 @@ See template (`docs/completion/loops-m<N>.md`).
 | Field | Value |
 |---|---|
 | Inputs | Runbook at `docs/RUNBOOK-<feature>.md`; current milestone N; prefix from runbook metadata; `gh` CLI |
-| Outputs | Pre-flight stdout listing open prior-retro issues for this prefix; updated runbook template with new section schema |
-| Interfaces touched | `/slo-execute` SKILL.md pre-flight section (additive); `docs/runbook-template_v_3_template.md` (additive section) |
+| Outputs | Pre-flight stdout listing open prior-retro issues for this prefix plus suggested lane; updated runbook template with new section schema |
+| Interfaces touched | `/slo-execute` SKILL.md pre-flight section (additive); `docs/runbook-template_v_3_template.md` (additive section with lane column) |
 | Files allowed to change | `skills/slo-execute/SKILL.md`, `docs/runbook-template_v_3_template.md`, `crates/sldo-install/tests/e2e_loops_m4.rs` (new) |
 | Files to read before changing anything | `skills/slo-execute/SKILL.md` current pre-flight; M3's `references/issue-filing-discipline.md` (for marker choice); `docs/runbook-template_v_3_template.md` |
 | New files allowed | `crates/sldo-install/tests/e2e_loops_m4.rs` |
@@ -719,13 +747,13 @@ See template (`docs/completion/loops-m<N>.md`).
 | File | Planned Change |
 |---|---|
 | `skills/slo-execute/SKILL.md` | Add pre-flight Step 1.5: "Read open prior-retro issues filtered by this runbook's prefix; surface as scope candidates". Cite M3's marker choice. |
-| `docs/runbook-template_v_3_template.md` | Add new optional section "## Carry-forward from prior retros" between "Background Context" and "BDD and Runtime Validation Rules". Schema: per-row issue # + title + suggested-milestone column. |
+| `docs/runbook-template_v_3_template.md` | Add new optional section "## Carry-forward from prior retros" between "Background Context" and "BDD and Runtime Validation Rules". Schema: per-row issue # + title + suggested lane (`micro | milestone | fresh-runbook`) + suggested milestone column. |
 | `crates/sldo-install/tests/e2e_loops_m4.rs` | NEW: structural-contract test asserting SKILL.md change + template change |
 
 #### Step-by-Step
 
 1. Test stub.
-2. Update SKILL.md pre-flight prose with the additive Step 1.5.
+2. Update SKILL.md pre-flight prose with the additive Step 1.5 and compact top-3 carry-forward summary.
 3. Update runbook template with the new section.
 4. Update one existing runbook (this runbook itself, when M4 closes — dogfood) to include a "Carry-forward from prior retros" section listing M1-M3's filed issues if any.
 5. Verify structural-contract test.
@@ -738,7 +766,9 @@ See template (`docs/completion/loops-m<N>.md`).
 
 | Scenario | Category | Given | When | Then |
 |---|---|---|---|---|
-| Pre-flight surfaces open prior-retro issues | happy path | runbook prefix `loops`; M1-M3 closed; issues filed | `/slo-execute M4` pre-flight runs | stdout lists open `loops`-prefix retro-derived issues with title + # |
+| Pre-flight surfaces open prior-retro issues | happy path | runbook prefix `loops`; M1-M3 closed; issues filed | `/slo-execute M4` pre-flight runs | stdout lists open `loops`-prefix retro-derived issues with title + # + suggested lane |
+| Small follow-up stays small | discoverability / orientation | open prior-retro issue is low-risk doc polish | `/slo-execute` pre-flight runs | item is surfaced as `micro`, not silently expanded into milestone-sized work |
+| Large follow-up does not silently widen scope | discoverability / orientation | open prior-retro issue requires new architecture work | `/slo-execute` pre-flight runs | item is surfaced as `fresh-runbook`; current milestone allow-list stays unchanged |
 | No prior-retro issues for this prefix | empty state | first milestone of a runbook | `/slo-execute M1` pre-flight runs | stdout: "no carry-forward from prior retros (this is M1)" |
 | `gh` unavailable | dependency failure | `gh` missing | pre-flight runs | warns + proceeds (does not block on gh-availability for this informational read) |
 | `gh` returns rate-limit | dependency failure (paradigm: comprehensive degraded states) | `gh issue list` returns 403 secondary rate-limit | pre-flight | applies 5s timeout; falls back to "carry-forward unavailable; gh rate-limited at <retry_after>"; never hangs |
@@ -772,6 +802,7 @@ See template (`docs/completion/loops-m<N>.md`).
 |---|---|---|
 | `slo_execute_pre_flight_extended` | SKILL.md change applied | grep for "prior-retro" in pre-flight section |
 | `runbook_template_carry_forward_section` | Template change applied | grep `runbook-template_v_3_template.md` for "Carry-forward from prior retros" |
+| `runbook_template_carry_forward_lane_column` | Lane schema applied | grep template for `micro | milestone | fresh-runbook` |
 | `gh_issue_list_argv_list_documented` | argv-list discipline | grep for `gh issue list` argv pattern in SKILL.md |
 | `no_auto_extend_allowlist_documented` | Discipline preserved | grep SKILL.md for "user decides each milestone's bounds" |
 
@@ -791,6 +822,7 @@ See template (`docs/completion/loops-m<N>.md`).
 - All BDD scenarios pass.
 - Pre-flight Step 1.5 added without removing Step 1.
 - Runbook template gains the new optional section.
+- Carry-forward section and pre-flight prose both use the `micro | milestone | fresh-runbook` lane vocabulary.
 - Dogfood: this runbook itself includes a "Carry-forward from prior retros" section after M4 closes (even if empty for M1).
 - Tracker + lessons + completion files written.
 - ARCHITECTURE.md "Feedback loops" section updated to mention milestone-start carry-forward.
@@ -802,7 +834,149 @@ See template (`docs/completion/loops-m<N>.md`).
 
 #### Notes
 
-- This runbook self-tests the loop. After M4 closes, M5 (which doesn't exist) won't run — but if a future runbook executes after this one ships, it inherits the carry-forward mechanic.
+- This runbook now self-tests the loop end-to-end: M4 introduces carry-forward, and M5 dogfoods the read-only orientation path that consumes it. After M5 closes there is no M6 here, but future runbooks inherit the mechanic.
+
+---
+
+### Milestone 5 — `/slo-resume` next-step digest + lane-aware orientation
+
+**Goal**: Extend `/slo-resume` so it becomes the pack's canonical "what next?" entrypoint for interrupted work: it reads the runbook tracker plus the optional carry-forward section, emits exactly one next action, and classifies the safest path as `micro`, `milestone`, or `fresh-runbook` without starting anything automatically.
+
+**Context**: The current `/slo-resume` behavior is helpful but shallow: it can name the first non-`done` milestone, but not the highest-value carry-forward item or whether the work should stay tiny, consume the current milestone, or split into a new runbook. This is the most directly applicable adoption lesson from the BMAD comparison: the pack needs one obvious orientation surface, but it should strengthen the existing `/slo-resume` verb rather than minting a parallel `/slo-help`.
+
+**Important design rule**: `/slo-resume` stays read-only and brief. It must answer three questions in one screen: where am I, what should I do next, and what can wait. No auto-starting skills. No dumping the full carry-forward table inline. Surface at most the top 3 carry-forward items plus a count of remaining items.
+
+**Refactor budget**: `Minimal local refactor permitted in listed files only`.
+
+#### Contract Block
+
+| Field | Value |
+|---|---|
+| Inputs | Current runbook's Milestone Tracker; optional "Carry-forward from prior retros" section; latest lessons/completion summary if needed for one-line context |
+| Outputs | A short orientation message: current milestone, status, recommended lane, exact next action, and top carry-forward item(s) if relevant |
+| Interfaces touched | `skills/slo-resume/SKILL.md` output contract (additive only) |
+| Files allowed to change | `skills/slo-resume/SKILL.md`, `crates/sldo-install/tests/e2e_loops_m5.rs` (new), `docs/RUNBOOK-LOOPS-AND-LESSONS-CLOSURE.md` (tracker + carry-forward dogfood row updates only) |
+| Files to read before changing anything | `skills/slo-resume/SKILL.md` current behavior; M4-updated `docs/runbook-template_v_3_template.md`; this runbook's new carry-forward section shape |
+| New files allowed | `crates/sldo-install/tests/e2e_loops_m5.rs` |
+| New dependencies allowed | `none` |
+| Migration allowed | `no` |
+| Compatibility commitments | `/slo-resume` stays read-only; existing "multiple runbooks -> ask user which" gate preserved; existing tracker-first behavior preserved and extended, not replaced |
+| Forbidden shortcuts | auto-starting the recommended skill; emitting a wall of prose; ignoring carry-forward lane; inventing a new public verb |
+| **Data classification** | `Internal` — runbook tracker plus carry-forward issue summaries |
+| **Proactive controls in play** | C5 (Validate inputs — runbook / carry-forward parsing is exact); C9 (Auditability — orientation output references artifact state rather than agent memory) |
+| **Abuse acceptance scenarios** | `tm-loops-abuse-8: carry-forward overload turns orientation into noise` — mitigated by top-3 inline cap + remainder count; `tm-loops-abuse-9: malicious carry-forward issue body smuggles prompt-injection text into /slo-resume output` — mitigated by not inlining full bodies and fence-wrapping any quoted snippets |
+
+#### Out of Scope / Must Not Do
+
+- Creating a new `/slo-help` skill.
+- Auto-starting `/slo-execute`, `/slo-verify`, or `/slo-ship`.
+- Rewriting milestone tracker status based on inference.
+- Mutating the runbook from `/slo-resume`.
+
+#### Pre-Flight
+
+1. Complete Global Entry Rules.
+2. Read [`skills/slo-resume/SKILL.md`](../skills/slo-resume/SKILL.md) end-to-end.
+3. Read the M4-updated carry-forward section schema in [`docs/runbook-template_v_3_template.md`](runbook-template_v_3_template.md).
+4. Inspect at least one completed runbook that already contains a carry-forward section to confirm the parser shape remains realistic.
+
+#### Files Allowed To Change
+
+| File | Planned Change |
+|---|---|
+| `skills/slo-resume/SKILL.md` | Extend the Method and Output sections so the skill reads carry-forward and emits one next action plus lane |
+| `crates/sldo-install/tests/e2e_loops_m5.rs` | NEW: structural-contract test asserting carry-forward-aware orientation rules |
+
+#### Step-by-Step
+
+1. Write the structural-contract test stub first.
+2. Confirm it fails for the expected reason.
+3. Update `/slo-resume` so it reads the tracker first, then the carry-forward section if present.
+4. Add the lane rules:
+   - `micro` = safe, bounded follow-up; keep within current or immediate next milestone.
+   - `milestone` = real milestone work inside the current runbook.
+   - `fresh-runbook` = material scope/risk shift; do not widen the current runbook silently.
+5. Keep the output compact: milestone, status, lane, next action, one-line context, top carry-forward item(s).
+6. Make the structural-contract test pass.
+7. Smoke test with one empty-state runbook and one runbook with carry-forward rows.
+8. Self-review gate.
+
+#### BDD Acceptance Scenarios
+
+**Feature: one-screen orientation after interruptions**
+
+| Scenario | Category | Given | When | Then |
+|---|---|---|---|---|
+| Next action from tracker only | happy path | one runbook; M1 done, M2 not_started; no carry-forward rows | `/slo-resume` runs | output names M2 and suggests the correct next skill |
+| Carry-forward item influences orientation | happy path | current milestone is in progress; carry-forward section has one `micro` item | `/slo-resume` runs | output keeps the current milestone, surfaces the `micro` item as context, and does not invent a new runbook |
+| Fresh-runbook follow-up is not silently widened into current milestone | discoverability / orientation | carry-forward row is marked `fresh-runbook` | `/slo-resume` runs | output says the current runbook should not widen scope and names the follow-up as separate work |
+| Empty carry-forward section | empty state | runbook has the section but no rows | `/slo-resume` runs | output still orients cleanly; no error about missing follow-ups |
+| Multiple runbooks present | dependency / ambiguity | more than one `docs/RUNBOOK-*.md` exists | `/slo-resume` runs | asks the user which runbook before orienting |
+| Blocked milestone | dependency failure | first non-`done` row is `blocked` | `/slo-resume` runs | output prints blocker plus the safest next human decision, not `/slo-execute` |
+| Carry-forward overload | abuse case (`tm-loops-abuse-8`) | carry-forward table has 12 open items | `/slo-resume` runs | inline output shows top 3 plus "9 more" instead of dumping the whole table |
+| Malicious carry-forward title/body snippet | abuse case (`tm-loops-abuse-9`) | carry-forward row references issue with prompt-injection text | `/slo-resume` runs | only short title/snippet appears, fence-wrapped if quoted; no raw full body is emitted |
+| All milestones done | backward compatibility | every tracker row is `done` | `/slo-resume` runs | suggests `/slo-ship` or confirms the runbook is complete |
+
+#### Regression Tests
+
+- `cargo test --workspace`.
+- Existing `/slo-resume` install tests still pass.
+- M1-M4 structural-contract tests still pass.
+
+#### Compatibility Checklist
+
+- [ ] `/slo-resume` remains read-only.
+- [ ] Existing tracker-only orientation still works when no carry-forward section exists.
+- [ ] Multiple-runbook ambiguity still asks the user rather than guessing.
+- [ ] No existing test fails.
+
+#### E2E Runtime Validation
+
+**File**: `crates/sldo-install/tests/e2e_loops_m5.rs`
+
+| E2E Test | What It Proves | Pass Criteria |
+|---|---|---|
+| `slo_resume_reads_carry_forward_section` | Carry-forward is part of orientation contract | grep `skills/slo-resume/SKILL.md` for "Carry-forward from prior retros" |
+| `slo_resume_lane_vocabulary_documented` | Lane model is fixed | grep for `micro`, `milestone`, and `fresh-runbook` in the orientation logic |
+| `slo_resume_output_stays_short` | Minimal visible ceremony preserved | output section explicitly says short message / one screen / top 3 carry-forward items max |
+| `slo_resume_no_auto_start_preserved` | Read-only rule still intact | grep for "Do not start the next action" or equivalent |
+
+#### Smoke Tests
+
+- [ ] Run `/slo-resume` against a runbook with no carry-forward rows; verify the old simple orientation still works.
+- [ ] Run `/slo-resume` against a runbook with `micro`, `milestone`, and `fresh-runbook` rows; verify the lane appears in output.
+- [ ] Verify output stays short when the carry-forward table is long.
+- [ ] `cargo test -p sldo-install` passes.
+
+#### Evidence Log
+
+| Step | Command / Check | Expected Result | Actual Result | Pass/Fail | Notes |
+|---|---|---|---|---|---|
+| Baseline | `cargo test --workspace` | green | | | |
+| Test stub created | `tests/e2e_loops_m5.rs` | fails for missing carry-forward-aware contract | | | |
+| `/slo-resume` updated | inspect file | tracker + carry-forward + lane + short output rules present | | | |
+| Empty-state smoke | manual `/slo-resume` run | correct simple orientation | | | |
+| Carry-forward smoke | manual `/slo-resume` run | one next action + lane + compact output | | | |
+| Full tests | `cargo test --workspace` | green | | | |
+| `.gitignore` review | | no new patterns needed | | | |
+
+#### Definition of Done
+
+- All BDD scenarios pass.
+- `/slo-resume` stays read-only and compact.
+- Lane vocabulary is documented and matches M4 (`micro | milestone | fresh-runbook`).
+- A user can recover one next action without rereading the full runbook.
+- Lessons + completion files written.
+- Tracker updated.
+
+#### Post-Flight
+
+- README.md update: optional, if the docs index calls out `/slo-resume` as the orientation entrypoint.
+- No runbook-template change required beyond M4.
+
+#### Notes
+
+- This is intentionally not a new `/slo-help` skill. The product lesson from BMAD is "one obvious way to ask what's next", not "more verbs".
 
 ---
 
@@ -813,23 +987,24 @@ See template (`docs/completion/loops-m<N>.md`).
 | 1 | Add "Feedback loops" section linking LOOPS-ENGINEERING.md | optional bullet in docs index | none | Per-skill SKILL.md cross-references |
 | 2 | Update "Feedback loops" section to link LOOPS-BUSINESS.md too | optional | none | Per-biz-skill SKILL.md cross-references |
 | 3 | Note `/slo-retro` issue-filing extension | optional | none | `skills/slo-retro/references/issue-filing-discipline.md` (new) |
-| 4 | Note `/slo-execute` pre-flight loop closure | optional | none | `docs/runbook-template_v_3_template.md` (new section) |
+| 4 | Note `/slo-execute` pre-flight loop closure | optional | none | `docs/runbook-template_v_3_template.md` (new section + lane column) |
+| 5 | none required | optional: mention `/slo-resume` as "what next?" entrypoint | none | `skills/slo-resume/SKILL.md` |
 
 ---
 
 ## Optional Fast-Fail Review Prompt for Agents
 
-> Restate the milestone goal, allowed files, forbidden changes, compatibility requirements, tests that must be written first, and the exact Definition of Done. Then list the smallest implementation approach that satisfies the contract without widening scope.
+> Restate the milestone goal, allowed files, forbidden changes, compatibility requirements, tests that must be written first, and the exact Definition of Done. Then list the smallest implementation approach that satisfies the contract without widening scope, and explain how the user-facing result reduces user decisions or reviewer work.
 
 ---
 
 ## Carry-forward from prior retros
 
-(This section is the dogfood of M4's template change. It is empty until M3 produces filings, at which point M3's own retro lands carry-forward into a hypothetical M5 — which doesn't exist for this runbook. The section is here so the artifact-shape is visible.)
+(This section is the dogfood of M4's template change. It is empty until M3 produces filings; M5 then uses the section as the read-only orientation input. The section is here so the artifact-shape is visible even before real rows accumulate.)
 
-| Issue | Title | Suggested milestone | Status |
-|---|---|---|---|
-| (none yet — M1) | | | |
+| Issue | Title | Suggested lane | Suggested milestone | Status |
+|---|---|---|---|---|
+| (none yet — M1) | | | | |
 
 ---
 
@@ -867,6 +1042,14 @@ The paradigm's "multi-layer defense without user friction" pattern:
 | Lessons drop-out | `/slo-retro` always writes lessons file FIRST | issue filing additive after | M4 surfaces at next milestone | LESSONS-BACKLOG.md fallback if `gh` unavailable |
 | Marker drift | single canonical marker chosen in M3 spike | structural-contract test asserts marker-format | three-strike search defends against evasion | spike-result review at +6 months (per critique L-3) |
 
+### One-screen orientation instead of more process
+
+The main user-facing simplicity rule added by this revision is: a stricter loop is only a win if the operator can still answer "what next?" without rereading the whole system. M4 introduces the `micro | milestone | fresh-runbook` lane so carry-forward does not silently widen scope; M5 teaches `/slo-resume` to turn that structure into a single next-step digest. This is the practical application of the BMAD comparison: keep the internal discipline, but make recovery and orientation feel lighter.
+
+### Anti-process-theatre check
+
+Every added user-visible surface in this runbook must pass one question: **does it reduce user decisions or reviewer work?** If not, it belongs in a reference file, a structural-contract test, or nowhere. That rule is the counter-weight to the paradigm's "add more discipline" instinct.
+
 ### Bounded by context-window
 
-This runbook stays inside the paradigm's "balance against context window, not attention" rule: the v3 template is the orchestrator (used by `/slo-plan`); methodology lives in `references/issue-filing-discipline.md` (consulted on-demand); the LESSONS-BACKLOG.md row schema is one line of text in the contract block; abuse-case BDD rows are individually small. No file in this runbook approaches the soft 200-line cap from R2.
+This runbook stays inside the paradigm's "balance against context window, not attention" rule: the v3 template is the orchestrator (used by `/slo-plan`); methodology lives in `references/issue-filing-discipline.md` (consulted on-demand); the LESSONS-BACKLOG.md row schema is one line of text in the contract block; abuse-case BDD rows are individually small; `/slo-resume` compresses the result back down to one screen for the user. No file in this runbook approaches the soft 200-line cap from R2.

--- a/docs/RUNBOOK-LOOPS-AND-LESSONS-CLOSURE.md
+++ b/docs/RUNBOOK-LOOPS-AND-LESSONS-CLOSURE.md
@@ -1,0 +1,872 @@
+# Loops + Lessons Closure — SunLitOrchestrate (AI-First Runbook v3)
+
+> **Purpose**: Make engineering loops and business loops first-class artifacts; extend `/slo-retro` to file lessons as tracked issues; close the loop at milestone start so prior-retro issues become scope candidates for the current milestone.
+> **Audience**: AI coding agents first, humans second.
+> **How to use**: Work through milestones sequentially. Before starting any milestone, read its full section and the Global Execution Rules. After completing it, follow the Global Exit Rules.
+> **Prerequisite reading**: [ARCHITECTURE.md](../ARCHITECTURE.md), [docs/design/loops-and-lessons-closure-overview.md](design/loops-and-lessons-closure-overview.md), [docs/idea/loops-and-lessons-closure.md](idea/loops-and-lessons-closure.md), [docs/research/loops-and-lessons-closure/synthesis.md](research/loops-and-lessons-closure/synthesis.md), [Issue #16](https://github.com/kerberosmansour/SunLitOrchestrate/issues/16), [Issue #17](https://github.com/kerberosmansour/SunLitOrchestrate/issues/17), [Issue #18](https://github.com/kerberosmansour/SunLitOrchestrate/issues/18)
+
+---
+
+## Runbook Metadata
+
+- **Runbook ID**: `loops-and-lessons-closure`
+- **Prefix for test files and lessons files**: `loops`
+- **Primary stack**: Markdown + Rust (`crates/sldo-install`) + `gh` CLI
+- **Primary package/app names**: `sldo-install`, `skills/slo-retro`, `skills/slo-execute`, `skills/slo-resume`
+- **Default test commands**:
+  - Workspace tests: `cargo test --workspace`
+  - Specific install tests: `cargo test -p sldo-install`
+  - E2E (markdown structural-contract tests): part of `cargo test -p sldo-install`
+  - Build: `cargo build --workspace`
+- **Allowed new dependencies by default**: `none`
+- **Schema/config migration allowed by default**: `no`
+- **Public interfaces that must remain stable unless explicitly listed otherwise**:
+  - `docs/runbook-template_v_3_template.md` section schema (additive only)
+  - `docs/lessons/<prefix>-m<N>.md` template
+  - `skills/slo-retro/SKILL.md` Outputs contract (additive only)
+  - `skills/slo-execute/SKILL.md` Pre-flight contract (additive only)
+
+---
+
+## Milestone Tracker
+
+| # | Milestone | Status | Started | Completed | Lessons File | Completion Summary |
+|---|---|---|---|---|---|---|
+| 1 | LOOPS-ENGINEERING.md authored + cross-linked | `not_started` | | | | |
+| 2 | LOOPS-BUSINESS.md authored + cross-linked | `not_started` | | | | |
+| 3 | `/slo-retro` extension: classify, dedupe, file lessons as issues | `not_started` | | | | |
+| 4 | `/slo-execute` pre-flight loop closure + runbook template "Carry-forward from prior retros" section | `not_started` | | | | |
+
+---
+
+## End-to-End Architecture Diagram
+
+```
+┌──────────────────────────────────────────────────────────────────────────┐
+│                  SunLitOrchestrate skill pack                           │
+│                                                                          │
+│  ┌────────────────┐         ┌──────────────────────┐                     │
+│  │ ARCHITECTURE.md│ ◀─────▶ │  docs/LOOPS-          │ ◀─────────┐        │
+│  │ (existing)     │         │  ENGINEERING.md       │ ─ ─ ─ ─ ─ │        │
+│  └────────────────┘         │  (M1 NEW)            │           │        │
+│         ▲                    └──────────────────────┘           │        │
+│         │                              ▲                        │        │
+│         │                              │                        │        │
+│  ┌──────┴──────────┐         ┌──────────────────────┐           │        │
+│  │  Engineering    │ ◀─────▶ │  docs/LOOPS-BUSINESS │           │        │
+│  │  SKILL.md files │         │  .md (M2 NEW)        │           │        │
+│  └─────────────────┘         └──────────────────────┘           │        │
+│                                       ▲                          │        │
+│                                       │                          │        │
+│                              ┌────────┴──────────┐               │        │
+│                              │  Biz SKILL.md     │               │        │
+│                              │  files            │               │        │
+│                              └───────────────────┘               │        │
+│                                                                  │        │
+│  ┌────────────────┐         ┌──────────────────────┐             │        │
+│  │ /slo-retro M<N>│ ────▶   │  docs/lessons/       │             │        │
+│  │ (M3 EXTENDED)  │         │  <prefix>-m<N>.md     │             │        │
+│  └────────────────┘         └──────┬───────────────┘             │        │
+│         │                          │                              │        │
+│         │ classify each lesson     │                              │        │
+│         ▼                          ▼                              │        │
+│  ┌─────────────────────────────────────────────────────┐         │        │
+│  │  gh issue create (with confirmation)                │         │        │
+│  │  destinations:                                       │         │        │
+│  │    - product → current repo                         │         │        │
+│  │    - upstream-OSS → resolved upstream repo          │ - - - ─ ┘        │
+│  │    - slo-process → kerberosmansour/SunLitOrchestrate│                  │
+│  │  fallback: LESSONS-BACKLOG.md                       │                  │
+│  └────────────────────────────┬────────────────────────┘                  │
+│                               │                                            │
+│                               ▼                                            │
+│              ┌──────────────────────────────────────┐                      │
+│              │ /slo-execute M<N+k> pre-flight        │                      │
+│              │ (M4 EXTENDED)                         │                      │
+│              │   gh issue list --label retro-derived │                      │
+│              │   surface as scope candidates         │                      │
+│              └──────────────────────────────────────┘                      │
+│                                                                            │
+│  Legend:  ─── existing    - - - new (this runbook)    ▶ data flow         │
+└──────────────────────────────────────────────────────────────────────────┘
+```
+
+### Component Summary Table
+
+| Component | Responsibility | Milestone Introduced/Changed | Key Interfaces |
+|---|---|---|---|
+| `docs/LOOPS-ENGINEERING.md` | First-class engineering-loops doc | M1 NEW | Cross-linked from ARCHITECTURE.md + each implicated engineering SKILL.md |
+| `docs/LOOPS-BUSINESS.md` | First-class business-loops doc | M2 NEW | Cross-linked from each implicated biz SKILL.md |
+| `skills/slo-retro/SKILL.md` | Extended: classify each lesson, dedupe via `gh search`, file with confirmation | M3 EXTENDED | Existing lessons-file output preserved; issue filing additive |
+| `skills/slo-retro/references/issue-filing-discipline.md` | argv-list + dedupe + rate-limit + fallback | M3 NEW | Cited from SKILL.md |
+| `skills/slo-execute/SKILL.md` | Extended: pre-flight reads open prior-retro issues for this runbook's prefix | M4 EXTENDED | Existing pre-flight steps preserved; issue read additive |
+| `docs/runbook-template_v_3_template.md` | New optional "Carry-forward from prior retros" section | M4 EXTENDED | Read by `/slo-plan` and `/slo-resume` |
+| `LESSONS-BACKLOG.md` | Local fallback for repos without `gh` available | M3 NEW | Append-only rows |
+
+### Data Flow Summary
+
+| Flow | From | To | Protocol/Mechanism | Milestone |
+|---|---|---|---|---|
+| Lesson classification | `/slo-retro` | LLM (the running agent) | In-skill judgment, structured output | M3 |
+| Issue dedupe | `/slo-retro` | GitHub | `gh search issues` (read-only) | M3 |
+| Issue creation | `/slo-retro` (with user confirmation) | GitHub OR LESSONS-BACKLOG.md | `gh issue create` argv-list OR file append | M3 |
+| Pre-flight loop closure | `/slo-execute` pre-flight | GitHub | `gh issue list` argv-list (read-only) | M4 |
+| Carry-forward surfacing | `/slo-execute` | Founder/operator console | Stdout prose | M4 |
+
+---
+
+## High-Level Design for Formal Verification (TLA+ Section)
+
+`tla_required: false`
+
+This work has no concurrent actors, no distributed state, no ordering guarantees, no resource ownership, no failure recovery protocols. The lesson-→issue-→carry-forward flow is sequential per milestone. Per [`/slo-tla`'s suitability gate](skills/slo-tla/SKILL.md#L120), TLA+ is not the right tool here — recommend the standard structural-contract tests in `cargo test --workspace` for correctness gating.
+
+---
+
+## Global Execution Rules
+
+See [docs/runbook-template_v_3_template.md §"Global Execution Rules"](runbook-template_v_3_template.md). Project-specific overrides:
+
+- This runbook produces **only markdown changes + skill SKILL.md prose updates + structural-contract tests**. No new Rust crates, no new runtime dependencies, no schema migrations.
+- Every `gh` invocation in modified skill prose MUST follow argv-list discipline (matches `/slo-sast` M5 + `/slo-sec-libs` M3).
+
+## Global Entry Rules (Pre-Milestone Protocol)
+
+See template. Specifics:
+
+- Baseline test command: `cargo test --workspace`. Confirm green before starting.
+- Read [`docs/design/loops-and-lessons-closure-overview.md`](design/loops-and-lessons-closure-overview.md) before M1.
+
+## Global Exit Rules (Post-Milestone Protocol)
+
+See template. Specifics:
+
+- Update [`ARCHITECTURE.md`](../ARCHITECTURE.md) with the new `docs/LOOPS-*.md` cross-references when M1 / M2 close.
+
+---
+
+## Background Context
+
+### Current State
+
+The SLO skill pack has 32 SKILL.md files, 7 reference subtrees under `references/`, 5+ active runbooks under `docs/RUNBOOK-*.md`, and an established lessons-file pattern at `docs/lessons/<prefix>-m<N>.md`. [`/slo-retro`](../skills/slo-retro/SKILL.md) writes the lessons file at milestone close; [`/slo-execute`](../skills/slo-execute/SKILL.md) reads the *previous* milestone's lessons at pre-flight (a single-step look-back, not a queued backlog).
+
+What works:
+
+- Lessons get written every milestone.
+- The previous milestone's lessons get read by `/slo-execute` Step 1.
+
+What does not work:
+
+- Lessons that apply to upstream tools (Semgrep, Playwright, `cargo audit`, etc.) never get filed upstream.
+- Lessons that apply to SLO itself never get filed as tracked work.
+- The cyclic structures of the skill pack (engineering loops, business loops) are implicit; newcomers and freshly-loaded Claude instances cannot see them.
+- A milestone in M5 cannot easily surface a lesson learned at M2 — the look-back is one-step.
+
+### Problem
+
+1. **Forward dropout in lessons**: Lessons land in markdown files but rarely get re-read past the immediately-following milestone. Concrete: M3 lessons file mentioned a naming-convention drift; M5 of the same runbook re-introduced the drift because no agent re-read M3's file before M5 work began.
+2. **Lateral dropout in upstream signal**: When `/slo-execute` discovers a bug in an upstream tool, the lesson sits in a markdown file. The library-feedback loop dies in a local file. Concrete: a Semgrep CLI flag deprecation was noted in `docs/lessons/slo-sec-m4.md` but never filed against the Semgrep repo.
+3. **Implicit loop structure**: ARCHITECTURE.md describes static structure; SKILL.md files describe individual moves. No document shows the cyclic feedback structures (sprint loop, security-tuning loop, lessons loop, library-feedback loop on engineering side; user-interview loop, GTM loop, pricing loop, founder-check loop on business side). Newcomers cannot answer "how does this skill pack improve itself?".
+4. **No fallback when `gh` is unavailable**: Any extension to `/slo-retro` that depends on `gh` becomes a hard dependency, which violates the graceful-degradation pattern observed across the rest of the pack. A `LESSONS-BACKLOG.md` local fallback closes this gap.
+
+### Target Architecture
+
+See "End-to-End Architecture Diagram" above.
+
+### Key Design Principles
+
+0. **Over-engineering for simplicity**: per [`docs/PARADIGM-OVER-ENGINEERING-FOR-SIMPLICITY.md`](PARADIGM-OVER-ENGINEERING-FOR-SIMPLICITY.md), the LLM-driven loop pipeline can sustainably carry MORE discipline than a human-driven equivalent because LLMs do not pay the cognitive-load tax. The lessons loop itself is the canonical example: humans skip post-mortems; LLMs file them as tracked work, run dedupe via `gh search`, and surface them at the next milestone's pre-flight. The user (founder / engineer) sees a working loop; the agent does the bookkeeping.
+
+1. **Loop docs live next to architecture**: `docs/LOOPS-ENGINEERING.md` and `docs/LOOPS-BUSINESS.md` are top-level `docs/` siblings of `ARCHITECTURE.md`. Cross-links go both ways: ARCHITECTURE.md links to LOOPS-*.md; each implicated SKILL.md links to its loop section.
+2. **Issue filing requires user confirmation**: Issue creation is publicly visible; never auto-file. This is a discipline rule, not a security boundary.
+3. **`gh search` is the dedupe mechanism**: Marker (title prefix vs label vs body sentinel) is decided in M3 spike step before the dedupe rule lands.
+4. **Graceful degradation when `gh` is unavailable**: `LESSONS-BACKLOG.md` local fallback. The retro skill never fails because of `gh` trouble.
+5. **Carry-forward at milestone start, not retro**: The retro filing produces issues but doesn't change behavior; surfacing at the next milestone's pre-flight is what closes the loop.
+6. **Argv-list discipline**: Every `gh` invocation in modified skill prose follows argv-list form. Inherited from `/slo-sast` M5 + `/slo-sec-libs` M3 disciplines.
+
+### What to Keep
+
+- Existing [`docs/lessons/<prefix>-m<N>.md`](lessons/) template (additive changes only).
+- Existing [`/slo-retro` Outputs contract](../skills/slo-retro/SKILL.md) (additive changes only — issue filing AFTER lessons file write).
+- Existing [`/slo-execute` Pre-flight steps](../skills/slo-execute/SKILL.md) (additive changes only — issue read AFTER existing pre-flight).
+- Existing structural-contract tests in [`crates/sldo-install/tests/`](../crates/sldo-install/tests/).
+
+### What to Change
+
+- **`docs/LOOPS-ENGINEERING.md`** — NEW (M1).
+- **`docs/LOOPS-BUSINESS.md`** — NEW (M2).
+- **`skills/slo-retro/SKILL.md`** — extend with classify/dedupe/file flow (M3).
+- **`skills/slo-retro/references/issue-filing-discipline.md`** — NEW (M3).
+- **`skills/slo-execute/SKILL.md`** — extend pre-flight with issue-list read (M4).
+- **`docs/runbook-template_v_3_template.md`** — add optional "Carry-forward from prior retros" section (M4).
+- **`ARCHITECTURE.md`** — add cross-links to LOOPS-*.md (M1, M2).
+- **Each engineering SKILL.md and biz SKILL.md** referenced by a loop — add a one-line cross-reference into LOOPS-*.md (M1, M2).
+
+### Global Red Lines
+
+Standard set; in addition:
+
+- No auto-filing of issues without user confirmation (discipline).
+- No `--no-verify` on git commits.
+- No `gh pr create --repo` (confused-deputy defense from `/slo-sast` M5).
+- No replacing the existing one-step lessons look-back in `/slo-execute` — additive only.
+
+---
+
+## BDD and Runtime Validation Rules
+
+See template. Project specifics:
+
+### Required Test Coverage Categories
+
+For each milestone:
+
+- happy path (the loop produces / consumes content as documented)
+- empty state (no prior-retro issues for this runbook's prefix)
+- dependency failure (`gh` not on PATH, or auth missing)
+- backward compatibility (existing runbooks without "Carry-forward" section still work)
+- abuse case (per-milestone — see threat-model rows in [`docs/design/loops-and-lessons-closure-overview.md`](design/loops-and-lessons-closure-overview.md))
+
+### Test File Naming
+
+| Layer | Convention | Location |
+|---|---|---|
+| Markdown structural-contract tests | `tests/e2e_loops_m<N>.rs` | `crates/sldo-install/tests/` |
+| Issue-filing discipline tests | inline in `crates/sldo-install/src/` test modules | — |
+
+---
+
+## Dependency, Migration, and Refactor Policy
+
+See template. **No new runtime dependencies in this runbook.** No schema migrations. Refactor budget per-milestone in the milestone sections.
+
+---
+
+## Evidence Log Template
+
+See template.
+
+---
+
+## Self-Review Gate
+
+See template.
+
+---
+
+## Lessons-Learned File Template
+
+See template (`docs/lessons/loops-m<N>.md`).
+
+---
+
+## Completion Summary Template
+
+See template (`docs/completion/loops-m<N>.md`).
+
+---
+
+## Milestone Plan
+
+### Milestone 1 — `docs/LOOPS-ENGINEERING.md` authored + cross-linked
+
+**Goal**: A `docs/LOOPS-ENGINEERING.md` that documents at minimum the four engineering loops (sprint, security-tuning, lessons, library-feedback), cross-linked from `ARCHITECTURE.md` and from each implicated engineering SKILL.md.
+
+**Context**: The project has no engineering-loops doc today. Issue [#17](https://github.com/kerberosmansour/SunLitOrchestrate/issues/17) is the canonical decision record for "split from business loops, separate doc, separate concerns" + "living doc, no staleness check" + "no per-runbook declaration of loops".
+
+**Important design rule**: Match the closest existing design-doc style (likely `docs/design/scanner-orchestration-overview.md`) for ASCII vs Mermaid choice. Per loop: name, trigger, steps, exit condition, artifacts, skills involved, diagram.
+
+**Refactor budget**: `No refactor permitted beyond direct implementation` — pure new doc + cross-link additions to existing files.
+
+#### Contract Block
+
+| Field | Value |
+|---|---|
+| Inputs | Issue #17 decisions; existing engineering SKILL.md files; existing ARCHITECTURE.md |
+| Outputs | `docs/LOOPS-ENGINEERING.md` (new); cross-links from ARCHITECTURE.md + each implicated SKILL.md |
+| Interfaces touched | ARCHITECTURE.md cross-references; per-skill SKILL.md cross-references |
+| Files allowed to change | `docs/LOOPS-ENGINEERING.md` (new), `ARCHITECTURE.md`, each engineering SKILL.md cited as part of a loop, `crates/sldo-install/tests/e2e_loops_m1.rs` (new) |
+| Files to read before changing anything | All engineering SKILL.md files; `docs/design/scanner-orchestration-overview.md` (for diagram style); Issue #17 |
+| New files allowed | `docs/LOOPS-ENGINEERING.md`, `crates/sldo-install/tests/e2e_loops_m1.rs` |
+| New dependencies allowed | `none` |
+| Migration allowed | `no` |
+| Compatibility commitments | All existing SKILL.md prose preserved; cross-link additions only |
+| Forbidden shortcuts | placeholder loop entries, hand-waved "and others"; every loop entry must name trigger / steps / exit condition / skills involved |
+| **Data classification** | `Public` — engineering loops doc is public-tier (no real PII; the SLO repo is currently private but the doc is intended for public consumption when the repo opens) |
+| **Proactive controls in play** | OWASP Proactive Controls v3 — `C1 Define Security Requirements` (loops document the engineering security-tuning loop explicitly); `C9 Implement Security Logging and Monitoring` (lessons loop is the engineering audit trail) |
+| **Abuse acceptance scenarios** | `tm-loops-abuse-1: prompt injection via lesson body content` — pre-existing `~~~text` user-string fence rule from `/slo-architect` SECURITY.md template applies; documented in this runbook's design overview as residual + mitigated |
+
+#### Out of Scope / Must Not Do
+
+- Adding business-loops content (M2's job).
+- Extending the runbook template (M4's job).
+- Modifying `/slo-retro` or `/slo-execute` SKILL.md (M3 / M4).
+- Removing any existing content from ARCHITECTURE.md.
+
+#### Pre-Flight
+
+1. Complete Global Entry Rules.
+2. Read [Issue #17](https://github.com/kerberosmansour/SunLitOrchestrate/issues/17) end-to-end.
+3. Survey every engineering SKILL.md to identify which ones participate in which loop.
+4. Pick diagram format (ASCII vs Mermaid) by inspecting `docs/design/` for the dominant style.
+
+#### Files Allowed To Change
+
+| File | Planned Change |
+|---|---|
+| `docs/LOOPS-ENGINEERING.md` | NEW: per-loop sections with name / trigger / steps / exit / artifacts / skills / diagram |
+| `ARCHITECTURE.md` | Add a "## Feedback loops" section linking to both LOOPS-*.md files (one paragraph + two bullets) |
+| `skills/<each-engineering-skill>/SKILL.md` | Add a one-line "See `docs/LOOPS-ENGINEERING.md#<loop-name>` for the loop this skill participates in" cross-reference |
+| `crates/sldo-install/tests/e2e_loops_m1.rs` | NEW: structural-contract test asserting (a) `docs/LOOPS-ENGINEERING.md` exists; (b) it has a section per loop; (c) every cross-referenced SKILL.md actually contains the cross-reference link |
+| `.gitignore` | (Likely no change; flag if M1 produces any temp artifacts.) |
+
+#### Step-by-Step
+
+1. Write the structural-contract test stub in `tests/e2e_loops_m1.rs` first (asserts file existence + section headers + cross-reference targets).
+2. Confirm the test fails for the expected reason (file missing).
+3. Author `docs/LOOPS-ENGINEERING.md` with the four documented loops:
+   - **Sprint loop**: think → plan → build → review → test → ship → reflect (skills involved: every `/slo-*`).
+   - **Security-tuning loop**: threat model → SAST/DAST tuning → findings → threat-model refinement (skills: `/slo-architect`, `/slo-sast`, `/slo-rulegen`, `/slo-ruleverify`, `/slo-verify`, `/slo-critique`).
+   - **Lessons loop**: retro → issues → priority order → next milestone (skills: `/slo-retro`, `/slo-execute`).
+   - **Library-feedback loop**: `/slo-sec-libs` capability gap → upstream filing → library improvement → re-scan (skills: `/slo-sec-libs` once R4 ships).
+4. Cross-link from `ARCHITECTURE.md`.
+5. Add per-skill cross-references (one-line each).
+6. Make the structural-contract test pass.
+7. Run full suite + smoke tests.
+8. Self-review gate.
+
+#### BDD Acceptance Scenarios
+
+**Feature: engineering loops documented and discoverable**
+
+| Scenario | Category | Given | When | Then |
+|---|---|---|---|---|
+| Engineering loops doc exists | happy path | repo at HEAD | open `docs/LOOPS-ENGINEERING.md` | document opens with at least 4 loop sections (sprint, security-tuning, lessons, library-feedback) |
+| ARCHITECTURE.md cross-links to engineering loops | happy path | ARCHITECTURE.md exists | grep ARCHITECTURE.md for `LOOPS-ENGINEERING.md` | match found in a "Feedback loops" section |
+| Each engineering SKILL.md cited in a loop has a cross-reference | happy path | SKILL.md cited under "Sprint loop" section | grep SKILL.md for `LOOPS-ENGINEERING.md` | match found |
+| Loop cited in doc has missing cross-reference | invalid input / structural | LOOPS-ENGINEERING.md cites SKILL.md X under loop Y | grep SKILL.md X for `LOOPS-ENGINEERING.md#<loop-y>` | structural-contract test FAILS until cross-reference is added |
+| Empty loops file | empty state | LOOPS-ENGINEERING.md is empty | structural-contract test runs | test FAILS with "no loop sections found" |
+| Library-feedback loop placeholder while R4 unshipped | partial | `/slo-sec-libs` does not yet exist | inspect Library-feedback loop section | section is present with "ships in Runbook 4" footnote, NOT removed silently |
+| Prompt-injection abuse case | abuse case (`tm-loops-abuse-1`) | a lesson body contains `<script>alert(1)</script>` | LOOPS-ENGINEERING.md template uses `~~~text` fence for any quoted lesson body | Markdown renders the script as literal text, not executable |
+
+#### Regression Tests
+
+- `cargo test --workspace` — full suite green.
+- Existing `crates/sldo-install/tests/` SKILL.md installation tests still pass after cross-references added.
+- Each modified SKILL.md still installs symlinked correctly.
+
+#### Compatibility Checklist
+
+- [ ] Every existing SKILL.md still installs.
+- [ ] ARCHITECTURE.md still renders cleanly (no broken links).
+- [ ] No existing test fails.
+
+#### E2E Runtime Validation
+
+**File**: `crates/sldo-install/tests/e2e_loops_m1.rs`
+
+| E2E Test | What It Proves | Pass Criteria |
+|---|---|---|
+| `loops_engineering_doc_exists_and_has_required_sections` | Document is present with required loop sections | All four loop sections present; each has name + trigger + steps + exit-condition + skills + diagram |
+| `architecture_md_cross_links_loops_engineering` | Bidirectional discoverability | ARCHITECTURE.md grep for `LOOPS-ENGINEERING.md` returns ≥ 1 match in a "Feedback loops" or equivalent section |
+| `every_cited_skill_has_cross_reference` | Cross-reference invariant | For every SKILL.md cited under a loop, that SKILL.md contains the corresponding `LOOPS-ENGINEERING.md#<loop>` link |
+
+#### Smoke Tests
+
+- [ ] Open `docs/LOOPS-ENGINEERING.md` — diagrams render in GitHub web view.
+- [ ] Click ARCHITECTURE.md → LOOPS-ENGINEERING.md — link works.
+- [ ] Open one cross-referenced SKILL.md — back-link to LOOPS-ENGINEERING.md works.
+- [ ] `cargo test -p sldo-install` passes.
+- [ ] `git status` shows no untracked test artifacts.
+
+#### Evidence Log
+
+| Step | Command / Check | Expected Result | Actual Result | Pass/Fail | Notes |
+|---|---|---|---|---|---|
+| Baseline | `cargo test --workspace` | green | | | |
+| Test stub created | `tests/e2e_loops_m1.rs` | fails with "file missing" | | | |
+| LOOPS-ENGINEERING.md authored | inspect file | 4 loop sections + diagrams | | | |
+| ARCHITECTURE cross-link | grep for `LOOPS-ENGINEERING.md` | ≥ 1 match | | | |
+| Per-skill cross-references | grep all engineering SKILL.md | every cited skill linked | | | |
+| Full tests | `cargo test --workspace` | green | | | |
+| `.gitignore` review | | no new patterns needed | | | |
+
+#### Definition of Done
+
+- All listed BDD scenarios pass.
+- Structural-contract test passes.
+- ARCHITECTURE.md links to LOOPS-ENGINEERING.md.
+- Every engineering SKILL.md cited under a loop has the cross-reference.
+- `cargo test --workspace` is green.
+- Lessons file written.
+- Completion summary written.
+- Tracker updated.
+
+#### Post-Flight
+
+- ARCHITECTURE.md update: confirm "Feedback loops" section landed and renders.
+- README.md update: add a "Loops" bullet in the docs index if the README has one.
+
+#### Notes
+
+- The Library-feedback loop section is a placeholder until R4 ships — explicit footnote; do not omit silently.
+- The runbook template change (M4) does not block M1.
+
+---
+
+### Milestone 2 — `docs/LOOPS-BUSINESS.md` authored + cross-linked
+
+**Goal**: A `docs/LOOPS-BUSINESS.md` document covering at minimum the four business loops (user-interview, GTM, pricing, founder-check), cross-linked from each implicated biz SKILL.md.
+
+**Context**: Issue [#18](https://github.com/kerberosmansour/SunLitOrchestrate/issues/18) is the canonical decision record. Same shape as M1; biz domain. Possible additional loops to inventory before authoring: fundraise loop, cofounder loop, hiring loop, legal-triage loop (Issue #18 Q1 leaves these as open additions).
+
+**Important design rule**: Match M1's diagram style for consistency. Per loop: name, trigger, steps, exit condition, artifacts, skills involved, diagram.
+
+**Refactor budget**: `No refactor permitted beyond direct implementation`.
+
+#### Contract Block
+
+| Field | Value |
+|---|---|
+| Inputs | Issue #18 decisions; existing biz SKILL.md files; M1's LOOPS-ENGINEERING.md as style anchor |
+| Outputs | `docs/LOOPS-BUSINESS.md` (new); per-biz-skill cross-references |
+| Interfaces touched | per-biz-skill SKILL.md cross-references; possibly ARCHITECTURE.md if a biz-side architectural sketch is added |
+| Files allowed to change | `docs/LOOPS-BUSINESS.md` (new), each biz SKILL.md cited as part of a loop, `crates/sldo-install/tests/e2e_loops_m2.rs` (new) |
+| Files to read before changing anything | All biz SKILL.md files; M1's LOOPS-ENGINEERING.md; Issue #18 thread |
+| New files allowed | `docs/LOOPS-BUSINESS.md`, `crates/sldo-install/tests/e2e_loops_m2.rs` |
+| New dependencies allowed | `none` |
+| Migration allowed | `no` |
+| Compatibility commitments | M1 work unchanged; biz SKILL.md prose preserved |
+| Forbidden shortcuts | "see M1" placeholder for biz loop steps; every biz loop must be authored explicitly |
+| **Data classification** | `Public` — biz loops doc is structural; no real founder PII |
+| **Proactive controls in play** | OWASP C1 (security requirements anchored in user-interview loop's PII handling); C7 (Enforce Access Controls — biz docs `tier:` discipline anchored in user-interview loop's PII flow) |
+| **Abuse acceptance scenarios** | `tm-loops-abuse-1: prompt injection via lesson body content` (same as M1); `tm-loops-abuse-2: biz-loop documentation leaks PII via interview-quote example` — eliminated by structural rule "no real interview quotes in LOOPS-BUSINESS.md; all examples use Alice / Bob pseudonyms" |
+
+#### Out of Scope / Must Not Do
+
+- Adding engineering-loops content (M1's job).
+- Modifying any biz SKILL.md beyond the cross-reference link.
+- Authoring new biz loops not anchored in existing skill invocations (the loop has to map to a real skill flow).
+
+#### Pre-Flight
+
+1. Complete Global Entry Rules.
+2. Read [Issue #18](https://github.com/kerberosmansour/SunLitOrchestrate/issues/18) end-to-end including thread comments for any inventory additions.
+3. Survey every biz SKILL.md to identify loop participation.
+4. Decide: are there 4 loops (Issue #18 inventory) or 5+ (added during runbook execution)? Confirm with project owner if more than 4.
+
+#### Files Allowed To Change
+
+| File | Planned Change |
+|---|---|
+| `docs/LOOPS-BUSINESS.md` | NEW: per-loop sections matching M1 style |
+| `skills/<each-biz-skill>/SKILL.md` | Add one-line cross-reference |
+| `crates/sldo-install/tests/e2e_loops_m2.rs` | NEW: same shape as M1's test |
+
+#### Step-by-Step
+
+1. Test stub first.
+2. Confirm fails for expected reason.
+3. Author `docs/LOOPS-BUSINESS.md` with the documented loops (user-interview, GTM, pricing, founder-check; plus any inventory additions confirmed in pre-flight).
+4. Add per-skill cross-references.
+5. Make tests pass.
+6. Smoke tests.
+7. Self-review gate.
+
+#### BDD Acceptance Scenarios
+
+**Feature: business loops documented and discoverable**
+
+| Scenario | Category | Given | When | Then |
+|---|---|---|---|---|
+| Business loops doc exists | happy path | repo at HEAD | open `docs/LOOPS-BUSINESS.md` | doc opens with ≥ 4 loop sections |
+| Per-biz-skill cross-reference present | happy path | SKILL.md cited under a loop | grep for `LOOPS-BUSINESS.md` | match found |
+| Real-PII example smuggled into doc | abuse case (`tm-loops-abuse-2`) | dev tries to commit LOOPS-BUSINESS.md with a real-name example | `/slo-verify` Pass 4 PII scan over docs/biz-public/ | scan flags; commit blocked until anonymized |
+| Backward compat with M1's LOOPS-ENGINEERING.md | backward compatibility | M1's doc + ARCHITECTURE cross-link | both docs present | both render; both cross-linked |
+| Empty business loops file | empty state | doc empty | structural-contract test runs | test fails |
+
+#### Regression Tests
+
+- `cargo test --workspace`.
+- M1's structural-contract test still passes.
+- Each modified biz SKILL.md still installs.
+
+#### Compatibility Checklist
+
+- [ ] M1's LOOPS-ENGINEERING.md unchanged.
+- [ ] All biz SKILL.md files still install.
+- [ ] No biz-pack structural-contract test regressed.
+
+#### E2E Runtime Validation
+
+**File**: `crates/sldo-install/tests/e2e_loops_m2.rs` — same shape as M1's, asserting business doc + cross-references.
+
+#### Smoke Tests
+
+- [ ] Diagrams render in GitHub web view.
+- [ ] Cross-links work both directions.
+- [ ] `cargo test -p sldo-install` passes.
+
+#### Evidence Log
+
+(Same shape as M1; copy at execution time.)
+
+#### Definition of Done
+
+- All listed BDD scenarios pass.
+- Cross-references in every biz SKILL.md cited under a loop.
+- `cargo test --workspace` green.
+- Lessons + completion files written.
+
+#### Post-Flight
+
+- ARCHITECTURE.md "Feedback loops" section updated to link both docs.
+
+#### Notes
+
+- If Issue #18 inventory adds loops (e.g., fundraise loop), confirm with project owner before authoring (skill prose may not yet support a true fundraise loop).
+
+---
+
+### Milestone 3 — `/slo-retro` extension: classify, dedupe, file lessons as issues
+
+**Goal**: `/slo-retro` extends to classify each lesson (product / upstream-OSS / slo-process), dedupe via `gh search`, and file as an issue with user confirmation. Fallback to `LESSONS-BACKLOG.md` if `gh` is unavailable. The lessons file is still written first; issue filing is additive after.
+
+**Context**: [Issue #16](https://github.com/kerberosmansour/SunLitOrchestrate/issues/16) is the canonical decision record. Decisions: extension of `/slo-retro` (not a separate skill), dedupe via `gh search` first, never auto-file (always confirm), reuse rate-limit discipline from `/slo-sec-libs`, fallback to local file when no tracker configured.
+
+**Important design rule**: Issue filing is ADDITIVE — the existing lessons file write happens unchanged first; classification + filing run after. If filing fails, the lessons file is still safely on disk.
+
+**Refactor budget**: `Minimal local refactor permitted in listed files only`.
+
+#### Contract Block
+
+| Field | Value |
+|---|---|
+| Inputs | `/slo-retro`-completed lessons file at `docs/lessons/<prefix>-m<N>.md`; runbook prefix; `gh` CLI availability; user confirmation for each filing |
+| Outputs | Issue(s) filed in product / upstream / slo-process repos OR rows appended to `LESSONS-BACKLOG.md`; updated lessons file with `filed_issues:` frontmatter listing the filings |
+| Interfaces touched | `gh issue create` (argv-list, no `--repo`); `gh search issues`; `LESSONS-BACKLOG.md` row format |
+| Files allowed to change | `skills/slo-retro/SKILL.md`, `skills/slo-retro/references/issue-filing-discipline.md` (new), `crates/sldo-install/tests/e2e_loops_m3.rs` (new) |
+| Files to read before changing anything | `skills/slo-retro/SKILL.md` current behavior; `skills/slo-sast/SKILL.md` M5 argv-list discipline; `skills/slo-sec-libs/references/upstream-filing-discipline.md` (R4 — if shipped before R1; otherwise inline-author the rate-limit pattern in this milestone) |
+| New files allowed | `skills/slo-retro/references/issue-filing-discipline.md`, `crates/sldo-install/tests/e2e_loops_m3.rs`, `LESSONS-BACKLOG.md` (in target repos that opt in) |
+| New dependencies allowed | `none` |
+| Migration allowed | `no` |
+| Compatibility commitments | Existing lessons-file write unchanged; existing `/slo-retro` Outputs still produced; issue filing is additive |
+| Forbidden shortcuts | auto-filing without user confirmation; shell-string interpolation of lesson body into `gh issue create`; bypassing dedupe; using `--repo` flag |
+| **Data classification** | `Internal` — lesson content may include reflection on internal codepaths but no real PII; the issue filing makes this content public when the destination repo is public |
+| **Proactive controls in play** | OWASP C5 (Validate All Inputs — lesson body content is fence-wrapped for argv-list); C9 (Logging and Monitoring — every filing carries `gh` author + timestamp); C7 (Access Controls — filing requires user `gh` auth; never silent) |
+| **Abuse acceptance scenarios** | `tm-loops-abuse-3: lesson body splices attacker prose into issue title/body via shell interpolation` — class eliminated by argv-list discipline (inherited from `/slo-sast` M5); `tm-loops-abuse-4: confused-deputy via tampered .git/config` — eliminated by NO `--repo` flag; `tm-loops-abuse-5: filing storm via runaway loop` — mitigated by per-session 40-issues/hr cap (reuses `/slo-sec-libs` pattern) |
+
+#### Out of Scope / Must Not Do
+
+- Replacing the lessons-file write (additive only).
+- Cross-repo issue federation beyond the three classifications.
+- Auto-merging filed issues.
+- Modifying [`crates/sldo-common::toolflags`](../crates/sldo-common/) skill-flag denials beyond what `/slo-retro` already declares.
+
+#### Pre-Flight
+
+1. Complete Global Entry Rules.
+2. Read [`skills/slo-retro/SKILL.md`](../skills/slo-retro/SKILL.md) end-to-end.
+3. Read `skills/slo-sast/SKILL.md` M5 (the argv-list + no-`--repo` discipline anchor).
+4. Read [Issue #16](https://github.com/kerberosmansour/SunLitOrchestrate/issues/16) thread for marker decision.
+5. **Spike step**: test `gh search` reliability against three marker options (title prefix `[retro]`, label `retro-derived`, body sentinel `<!-- retro-derived -->`) on a small populated set. Document the choice in the lessons file before locking it.
+6. Decide explicit upstream-mapping format: `.sldo/upstream-mapping.toml` with crates.io / npm fallback resolution.
+
+#### Files Allowed To Change
+
+| File | Planned Change |
+|---|---|
+| `skills/slo-retro/SKILL.md` | Extend Outputs section with classification + dedupe + filing flow; preserve existing lessons-file output |
+| `skills/slo-retro/references/issue-filing-discipline.md` | NEW: argv-list rules, comprehensive dedupe procedure (NFKC normalization, RTL-override rejection, zero-width / homoglyph rejection, lowercase-fold + whitespace-collapse before search, three-strike search with progressively-broadened queries to catch near-duplicates), rate-limit cap (40 issues/hr per session) PLUS adaptive backoff on observed `gh` rate-limit response codes, confirmation gate with full record-preview, `LESSONS-BACKLOG.md` fallback **with comprehensive audit row schema: `\| YYYY-MM-DD HH:MM:SSZ \| classification (product/upstream-OSS/slo-process) \| skill_or_runbook_prefix \| agent_version (claude-model-id) \| originating_milestone \| dedupe_search_result (none/match-id/ambiguous) \| filed_to (repo-or-local) \| issue_url_or_local_ref \| disposition (filed/skipped-dupe/skipped-user/spilled-cap) \| body_sha256 (first 12 chars, for re-dedup across sessions) \| retry_count \| status (open/closed/transferred) \|`**, three-classification routing |
+| `crates/sldo-install/tests/e2e_loops_m3.rs` | NEW: structural-contract test asserting SKILL.md changes + reference file existence + argv-list discipline mention |
+
+#### Step-by-Step
+
+1. Run the marker-choice spike on a populated test repo.
+2. Author `references/issue-filing-discipline.md` with the marker choice locked.
+3. Test stub first (`tests/e2e_loops_m3.rs`).
+4. Update SKILL.md with the extension flow, citing the new reference file.
+5. Validate via the structural-contract test.
+6. Manual smoke: invoke `/slo-retro` against a sample lessons file; observe classify + dedupe + confirmation prompt.
+7. Self-review gate.
+
+#### BDD Acceptance Scenarios
+
+**Feature: retro extension files lessons as issues with discipline**
+
+| Scenario | Category | Given | When | Then |
+|---|---|---|---|---|
+| Happy path: 3 lessons classified + filed | happy path | lessons file with 3 lessons (1 product, 1 upstream, 1 slo-process) | `/slo-retro` runs after milestone close | 3 issues filed with user confirmation; `filed_issues:` frontmatter in lessons file |
+| Dedupe finds existing issue | happy path | similar lesson already filed | `/slo-retro` classifies + searches | dedupe surfaces the existing issue; no new filing |
+| `gh` not on PATH | dependency failure | `which gh` returns nothing | `/slo-retro` runs | falls back to `LESSONS-BACKLOG.md`; lessons file written; user notified |
+| `gh auth login` not configured | dependency failure | `gh auth status` returns unauth | `/slo-retro` runs | falls back to `LESSONS-BACKLOG.md`; user notified with `gh auth login` install hint |
+| User declines a specific filing | invalid input / consent | user types `n` at confirmation | `/slo-retro` skips that one | other filings proceed; declined filing recorded in lessons frontmatter as `filed: false` |
+| Empty lessons file (no lessons to file) | empty state | lessons file has no flagged lessons | `/slo-retro` runs | "no lessons to file" notice; no `gh` calls; exit clean |
+| Lesson body contains shell-injection payload | abuse case (`tm-loops-abuse-3`) | lesson body has `; rm -rf /` | `/slo-retro` constructs `gh issue create` argv | argv-list passes the string as a single argument; `rm -rf` not executed |
+| Title with homoglyph evades dedupe | abuse case (`tm-loops-abuse-3a`, paradigm: comprehensive abuse enumeration) | candidate title `[retroʿ] X` (Hebrew letter substituted for `o`) | dedupe runs three-strike search (literal, NFKC-normalized, ASCII-only-collapsed) | dedupe matches if any of the three strikes hits; refuses to file silently if homoglyph normalization would change the marker (escalates to user) |
+| Title with zero-width characters | abuse case (`tm-loops-abuse-3b`) | candidate title `[retro​] X` | dedupe pre-normalizes by stripping zero-width codepoints (U+200B / U+200C / U+200D / U+FEFF) | dedupe match found in normalized form |
+| Title with RTL override | abuse case (`tm-loops-abuse-3c`) | candidate title contains U+202E or U+202D | dedupe rejects RTL/LTR override codepoints | refuses to file with clear stderr; never falls through to "looks fine" |
+| Body with code-injection in fence | abuse case (`tm-loops-abuse-3d`) | lesson body has ```` ```bash; rm -rf /``` ```` | issue body wrapped in `~~~text` fence per `/slo-architect` user-string-fence rule (load-bearing across the pack) | fence preserved verbatim; agent reading the issue back via M4 carry-forward treats the content as literal text |
+| Body > 65,536 chars (GitHub issue body cap) | dependency failure (paradigm: handle every degraded state, not just happy) | lesson body exceeds GitHub's 65,536-char issue body limit | filer truncates body with `... [truncated; full body in lessons file at <path>]` footer | filer never silently fails on the API error; preserves discoverability via the lessons file path |
+| Issue body contains a markdown reference cycle | abuse case (`tm-loops-abuse-3e`) | lesson body cites `docs/lessons/<this-milestone>.md` (self-reference) | filer detects self-reference; rewrites as `<this milestone, see runbook tracker>` | no infinite recursion when M4 carry-forward reads it back |
+| Filing during a `gh` rate-limit response | dependency failure | `gh issue create` returns secondary rate-limit error | filer reads `Retry-After` header, applies adaptive backoff, surfaces to user | does not retry blind; either waits + retries with user confirm, or spills to LESSONS-BACKLOG.md |
+| Two retros in same session try to file same lesson | concurrency (paradigm: comprehensive coverage even when unlikely) | M3-of-runbook-A and M3-of-runbook-B both produce a similar lesson | dedupe via body_sha256 (in audit row) catches the cross-runbook duplicate | second filing surfaces the prior; user decides merge / skip / file-new |
+| Tampered `.git/config` redirects origin | abuse case (`tm-loops-abuse-4`) | adversary modifies `.git/config` remote.origin.url | `/slo-retro` files | NO `--repo` flag = uses local origin; resolved to attacker repo only if attacker also controls local config (same trust class) — surfaced in confirmation gate ("filing to <origin>: confirm?") |
+| Filing storm | abuse case (`tm-loops-abuse-5`) | session has filed 40 issues already | 41st filing attempted | rate-limit cap fires; remaining lessons routed to `LESSONS-BACKLOG.md` |
+| Backward compat: lessons file with no `filed_issues:` frontmatter | backward compatibility | existing lessons file pre-M3 | `/slo-retro` runs again | no-op on already-closed milestone; new milestone runs clean |
+
+#### Regression Tests
+
+- `cargo test --workspace`.
+- Existing `/slo-retro` SKILL.md install symlink test.
+- M1 + M2 structural-contract tests still pass.
+
+#### Compatibility Checklist
+
+- [ ] Existing lessons-file write happens before any `gh` call.
+- [ ] If `gh` errors, lessons file is still on disk.
+- [ ] Existing `/slo-retro` install symlink unchanged.
+- [ ] `/slo-execute`'s existing pre-flight Step 1 (read previous milestone's lessons) unaffected.
+
+#### E2E Runtime Validation
+
+**File**: `crates/sldo-install/tests/e2e_loops_m3.rs`
+
+| E2E Test | What It Proves | Pass Criteria |
+|---|---|---|
+| `slo_retro_skill_md_extended` | SKILL.md has the new section | grep matches "## Issue filing" or equivalent header |
+| `issue_filing_discipline_reference_exists` | Reference file exists | `references/issue-filing-discipline.md` present + frontmatter valid |
+| `argv_list_discipline_documented` | argv-list rule present in reference file | grep for "argv-list" in `references/issue-filing-discipline.md` |
+| `no_repo_flag_documented` | NO `--repo` rule present | grep for "NO `--repo`" |
+| `rate_limit_cap_documented` | 40-issues/hr cap present | grep for "40 issues" or "40 per session" |
+| `lessons_backlog_fallback_documented` | Fallback present | grep for `LESSONS-BACKLOG.md` |
+
+#### Smoke Tests
+
+- [ ] Mock-invoke `/slo-retro` against a fixture lessons file; observe confirmation prompt.
+- [ ] Decline at the confirmation prompt; verify no filing happens.
+- [ ] Set `gh auth status` to unauth via env override; observe fallback.
+- [ ] Test argv-list with a payload containing `;` `|` `&` — confirm no shell interpretation.
+
+#### Evidence Log
+
+(Copy at execution time.)
+
+#### Definition of Done
+
+- All BDD scenarios pass.
+- Argv-list discipline cited and tested.
+- Marker choice locked in `references/issue-filing-discipline.md` with the spike data.
+- Fallback works (verified manually).
+- Tracker + lessons + completion files written.
+
+#### Post-Flight
+
+- `ARCHITECTURE.md` update: add a paragraph in the "Feedback loops" section pointing at the new filing flow.
+- README.md update: not required.
+
+#### Notes
+
+- The marker-choice spike result is itself a lesson worth filing; M3 closing produces M3-of-this-runbook lessons that get filed via... M3's own mechanic. Self-bootstrapping; document the dogfood-smoke-test in the completion summary.
+
+---
+
+### Milestone 4 — `/slo-execute` pre-flight loop closure + runbook template "Carry-forward from prior retros" section
+
+**Goal**: `/slo-execute M<N>` pre-flight queries open issues filed by `/slo-retro` for prior milestones in this runbook's prefix; surfaces them as scope candidates; user decides each milestone's bounds. Runbook template gains an optional "Carry-forward from prior retros" section so the loop is visible in the artifact, not just in the skill flow.
+
+**Context**: [Issue #16](https://github.com/kerberosmansour/SunLitOrchestrate/issues/16) decision: "close the loop in execution flow ... runbook template should reflect this — don't bolt it onto the skill alone." [Issue #16 Q3](https://github.com/kerberosmansour/SunLitOrchestrate/issues/16) decision (folded into this runbook): the template change lives here.
+
+**Important design rule**: Surfacing is informational, not auto-additive. The user decides each milestone's bounds; the skill never auto-extends the allow-list.
+
+**Refactor budget**: `Minimal local refactor permitted in listed files only`.
+
+#### Contract Block
+
+| Field | Value |
+|---|---|
+| Inputs | Runbook at `docs/RUNBOOK-<feature>.md`; current milestone N; prefix from runbook metadata; `gh` CLI |
+| Outputs | Pre-flight stdout listing open prior-retro issues for this prefix; updated runbook template with new section schema |
+| Interfaces touched | `/slo-execute` SKILL.md pre-flight section (additive); `docs/runbook-template_v_3_template.md` (additive section) |
+| Files allowed to change | `skills/slo-execute/SKILL.md`, `docs/runbook-template_v_3_template.md`, `crates/sldo-install/tests/e2e_loops_m4.rs` (new) |
+| Files to read before changing anything | `skills/slo-execute/SKILL.md` current pre-flight; M3's `references/issue-filing-discipline.md` (for marker choice); `docs/runbook-template_v_3_template.md` |
+| New files allowed | `crates/sldo-install/tests/e2e_loops_m4.rs` |
+| New dependencies allowed | `none` |
+| Migration allowed | `no` |
+| Compatibility commitments | Existing pre-flight Step 1 (read previous milestone's lessons) unchanged; new step ADDED at Step 1.5 or as Step 2; existing runbooks without "Carry-forward" section still work |
+| Forbidden shortcuts | auto-extending allow-list based on carry-forward; silently filtering issues; `--repo` flag |
+| **Data classification** | `Internal` — issue titles / bodies surface as stdout; no PII expected (lesson-derived) |
+| **Proactive controls in play** | C5 (Validate inputs); C9 (Logging — every pre-flight read recorded in evidence log) |
+| **Abuse acceptance scenarios** | `tm-loops-abuse-6: malicious carry-forward issue body smuggles prompt-injection content into agent context` — eliminated by `~~~text` fence around any quoted issue body (matches `/slo-architect` user-string-fence rule) |
+
+#### Out of Scope / Must Not Do
+
+- Auto-extending the allow-list.
+- Cross-runbook carry-forward (each runbook reads only its own prefix).
+- Modifying the lesson-→issue filing flow (M3's domain).
+- Removing existing pre-flight steps.
+
+#### Pre-Flight
+
+1. Complete Global Entry Rules.
+2. Read M3's `skills/slo-retro/references/issue-filing-discipline.md` for the marker that the carry-forward query uses.
+3. Read [`skills/slo-execute/SKILL.md`](../skills/slo-execute/SKILL.md) end-to-end.
+4. Read [`docs/runbook-template_v_3_template.md`](runbook-template_v_3_template.md) end-to-end.
+
+#### Files Allowed To Change
+
+| File | Planned Change |
+|---|---|
+| `skills/slo-execute/SKILL.md` | Add pre-flight Step 1.5: "Read open prior-retro issues filtered by this runbook's prefix; surface as scope candidates". Cite M3's marker choice. |
+| `docs/runbook-template_v_3_template.md` | Add new optional section "## Carry-forward from prior retros" between "Background Context" and "BDD and Runtime Validation Rules". Schema: per-row issue # + title + suggested-milestone column. |
+| `crates/sldo-install/tests/e2e_loops_m4.rs` | NEW: structural-contract test asserting SKILL.md change + template change |
+
+#### Step-by-Step
+
+1. Test stub.
+2. Update SKILL.md pre-flight prose with the additive Step 1.5.
+3. Update runbook template with the new section.
+4. Update one existing runbook (this runbook itself, when M4 closes — dogfood) to include a "Carry-forward from prior retros" section listing M1-M3's filed issues if any.
+5. Verify structural-contract test.
+6. Smoke tests.
+7. Self-review.
+
+#### BDD Acceptance Scenarios
+
+**Feature: milestone-start loop closure**
+
+| Scenario | Category | Given | When | Then |
+|---|---|---|---|---|
+| Pre-flight surfaces open prior-retro issues | happy path | runbook prefix `loops`; M1-M3 closed; issues filed | `/slo-execute M4` pre-flight runs | stdout lists open `loops`-prefix retro-derived issues with title + # |
+| No prior-retro issues for this prefix | empty state | first milestone of a runbook | `/slo-execute M1` pre-flight runs | stdout: "no carry-forward from prior retros (this is M1)" |
+| `gh` unavailable | dependency failure | `gh` missing | pre-flight runs | warns + proceeds (does not block on gh-availability for this informational read) |
+| `gh` returns rate-limit | dependency failure (paradigm: comprehensive degraded states) | `gh issue list` returns 403 secondary rate-limit | pre-flight | applies 5s timeout; falls back to "carry-forward unavailable; gh rate-limited at <retry_after>"; never hangs |
+| Tampered issue body smuggles prompt | abuse case (`tm-loops-abuse-6`) | issue body contains `<role>system</role>` payload | pre-flight surfaces issue | issue body wrapped in `~~~text` fence in stdout; agent treats as literal text |
+| Issue was transferred to another repo | dependency failure (paradigm: comprehensive degraded states) | retro-derived issue moved from current repo to `kerberosmansour/SunLitOrchestrate` | `gh issue list` returns it under different repo | carry-forward surfaces with `[transferred from <origin>]` annotation; does NOT auto-follow the cross-repo reference |
+| Issue closed but linked PR is open | dependency failure | issue closed by referencing PR `Fixes #N` but PR is unmerged | carry-forward query | surfaces as "closed-via-PR-pending"; user decides whether to track |
+| Issue is a `gh` cache stale-read | dependency failure | local `gh` cache returns issue last-known-state from 2 weeks ago | carry-forward query | carry-forward annotates "freshness: cached <timestamp>"; user can `gh repo refresh` and re-run |
+| Multi-runbook prefix collision | edge case | two runbooks share a prefix accidentally (e.g., both `loops`) | carry-forward query | filter is by exact prefix; if collision, surface BOTH as "ambiguous prefix; consider runbook ID renaming" |
+| Backward compat: runbook without Carry-forward section | backward compatibility | existing runbook pre-M4 | `/slo-execute` runs | works unchanged; no error about missing section |
+| Forward compat: runbook with Carry-forward section but no filed issues yet | backward compatibility | new runbook with section template | `/slo-execute M1` runs | section is empty; no error |
+| Auto-extend allow-list attempt | abuse case (`tm-loops-abuse-7: agent extends allow-list silently based on carry-forward`) | carry-forward suggests editing file outside allow-list | `/slo-execute` runs | flagged; user-confirmation gate fires before any extension; matches existing allow-list rule |
+
+#### Regression Tests
+
+- `cargo test --workspace`.
+- Existing `/slo-execute` install + behavior tests.
+- M1, M2, M3 structural-contract tests.
+
+#### Compatibility Checklist
+
+- [ ] `/slo-execute` Step 1 (previous milestone's lessons) still runs first.
+- [ ] Existing runbooks without "Carry-forward" section still execute milestones cleanly.
+- [ ] No existing test fails.
+- [ ] Auto-extension of allow-list is blocked by existing allow-list rule.
+
+#### E2E Runtime Validation
+
+**File**: `crates/sldo-install/tests/e2e_loops_m4.rs`
+
+| E2E Test | What It Proves | Pass Criteria |
+|---|---|---|
+| `slo_execute_pre_flight_extended` | SKILL.md change applied | grep for "prior-retro" in pre-flight section |
+| `runbook_template_carry_forward_section` | Template change applied | grep `runbook-template_v_3_template.md` for "Carry-forward from prior retros" |
+| `gh_issue_list_argv_list_documented` | argv-list discipline | grep for `gh issue list` argv pattern in SKILL.md |
+| `no_auto_extend_allowlist_documented` | Discipline preserved | grep SKILL.md for "user decides each milestone's bounds" |
+
+#### Smoke Tests
+
+- [ ] Mock-invoke `/slo-execute` on a runbook with M1-M3 closed; observe carry-forward surface.
+- [ ] Mock-invoke on a runbook with no prior milestones; observe empty-state message.
+- [ ] Verify `gh` unavailable does not block.
+- [ ] Manual: confirm template's new section renders.
+
+#### Evidence Log
+
+(Copy at execution time.)
+
+#### Definition of Done
+
+- All BDD scenarios pass.
+- Pre-flight Step 1.5 added without removing Step 1.
+- Runbook template gains the new optional section.
+- Dogfood: this runbook itself includes a "Carry-forward from prior retros" section after M4 closes (even if empty for M1).
+- Tracker + lessons + completion files written.
+- ARCHITECTURE.md "Feedback loops" section updated to mention milestone-start carry-forward.
+
+#### Post-Flight
+
+- ARCHITECTURE.md update: "Feedback loops" section gains the milestone-start-carry-forward bullet.
+- README.md update: not required.
+
+#### Notes
+
+- This runbook self-tests the loop. After M4 closes, M5 (which doesn't exist) won't run — but if a future runbook executes after this one ships, it inherits the carry-forward mechanic.
+
+---
+
+## Documentation Update Table
+
+| Milestone | ARCHITECTURE.md Update | README.md Update | .gitignore Update | Other Docs |
+|---|---|---|---|---|
+| 1 | Add "Feedback loops" section linking LOOPS-ENGINEERING.md | optional bullet in docs index | none | Per-skill SKILL.md cross-references |
+| 2 | Update "Feedback loops" section to link LOOPS-BUSINESS.md too | optional | none | Per-biz-skill SKILL.md cross-references |
+| 3 | Note `/slo-retro` issue-filing extension | optional | none | `skills/slo-retro/references/issue-filing-discipline.md` (new) |
+| 4 | Note `/slo-execute` pre-flight loop closure | optional | none | `docs/runbook-template_v_3_template.md` (new section) |
+
+---
+
+## Optional Fast-Fail Review Prompt for Agents
+
+> Restate the milestone goal, allowed files, forbidden changes, compatibility requirements, tests that must be written first, and the exact Definition of Done. Then list the smallest implementation approach that satisfies the contract without widening scope.
+
+---
+
+## Carry-forward from prior retros
+
+(This section is the dogfood of M4's template change. It is empty until M3 produces filings, at which point M3's own retro lands carry-forward into a hypothetical M5 — which doesn't exist for this runbook. The section is here so the artifact-shape is visible.)
+
+| Issue | Title | Suggested milestone | Status |
+|---|---|---|---|
+| (none yet — M1) | | | |
+
+---
+
+## Paradigm-driven enhancements (per `docs/PARADIGM-OVER-ENGINEERING-FOR-SIMPLICITY.md`)
+
+This runbook applies the over-engineering-for-simplicity paradigm — LLM-driven workflows can absorb more discipline than human-driven equivalents because LLMs do not pay the cognitive-load tax. Specific layers added because the LLM is the executor:
+
+### Multi-layer dedupe defense (M3)
+
+Where a human-driven implementation would pick ONE marker scheme (title prefix, label, or body sentinel) and rely on a single `gh search` query, this runbook layers:
+
+1. **Three-strike dedupe**: literal search + NFKC-normalized search + ASCII-collapsed search (defends against homoglyph + zero-width + RTL-override evasions).
+2. **Body-SHA-256 cross-session dedupe**: 12-char prefix in the LESSONS-BACKLOG.md row catches duplicates filed across sessions (different agents, same lesson).
+3. **User-confirmation gate**: every filing surfaces the search-result disposition (`none` / `match-id` / `ambiguous`) so the user sees what dedupe found.
+4. **Audit trail**: every audit row records the dedupe outcome so future debugging can trace why a duplicate slipped through.
+
+Each layer adds zero user friction; combined, they catch the failure modes a single-layer human implementation would miss.
+
+### Comprehensive abuse-case enumeration
+
+M3's BDD table enumerates 9 distinct abuse / degraded-state scenarios (homoglyph, zero-width, RTL override, code-fence injection, body > GitHub cap, markdown reference cycle, rate-limit during filing, cross-session duplicate, multi-runbook prefix collision). A human-authored equivalent would typically enumerate 2-3.
+
+### Comprehensive audit row schema
+
+LESSONS-BACKLOG.md row carries 12 fields (date, classification, prefix, agent_version, originating_milestone, dedupe_search_result, filed_to, issue_url_or_local_ref, disposition, body_sha256, retry_count, status). A human-authored row would carry 4-5; the additional fields are no marginal cost to LLM authoring + filing, and unlock cross-session dedupe + audit replay.
+
+### Defense-in-depth across milestones
+
+The paradigm's "multi-layer defense without user friction" pattern:
+
+| Concern | Layer 1 | Layer 2 | Layer 3 | Layer 4 |
+|---|---|---|---|---|
+| Issue body injection | argv-list at `gh issue create` | `~~~text` fence around lesson body | issue-template structured fields | M4 carry-forward also fence-wraps when surfacing |
+| Confused-deputy via `.git/config` | NO `--repo` flag (M3 + M4) | confirmation gate shows resolved origin | carry-forward filter by prefix (limits cross-repo surface) | argv-list (no shell-string interpolation of remote URL) |
+| Lessons drop-out | `/slo-retro` always writes lessons file FIRST | issue filing additive after | M4 surfaces at next milestone | LESSONS-BACKLOG.md fallback if `gh` unavailable |
+| Marker drift | single canonical marker chosen in M3 spike | structural-contract test asserts marker-format | three-strike search defends against evasion | spike-result review at +6 months (per critique L-3) |
+
+### Bounded by context-window
+
+This runbook stays inside the paradigm's "balance against context window, not attention" rule: the v3 template is the orchestrator (used by `/slo-plan`); methodology lives in `references/issue-filing-discipline.md` (consulted on-demand); the LESSONS-BACKLOG.md row schema is one line of text in the contract block; abuse-case BDD rows are individually small. No file in this runbook approaches the soft 200-line cap from R2.

--- a/docs/RUNBOOK-SLO-SEC-LIBS.md
+++ b/docs/RUNBOOK-SLO-SEC-LIBS.md
@@ -1,0 +1,968 @@
+# /slo-sec-libs — Phase 4 of slo-security-embedding (AI-First Runbook v3)
+
+> **Purpose**: Add a `/slo-sec-libs` skill that reads target repo's CycloneDX 1.6+ declarations from Hulumi + SunLitSecureLibraries; matches each runbook proactive-control requirement against advertised library capabilities; recommends a specific component or files a structured capability-gap issue.
+> **Audience**: AI coding agents first, humans second.
+> **How to use**: Work through milestones sequentially. Pre-requisites (one-time) must complete BEFORE M1.
+> **Prerequisite reading**: [ARCHITECTURE.md](../ARCHITECTURE.md), [docs/design/slo-sec-libs-overview.md](design/slo-sec-libs-overview.md), [docs/idea/slo-sec-libs.md](idea/slo-sec-libs.md), [docs/research/slo-sec-libs/synthesis.md](research/slo-sec-libs/synthesis.md), [docs/research/slo-security-embedding/synthesis.md](research/slo-security-embedding/synthesis.md), [Issue #4](https://github.com/kerberosmansour/SunLitOrchestrate/issues/4)
+
+---
+
+## Runbook Metadata
+
+- **Runbook ID**: `slo-sec-libs`
+- **Prefix for test files and lessons files**: `sec-libs`
+- **Primary stack**: Markdown + Rust (`crates/sldo-install`, `crates/sldo-common::toolflags`) + Python 3.10+ subprocess (jsonschema validator) + `gh` CLI + `git`
+- **Primary package/app names**: `skills/slo-sec-libs`, `crates/sldo-common`, `crates/sldo-install`
+- **Default test commands**:
+  - Workspace tests: `cargo test --workspace`
+  - Specific install tests: `cargo test -p sldo-install`
+  - Build: `cargo build --workspace`
+  - Python subprocess test (M1): manual run with fixture declarations file
+- **Allowed new dependencies by default**: `none` (Python jsonschema is system-installed; no new Rust crates)
+- **Schema/config migration allowed by default**: `no`
+- **Public interfaces that must remain stable**:
+  - Phase 1 security-aware skills (`/slo-ideate`, `/slo-architect`, `/slo-plan`, `/slo-critique`, `/slo-verify`) unchanged.
+  - Existing `/slo-sast`, `/slo-rulegen`, `/slo-ruleverify` argv-list discipline preserved.
+  - `crates/sldo-common::toolflags` deny-list pattern unchanged.
+
+---
+
+## Milestone Tracker
+
+| # | Milestone | Status | Started | Completed | Lessons File | Completion Summary |
+|---|---|---|---|---|---|---|
+| 1 | CycloneDX 1.6 declarations reader (Python jsonschema subprocess) | `not_started` | | | | |
+| 2 | Capability matcher (proactive-controls → advertised capabilities) | `not_started` | | | | |
+| 3 | SLO-intake filer (default channel; `kerberosmansour/slo-security-intake`) | `not_started` | | | | |
+| 4 | Third-party filing gate + per-session 40-issues/hr cap | `not_started` | | | | |
+| 5 | Dogfood: re-critique an SLO milestone using `/slo-sec-libs` | `not_started` | | | | |
+
+### Pre-requisites (one-time, BEFORE M1)
+
+- [ ] Create `kerberosmansour/slo-security-intake` repo (issue-tracker-only).
+- [ ] Populate `ISSUE_TEMPLATE/capability-gap-record.md` per the M3 schema.
+- [ ] Add CycloneDX 1.6 `declarations` JSON to `kerberosmansour/hulumi`. Each crate / component advertises controls (use `cdx:sunlit:crypto:*` namespace for parametric crypto claims).
+- [ ] Add CycloneDX 1.6 `declarations` JSON to `SunLitSecureLibraries`. Same shape.
+- [ ] Confirm `gh` CLI scopes (`repo` or `public_repo` for same-owner; `repo` for cross-repo fork+PR fallback) on contributor machines.
+
+---
+
+## End-to-End Architecture Diagram
+
+```
+┌──────────────────────────────────────────────────────────────────────────┐
+│                  /slo-sec-libs skill                                     │
+│                                                                          │
+│  Inputs:                                                                 │
+│  - target repo's ARCHITECTURE.md + stack-decision.md                    │
+│  - target repo's RUNBOOK-<slug>.md proactive-controls rows              │
+│  - pinned CycloneDX schema SHA                                          │
+│  - pinned Hulumi + SunLitSecureLibraries declaration SHA per source     │
+│                                                                          │
+│  ┌───────────────────────────────────────────────────────────────┐     │
+│  │ Pre-flight (every invocation):                                 │     │
+│  │ 1. Python 3.10+ + jsonschema available (`python3 -c "import   │     │
+│  │    jsonschema"`)                                               │     │
+│  │ 2. target repo has ARCHITECTURE.md + stack-decision.md         │     │
+│  │ 3. runbook declares security_libs_required: true               │     │
+│  │ 4. pinned-SHA values present (regex 40-char hex)              │     │
+│  │ 5. cwd is a git repo                                           │     │
+│  └─────────────────────────┬─────────────────────────────────────┘     │
+│                            │                                              │
+│                            ▼                                              │
+│  ┌─────────────────────────────────────────────────────────────────┐   │
+│  │ M1: declarations reader (Python jsonschema subprocess)          │   │
+│  │   - fetch CycloneDX 1.6 declarations from cache or git clone    │   │
+│  │     (~/.cache/sldo/declarations/<sha>/)                         │   │
+│  │   - validate with jsonschema (strict; reject billion-laughs)    │   │
+│  │   - extract structured capability catalog (stdout JSON)         │   │
+│  │   - argv-list subprocess invocation                             │   │
+│  │   - file size cap 10 MiB before parse                           │   │
+│  └─────────────────────────┬───────────────────────────────────────┘   │
+│                            │                                              │
+│                            ▼                                              │
+│  ┌─────────────────────────────────────────────────────────────────┐   │
+│  │ M2: capability matcher                                          │   │
+│  │   - read target runbook proactive-controls rows                 │   │
+│  │   - match each row against capability catalog                   │   │
+│  │   - tiebreaker: more parametric claims = more specific          │   │
+│  │   - emit JSON: { matched: [...], unmatched: [...] }             │   │
+│  └─────────────────────────┬───────────────────────────────────────┘   │
+│                            │                                              │
+│                            ▼                                              │
+│  ┌─────────────────────────────────────────────────────────────────┐   │
+│  │ M3: SLO-intake filer (default)                                  │   │
+│  │   - for each unmatched: produce capability-gap record           │   │
+│  │     (regex-validated schema; NO free-text from target prose)    │   │
+│  │   - user confirms each filing                                   │   │
+│  │   - gh issue create (argv-list, NO --repo)                      │   │
+│  │     → kerberosmansour/slo-security-intake                       │   │
+│  └─────────────────────────┬───────────────────────────────────────┘   │
+│                            │                                              │
+│                            ▼                                              │
+│  ┌─────────────────────────────────────────────────────────────────┐   │
+│  │ M4: third-party filing gate (--file-upstream flag)              │   │
+│  │   - default: file to slo-security-intake                        │   │
+│  │   - if --file-upstream: file to library-owner repo              │   │
+│  │   - per-session 40-issues/hr cap (defensive)                    │   │
+│  │   - exceeded → spillover to LESSONS-BACKLOG.md                  │   │
+│  └─────────────────────────────────────────────────────────────────┘   │
+│                                                                          │
+│  M5: Dogfood — re-critique one SLO milestone using /slo-sec-libs        │
+│                                                                          │
+│  Out-of-scope this runbook:                                             │
+│  - Rust CycloneDX emitter (cyclonedx-bom 0.8.1 is 1.5 only — separate)  │
+│  - Phase 2 /slo-threat-model (parked; reader-side only here)            │
+│  - Phase 3 /slo-security-test (separate program)                        │
+│                                                                          │
+│  Legend:  ─── existing    NEW (this runbook)    ▶ data flow             │
+└──────────────────────────────────────────────────────────────────────────┘
+```
+
+### Component Summary Table
+
+| Component | Responsibility | Milestone | Key Interfaces |
+|---|---|---|---|
+| `skills/slo-sec-libs/SKILL.md` | Skill orchestrator; mode dispatch; pre-flight cascade | M1-M5 | Cited from runbook proactive-controls rows |
+| `skills/slo-sec-libs/scripts/read-declarations.py` | Python jsonschema validator + capability extractor | M1 | Subprocess input: CycloneDX JSON; output: stdout JSON catalog |
+| `skills/slo-sec-libs/references/methodology-m1-reader.md` | Declarations reader spec | M1 | Cited from SKILL.md |
+| `skills/slo-sec-libs/references/methodology-m2-matcher.md` | Capability matching algorithm + tiebreaker | M2 | Cited from SKILL.md |
+| `skills/slo-sec-libs/references/capability-gap-schema.md` | Regex-validated schema for gap records | M3 | Cited from SKILL.md and consumed by intake-template |
+| `skills/slo-sec-libs/references/upstream-filing-discipline.md` | argv-list + no-`--repo` + rate-limit | M3-M4 | Cited from SKILL.md |
+| `crates/sldo-common::toolflags::sec_libs_deny_flags()` | Skill-flag denial: `WebFetch`, `WebSearch` denied | M1 | SLO-CLI invocation layer |
+| `kerberosmansour/slo-security-intake` (repo) | Default capability-gap filing destination | Pre-req | `gh issue create` target |
+| Hulumi + SunLitSecureLibraries CycloneDX 1.6 declarations | Capability advertisement | Pre-req | JSON in each repo's release artifacts |
+| `~/.cache/sldo/declarations/<sha>/` | Pinned-SHA cache | M1 | Local FS |
+
+### Data Flow Summary
+
+| Flow | From | To | Protocol/Mechanism | Milestone |
+|---|---|---|---|---|
+| Declarations fetch | Hulumi / SunLitSecureLibraries repo | Local cache | `git clone` (argv-list) → cache | M1 |
+| Declarations parse | Python subprocess | stdout JSON | `python3 scripts/read-declarations.py` (argv-list) | M1 |
+| Capability match | runbook proactive-controls | catalog | LLM judgment + matcher rules | M2 |
+| Capability-gap filing | unmatched record | GitHub | `gh issue create` (argv-list, no `--repo`) | M3-M4 |
+| Rate-limit enforcement | session counter | spillover file | local file write | M4 |
+
+---
+
+## High-Level Design for Formal Verification (TLA+ Section)
+
+`tla_required: false`
+
+No concurrent actors, no distributed state. Single-session, single-actor, sequential (read declarations → match → file). Rate-limit is per-session client-side, not a distributed state machine. Per `/slo-tla`'s suitability gate, this is the wrong tool here.
+
+---
+
+## Global Execution Rules
+
+See [docs/runbook-template_v_3_template.md §"Global Execution Rules"](runbook-template_v_3_template.md). Project-specific overrides:
+
+- **Argv-list discipline non-negotiable**. Every `git`, `gh`, `python3` invocation uses argv-list form. Never shell-string interpolation. Inherited from `/slo-sast` M5 + `/slo-rulegen`.
+- **NO `--repo` flag on `gh pr create` / `gh issue create`** (SEC-8 from `/slo-sast` M5; confused-deputy defense).
+- **NO autofix / merge flags** anywhere. Reader-side + filer only.
+- Research-validation discipline (R2's `references/templates/citation-discipline.md`) applies to every claim about CycloneDX schema, GitHub API, Octokit rate-limit point cost, jsonschema billion-laughs defenses.
+
+## Global Entry / Exit Rules
+
+See template. Specifics:
+
+- Baseline: `cargo test --workspace`. Confirm green before each milestone.
+- Pre-requisites listed at top of Milestone Tracker MUST be confirmed complete before M1.
+
+---
+
+## Background Context
+
+### Current State
+
+[PR #3 (slo-security-embedding M1-M4)](https://github.com/kerberosmansour/SunLitOrchestrate/pull/3) merged. Phase 1 of the security-embedding program complete: `/slo-ideate`, `/slo-architect`, `/slo-plan`, `/slo-critique`, `/slo-verify` are security-aware. Every milestone's Contract Block now declares Data classification + Proactive controls + Abuse acceptance scenarios.
+
+What works:
+
+- Phase 1 makes runbooks security-aware at the planning + critique + verify level.
+- Hulumi (Pulumi components for AWS) and SunLitSecureLibraries (Rust security crates) advertise capabilities via CycloneDX (existing repos).
+- `/slo-sast` ships the SAST orchestration (separate program).
+
+What does not work:
+
+- When a runbook milestone declares "this surface needs an Argon2id password hasher", the agent has no source-of-truth for which library covers that requirement at the runbook's pinned version. Defaults to whatever the model recalls.
+- Hulumi + SunLitSecureLibraries' CycloneDX advertising is dead weight — no skill reads the declarations.
+- When the recommender finds NO library that covers a requirement, the gap dies in lessons file commentary. No upstream filing.
+
+### Problem
+
+1. **No declarations reader**: Phase 1 produces security-aware runbooks; Phase 4 needs to consume the per-library capability advertising that Hulumi + SunLitSecureLibraries already publish.
+2. **No capability matcher**: declarations alone don't pick the library; the matcher reads runbook proactive-controls rows and matches.
+3. **No capability-gap filing**: gaps die in markdown.
+4. **Rust ecosystem lacks 1.6+ declarations support** ([Phase 1 research Q2](research/slo-security-embedding/synthesis.md)): `cyclonedx-bom 0.8.1` is spec-1.5 only. Python jsonschema subprocess is the path; matches Phase 2 SecOpsTM precedent.
+5. **GitHub secondary rate-limit point costs are undocumented** ([Phase 1 research Q5](research/slo-security-embedding/synthesis.md)): defensive cap (40 issues/hr per session) is the answer.
+
+### Target Architecture
+
+See "End-to-End Architecture Diagram" above.
+
+### Key Design Principles
+
+0. **Over-engineering for simplicity**: per [`docs/PARADIGM-OVER-ENGINEERING-FOR-SIMPLICITY.md`](PARADIGM-OVER-ENGINEERING-FOR-SIMPLICITY.md), `/slo-sec-libs` exemplifies the paradigm at the security-library scale. A human-driven library-feedback loop ("file capability gaps upstream") routinely fails because filing 10 issues per quarter is 5 hours of cumulative effort, and developers shortcut to "good enough libraries". The LLM-driven `/slo-sec-libs` files capability gaps as structured records with regex-validated schema, per-session 40-issues/hr cap, argv-list discipline, no `--repo` flag, multi-layer Unicode-trick + billion-laughs + symlink-traversal defenses — all costing the user nothing visible. The user sees: "your runbook needed Argon2id; here's the SunLitSecureLibraries crate that advertises it with parametrics; we filed gaps upstream for the 2 unmatched controls."
+
+1. **Reader-side only this phase**: no Rust CycloneDX emitter work; declarations come from Hulumi + SunLitSecureLibraries; SLO reads them.
+2. **Python jsonschema subprocess**: matches Phase 2 precedent; Rust ecosystem will catch up later.
+3. **SLO-owned intake repo as default**: `kerberosmansour/slo-security-intake`; same-owner authentication; user controls issue-template shape.
+4. **Third-party filing is gated**: `--file-upstream` flag + per-session 40-issues/hr cap.
+5. **Argv-list discipline + no `--repo` flag**: inherited from `/slo-sast` M5; defends against confused-deputy via tampered `.git/config`.
+6. **Capability-gap records are regex-validated**: only structured fields flow into issue body; no free-text from target repo prose.
+7. **Crypto-primitive parametric claims in `cdx:sunlit:crypto:*` namespace**: vendored until upstream Property Taxonomy contribution lands (deferred to follow-up).
+8. **Pre-requisites are out-of-band**: 3 one-time setups before M1; runbook does NOT bootstrap the intake repo or the declarations files.
+9. **Strict jsonschema validate**: reject malformed; reject > 10 MiB before parse (billion-laughs / SEC-2 defense).
+10. **Source hierarchy applies**: every claim about CycloneDX schema / GitHub API / Octokit costs source-verified per R2's `citation-discipline.md`.
+
+### What to Keep
+
+- Phase 1 security-aware skills unchanged.
+- Existing `/slo-sast`, `/slo-rulegen`, `/slo-ruleverify` argv-list discipline.
+- `crates/sldo-common::toolflags` deny-list pattern.
+- Existing `/slo-architect` `~~~text` user-string fence rule.
+- Existing `crates/sldo-install` install-symlink pattern.
+
+### What to Change
+
+- `skills/slo-sec-libs/` (NEW skill: SKILL.md + scripts/ + references/) — M1-M5.
+- `crates/sldo-common::toolflags::sec_libs_deny_flags()` (NEW function) — M1.
+- `crates/sldo-install/tests/e2e_sec_libs_m<N>.rs` (NEW per milestone).
+
+### Global Red Lines
+
+Standard set; in addition:
+
+- **Argv-list discipline non-negotiable**.
+- **NO `--repo` flag on `gh` commands**.
+- **NO `--autofix`, `--auto`, `--squash`, `--rebase`, `--admin`, `--merge`, `gh pr merge`, `gh auth login` from this skill**.
+- **NO Vendor SaaS API fallbacks** (Semgrep AppSec, Snyk, GitHub Advanced Security — explicitly rejected per Phase 1 stack-decision).
+- **NO state persistence across invocations** (rate-limit is per-session; cross-invocation rate is external).
+- **NO `WebFetch` / `WebSearch`** — denied at the SLO-CLI invocation layer.
+- Research-validation discipline applies; unverifiable claims removed.
+
+---
+
+## BDD and Runtime Validation Rules
+
+See template. Project specifics:
+
+### Required Test Coverage Categories
+
+For each milestone:
+
+- happy path
+- empty state (no proactive-controls rows; no declarations file)
+- dependency failure (Python missing, gh missing, declarations file > 10 MiB, malformed JSON)
+- backward compatibility (Phase 1 skills unchanged)
+- abuse case (per-milestone, see `tm-slo-sec-libs-abuse-1..5` from design overview)
+
+### Test File Naming
+
+| Layer | Convention | Location |
+|---|---|---|
+| Skill structural-contract tests | `tests/e2e_sec_libs_m<N>.rs` | `crates/sldo-install/tests/` |
+| Python script tests | inline doctests + integration test in `tests/python/` (M1) | same |
+
+---
+
+## Dependency, Migration, and Refactor Policy
+
+See template. **No new Rust dependencies**. Python 3.10+ + jsonschema is system-installed; pre-flight check.
+
+Refactor budget per-milestone in milestone sections.
+
+---
+
+## Evidence Log Template + Self-Review Gate + Lessons + Completion Templates
+
+See template (`docs/lessons/sec-libs-m<N>.md`, `docs/completion/sec-libs-m<N>.md`).
+
+---
+
+## Milestone Plan
+
+### Milestone 1 — CycloneDX 1.6 declarations reader
+
+**Goal**: `skills/slo-sec-libs/SKILL.md` (skeleton) + `scripts/read-declarations.py` (Python jsonschema validator) reads a CycloneDX 1.6 declarations file from `~/.cache/sldo/declarations/<sha>/`, validates with strict jsonschema, extracts a structured capability catalog as stdout JSON.
+
+**Context**: Phase 1 research Q1-Q2 confirmed CycloneDX 1.6 `declarations` as the canonical input; Rust ecosystem has no 1.6+ support → Python subprocess. M1 lands the reader scaffold + the Python script + the toolflag denial.
+
+**Important design rule**: Strict jsonschema validate. Reject any input > 10 MiB before parse (billion-laughs / SEC-2 defense). Argv-list invocation throughout.
+
+**Refactor budget**: `No refactor permitted beyond direct implementation`.
+
+#### Contract Block
+
+| Field | Value |
+|---|---|
+| Inputs | Pinned CycloneDX 1.6 schema URL + SHA; pinned Hulumi + SunLitSecureLibraries declaration source SHAs; Python 3.10+ + jsonschema availability |
+| Outputs | `skills/slo-sec-libs/SKILL.md` (skeleton); `scripts/read-declarations.py`; `references/methodology-m1-reader.md`; `crates/sldo-common::toolflags::sec_libs_deny_flags()`; structured-contract test |
+| Interfaces touched | NEW skill subtree; toolflag deny-list extension |
+| Files allowed to change | `skills/slo-sec-libs/SKILL.md` (NEW), `skills/slo-sec-libs/scripts/read-declarations.py` (NEW), `skills/slo-sec-libs/references/methodology-m1-reader.md` (NEW), `crates/sldo-common/src/toolflags.rs` (extend), `crates/sldo-install/tests/e2e_sec_libs_m1.rs` (NEW) |
+| Files to read before changing anything | `docs/research/slo-security-embedding/dossier.md` Q1-Q2; `crates/sldo-common/src/toolflags.rs`; existing Phase 1 skills' SKILL.md prose for shape |
+| New files allowed | The 4 new files above |
+| New dependencies allowed | `none` (Python is system-installed; pre-flight check enforces availability) |
+| Migration allowed | `no` |
+| Compatibility commitments | Phase 1 security-aware skills unchanged; existing toolflag deny-list patterns preserved |
+| Forbidden shortcuts | shell-string subprocess; missing argv-list; missing 10 MiB cap; missing strict jsonschema; non-stdlib Python imports (only `jsonschema` allowed; everything else rejected); **per critique S-4: forbidden vendor-SaaS API fallbacks** — Semgrep AppSec, Snyk, GitHub Advanced Security, Veracode, Checkmarx all explicitly banned (Phase 1 stack-decision); **per paradigm — comprehensive defense layers**: missing entity-expansion guard; missing anchor-recursion guard; reading the cache without `git rev-parse HEAD` integrity check; SHA hex non-lowercase or non-40-char (regex `^[0-9a-f]{40}$` strict); using `--depth=1` clone without then verifying SHA matches pin (depth-1 can mask SHA tampering if not verified post-clone); cache layout outside `~/.cache/sldo/declarations/<sha>/` (e.g., `/tmp` is rejected — survives across reboots wrong, attacker-influenceable); silently retrying on `git clone` failure (must surface error + diagnose, not retry blind); reading declarations from a directory that contains a symlink anywhere in the path (O_NOFOLLOW-style) |
+| **Data classification** | `Public` (CycloneDX schemas + capability declarations are public artifacts) |
+| **Proactive controls in play** | C1 (security requirements); C5 (validate inputs — strict jsonschema); C9 (audit trail via cache-SHA) |
+| **Abuse acceptance scenarios** | `tm-slo-sec-libs-abuse-5: malicious CycloneDX file triggers Python jsonschema infinite recursion` — class eliminated by strict validate (no entity expansion / anchor recursion) + 10 MiB cap; `tm-slo-sec-libs-abuse-1: tampered declarations file inflates capability claims` — class eliminated by SHA pinning + `git rev-parse HEAD` cache integrity check; **per paradigm — additional abuse cases enumerated**: `tm-slo-sec-libs-abuse-9: schema-version mismatch attack` (declarations file claims `specVersion: "1.6"` but uses 1.5-only fields) — eliminated by strict validate against pinned 1.6 schema rejects unknown / missing fields; `tm-slo-sec-libs-abuse-10: declarations file with unicode-trick component name` (e.g., a component named `secure-jsonʿ` with homoglyph) — eliminated by NFKC normalization on component names + reject if normalization changes name; `tm-slo-sec-libs-abuse-11: cache poisoning via in-flight tag-rewrite` — eliminated by post-clone `git rev-parse HEAD` verification; `tm-slo-sec-libs-abuse-12: declarations claim a control with no parametric details` (e.g., "supports Argon2id" with no iterations / memory / parallelism) — surfaced as low-confidence match, never as preferred recommendation; `tm-slo-sec-libs-abuse-13: declarations file references an external schema URL not on the pinned hierarchy` — strict validate rejects (offline mode required) |
+
+#### Out of Scope / Must Not Do
+
+- M2's matcher.
+- M3's filer.
+- Rust CycloneDX emitter work.
+- SecOpsTM integration.
+- Vendor SaaS API fallbacks.
+
+#### Pre-Flight
+
+1. Complete Global Entry Rules.
+2. Visit https://cyclonedx.org/docs/1.6/json/ at runbook-author time. Capture schema URL + SHA.
+3. Confirm pre-requisites complete (intake repo + Hulumi/SunLitSecureLibraries declarations exist).
+4. Read `crates/sldo-common/src/toolflags.rs` for the existing deny-list pattern.
+5. Read R2 M1's `references/templates/citation-discipline.md` for source hierarchy.
+
+#### Files Allowed To Change
+
+| File | Planned Change |
+|---|---|
+| `skills/slo-sec-libs/SKILL.md` | NEW: skeleton with pre-flight cascade (Python + jsonschema check, target repo check, runbook check, pinned SHA check, cwd-is-git check), mode dispatch (M1: declarations-reader-only), anti-patterns (shell-string, autofix, vendor SaaS, etc.) |
+| `skills/slo-sec-libs/scripts/read-declarations.py` | NEW: argv `<declarations.json>`; reject > 10 MiB; strict jsonschema validate against pinned 1.6 schema; extract structured capability catalog; emit JSON to stdout; stdlib-only |
+| `skills/slo-sec-libs/references/methodology-m1-reader.md` | NEW: declarations reader spec, cache layout (`~/.cache/sldo/declarations/<sha>/`), SHA pinning + `git rev-parse HEAD` cache integrity check, fault-handling. **Per critique C-4**: cache eviction policy specified — size cap **1 GiB**, age cap **90 days**, eviction strategy **LRU** (least-recently-used). Document in this methodology file; pre-flight cache check enforces. |
+| `crates/sldo-common/src/toolflags.rs` | Extend with `sec_libs_deny_flags()` returning `WebFetch`, `WebSearch` denials |
+| `crates/sldo-install/tests/e2e_sec_libs_m1.rs` | NEW: structural-contract test asserting (a) skill files exist + frontmatter, (b) `sec_libs_deny_flags()` returns expected set, (c) Python script is stdlib-only (no `import requests` etc.), (d) SKILL.md cites argv-list discipline + 10 MiB cap |
+
+#### Step-by-Step
+
+1. Test stub first.
+2. Author SKILL.md skeleton.
+3. Author Python script with strict validate + 10 MiB cap.
+4. Author `methodology-m1-reader.md`.
+5. Extend toolflags.
+6. Run structural-contract test.
+7. Manual smoke: feed a fixture declarations file; observe stdout catalog.
+8. Self-review.
+
+#### BDD Acceptance Scenarios
+
+**Feature: declarations reader works under discipline**
+
+| Scenario | Category | Given | When | Then |
+|---|---|---|---|---|
+| Valid CycloneDX 1.6 declarations | happy path | fixture file | Python script runs | stdout emits structured capability catalog |
+| Malformed JSON | dependency failure | invalid JSON file | script runs | refuses with clear stderr; exit non-zero |
+| File > 10 MiB | abuse case (`tm-slo-sec-libs-abuse-5` related) | 11 MiB file | script runs | refuses before parse |
+| Strict validate rejects entity expansion | abuse case (`tm-slo-sec-libs-abuse-5`) | file with anchor recursion | script runs | strict mode rejects |
+| Tampered declarations (SHA mismatch) | abuse case (`tm-slo-sec-libs-abuse-1`) | cache content's `git rev-parse HEAD` differs from pinned SHA | reader pre-flight | refuses to use cache; wipes cache |
+| Python missing | dependency failure | `which python3` returns nothing | skill pre-flight | clear install hint; exit non-zero |
+| jsonschema library missing | dependency failure | `python3 -c "import jsonschema"` fails | skill pre-flight | install hint (`pip install jsonschema`); exit non-zero |
+| Non-stdlib import in script | abuse case (script provenance) | someone adds `import requests` to the script | structural-contract test | test FAILS |
+| `WebFetch` attempt within script | abuse case (deny-list bypass) | someone adds a WebFetch wrapper | toolflag deny-list | denied at SLO-CLI invocation layer |
+| Backward compat: Phase 1 skills unchanged | backward compatibility | full suite | runs | passes |
+
+#### Regression Tests
+
+- `cargo test --workspace`.
+- Phase 1 skills' install symlink tests.
+- All existing biz-pack and SAST tests.
+
+#### Compatibility Checklist
+
+- [ ] Phase 1 skills unchanged.
+- [ ] `crates/sldo-common::toolflags` extension is additive.
+- [ ] No new Rust dependencies.
+
+#### E2E Runtime Validation
+
+**File**: `crates/sldo-install/tests/e2e_sec_libs_m1.rs`
+
+| E2E Test | What It Proves | Pass Criteria |
+|---|---|---|
+| `slo_sec_libs_skill_exists` | Skill subtree present | `SKILL.md`, `scripts/read-declarations.py`, `references/methodology-m1-reader.md` exist |
+| `sec_libs_deny_flags_returns_webfetch_websearch` | Deny-list extended | function call returns expected set |
+| `python_script_stdlib_only` | Script provenance | grep imports against stdlib allow-list |
+| `argv_list_discipline_documented` | Discipline cited | grep SKILL.md for argv-list rule |
+| `ten_mib_cap_documented` | Size cap cited | grep methodology + script |
+| `strict_jsonschema_documented` | Strict mode cited | grep methodology |
+| `phase_1_skills_unchanged` | Backward compat | git diff against Phase 1 skill SKILL.md files |
+
+#### Smoke Tests
+
+- [ ] Run Python script against a valid Hulumi declarations fixture; observe catalog.
+- [ ] Run against a malformed fixture; observe refusal.
+- [ ] Run against an 11 MiB file; observe refusal before parse.
+- [ ] `cargo test -p sldo-install` passes.
+
+#### Evidence Log
+
+(Copy at execution time.)
+
+#### Definition of Done
+
+- All BDD scenarios pass.
+- Python script stdlib-only + strict + size-capped.
+- Toolflag deny-list extended.
+- Tracker + lessons + completion files written.
+
+#### Post-Flight
+
+- ARCHITECTURE.md update: add `/slo-sec-libs` to skill inventory.
+- README.md: optional bullet.
+
+#### Notes
+
+- The Python script is invoked by Claude Code via `Bash` tool; the SKILL.md prose specifies the exact argv form.
+
+---
+
+### Milestone 2 — Capability matcher
+
+**Goal**: Read target runbook's proactive-controls rows; match each against the capability catalog from M1; emit JSON with `matched: [...]` and `unmatched: [...]`. Tiebreaker rule: more parametric claims = more specific advertising = preferred.
+
+**Context**: M1 produced the catalog. M2 produces the recommendations + gap list. Pure-read; no GitHub side effects.
+
+**Important design rule**: Tiebreaker rule documented; ambiguity-resolution explicit. When two libraries claim the same capability, prefer the one with more parametric claims (more specific advertising). When claims are equally specific, surface BOTH to the user with a "tie" disposition.
+
+**Refactor budget**: `Targeted refactor permitted for matcher logic`.
+
+#### Contract Block
+
+| Field | Value |
+|---|---|
+| Inputs | M1's catalog stdout; target runbook's proactive-controls rows; M1's pre-flight cascade |
+| Outputs | JSON `{ matched: [...], unmatched: [...] }`; methodology-m2 file |
+| Interfaces touched | SKILL.md mode dispatch extended; methodology files |
+| Files allowed to change | `skills/slo-sec-libs/SKILL.md` (extend), `skills/slo-sec-libs/references/methodology-m2-matcher.md` (NEW), `crates/sldo-install/tests/e2e_sec_libs_m2.rs` (NEW) |
+| Files to read before changing anything | M1 lessons + outputs |
+| New files allowed | methodology + test |
+| New dependencies allowed | `none` |
+| Migration allowed | `no` |
+| Compatibility commitments | M1 reader unchanged; toolflag deny-list unchanged |
+| Forbidden shortcuts | LLM-only matching without structured comparison; missing tiebreaker; missing tie disposition |
+| **Data classification** | `Public` |
+| **Proactive controls in play** | C1; C5 (validate inputs against catalog) |
+| **Abuse acceptance scenarios** | `tm-slo-sec-libs-abuse-7: matcher fabricates a capability claim from training memory rather than reading catalog` — class eliminated by structural-contract test asserting matcher output's matched-rows reference catalog entries by ID; no free-text recommendations |
+
+#### Out of Scope / Must Not Do
+
+- Filing (M3 job).
+- Rate-limiting (M4 job).
+- Modifying the M1 catalog format.
+
+#### Pre-Flight
+
+1. Complete Global Entry Rules.
+2. Read M1 lessons + the methodology file.
+3. Plan tiebreaker rule.
+
+#### Files Allowed To Change
+
+(See contract block.)
+
+#### Step-by-Step
+
+1. Test stub first.
+2. Author `methodology-m2-matcher.md` with the matching algorithm + tiebreaker.
+3. Update SKILL.md mode dispatch with M2 mode.
+4. Verify structural-contract test.
+5. Smoke test: feed fixture catalog + fixture runbook; observe matched/unmatched output.
+6. Self-review.
+
+#### BDD Acceptance Scenarios
+
+**Feature: capability matcher resolves runbook → catalog**
+
+| Scenario | Category | Given | When | Then |
+|---|---|---|---|---|
+| All proactive-controls match | happy path | runbook rows match catalog entries | matcher runs | JSON `matched:[...]` populated; `unmatched:[]` |
+| One row unmatched | happy path | runbook needs Argon2id but catalog only has Bcrypt | matcher runs | one entry in `unmatched:[...]` with reason |
+| Tie (two libs claim same capability equally) | happy path | two libs each claim Argon2id with same parametrics | matcher runs | both surfaced in `matched:[...]` with `disposition: tie` |
+| Tiebreaker by specificity | happy path | one lib claims "Argon2id", another "Argon2id with iterations≥3, memory≥64MiB" | matcher runs | second wins; disposition `preferred-by-specificity` |
+| Empty runbook | empty state | no proactive-controls rows | matcher runs | `matched:[]`, `unmatched:[]`; "no controls to match" stderr |
+| Empty catalog | empty state | M1 returned empty catalog | matcher runs | every runbook row → `unmatched`; "no candidate libraries" stderr |
+| Fabricated match | abuse case (`tm-sec-libs-abuse-7`) | matcher emits a `matched:` entry with an ID not in catalog | structural-contract test | test FAILS |
+| Backward compat | backward compatibility | M1 catalog format unchanged | full suite | passes |
+
+#### Regression Tests
+
+- `cargo test --workspace`.
+- M1 structural-contract test.
+
+#### Compatibility Checklist
+
+- [ ] M1 reader unchanged.
+- [ ] Toolflag deny-list unchanged.
+
+#### E2E Runtime Validation
+
+**File**: `crates/sldo-install/tests/e2e_sec_libs_m2.rs`
+
+| E2E Test | What It Proves | Pass Criteria |
+|---|---|---|
+| `methodology_m2_exists` | Methodology file present | path + frontmatter |
+| `tiebreaker_rule_documented` | Specificity rule cited | grep methodology |
+| `tie_disposition_documented` | Tie handling | grep |
+| `every_matched_entry_references_catalog_id` | No fabrication | structural rule on output JSON |
+
+#### Smoke Tests
+
+- [ ] Feed fixture runbook + catalog; observe matcher output.
+- [ ] Feed runbook with unmatched control; observe `unmatched:` populated.
+- [ ] `cargo test -p sldo-install` passes.
+
+#### Evidence Log
+
+(Copy at execution time.)
+
+#### Definition of Done
+
+- All BDD scenarios pass.
+- Tiebreaker rule documented + tested.
+- Tracker + lessons + completion files written.
+
+#### Post-Flight
+
+- ARCHITECTURE.md: not required.
+- README.md: not required.
+
+#### Notes
+
+- M2 is reader-side only; no GitHub side effects yet. M3 is when the filing surface comes in.
+
+---
+
+### Milestone 3 — SLO-intake filer (default channel)
+
+**Goal**: For each `unmatched` capability gap from M2, produce a regex-validated capability-gap record; user confirms each filing; `gh issue create` (argv-list, no `--repo`) to default destination `kerberosmansour/slo-security-intake`.
+
+**Context**: Default destination is SLO-owned. Pre-requisite repo (`slo-security-intake` with `ISSUE_TEMPLATE/capability-gap-record.md`) must exist before this milestone runs.
+
+**Important design rule**: **Capability-gap record is regex-validated.** Only structured fields flow into issue body. No free-text from target repo prose. argv-list throughout. No `--repo` flag.
+
+**Refactor budget**: `Targeted refactor permitted for filer logic`.
+
+#### Contract Block
+
+| Field | Value |
+|---|---|
+| Inputs | M2's `unmatched:` records; user `gh` auth; pre-requisite intake repo + ISSUE_TEMPLATE |
+| Outputs | filed issues in `kerberosmansour/slo-security-intake`; capability-gap-schema.md (NEW); upstream-filing-discipline.md (NEW) |
+| Interfaces touched | SKILL.md mode dispatch extended; new methodology files; `gh issue create` invocation |
+| Files allowed to change | `skills/slo-sec-libs/SKILL.md` (extend), `skills/slo-sec-libs/references/capability-gap-schema.md` (NEW), `skills/slo-sec-libs/references/upstream-filing-discipline.md` (NEW), `crates/sldo-install/tests/e2e_sec_libs_m3.rs` (NEW) |
+| Files to read before changing anything | M2 lessons; `/slo-sast/SKILL.md` M5 (argv-list + no `--repo`); R1 M3's `issue-filing-discipline.md` (rate-limit cap shape) |
+| New files allowed | 2 references + test file |
+| New dependencies allowed | `none` |
+| Migration allowed | `no` |
+| Compatibility commitments | M1 + M2 unchanged; toolflag deny-list unchanged; existing `/slo-sast` argv-list discipline preserved |
+| Forbidden shortcuts | shell-string interpolation; `--repo` flag; auto-filing without confirmation; merge flags; free-text prose in issue body |
+| **Data classification** | `Public` (capability-gap records describe library deltas, not user content) |
+| **Proactive controls in play** | C1; C5 (validate inputs — regex-validated record schema); C7 (access controls — user `gh` auth + per-issue confirmation); C9 (audit trail — every filing carries `gh` author + timestamp) |
+| **Abuse acceptance scenarios** | `tm-slo-sec-libs-abuse-2: capability-gap record body splices attacker-supplied prose from target repo content` — class eliminated by regex-validated schema; `tm-slo-sec-libs-abuse-4: confused-deputy via tampered .git/config redirecting gh` — class eliminated by NO `--repo` flag (inherits SEC-8 from `/slo-sast` M5) |
+
+#### Out of Scope / Must Not Do
+
+- Third-party filing (M4 job).
+- Rate-limit cap (M4 job).
+- Auto-merging anything.
+- Vendor SaaS API fallbacks.
+
+#### Pre-Flight
+
+1. Complete Global Entry Rules.
+2. Read M1, M2 lessons.
+3. Confirm `slo-security-intake` repo exists and has `ISSUE_TEMPLATE/capability-gap-record.md`.
+4. Read `/slo-sast/SKILL.md` M5 (argv-list + no `--repo` discipline).
+5. Read R1 M3's `references/issue-filing-discipline.md` if R1 has shipped (otherwise inline the rate-limit pattern).
+
+#### Files Allowed To Change
+
+(See contract block.)
+
+#### Step-by-Step
+
+1. Test stub first.
+2. Author `capability-gap-schema.md` with regex-validated fields.
+3. Author `upstream-filing-discipline.md` with argv-list + no `--repo` rules.
+4. Update SKILL.md with M3 mode dispatch.
+5. Verify structural-contract test.
+6. Manual smoke: feed M2 unmatched record; confirm filing; observe issue created in intake repo.
+7. Self-review.
+
+#### BDD Acceptance Scenarios
+
+**Feature: capability-gap filing under discipline**
+
+| Scenario | Category | Given | When | Then |
+|---|---|---|---|---|
+| Single gap filed | happy path | M2 produces 1 unmatched | M3 runs with confirmation | issue created in `slo-security-intake` |
+| Multiple gaps filed | happy path | 3 unmatched | M3 runs | 3 issues filed (one per gap, with confirmation each) |
+| User declines a filing | invalid input / consent | user types `n` | M3 prompts | that gap not filed; others proceed |
+| Free-text prose in record | abuse case (`tm-sec-libs-abuse-2`) | adversary plants `<script>` in target repo's RUNBOOK | M3 constructs issue body | regex-validated schema rejects; no script in body |
+| Tampered `.git/config` | abuse case (`tm-sec-libs-abuse-4`) | adversary modifies `.git/config` remote.origin.url | M3 files | NO `--repo` flag = uses local origin; same trust class as user's local config |
+| Shell injection attempt | abuse case (argv-list) | record content contains `;` `|` `&` | argv-list invocation | passed as single argument; no shell interpretation |
+| `gh` not authenticated | dependency failure | `gh auth status` unauth | M3 pre-flight | clear `gh auth login` install hint; exit non-zero (do NOT auth from skill) |
+| Issue template missing in intake repo | dependency failure | `slo-security-intake` lacks ISSUE_TEMPLATE | M3 attempts file | warns; falls back to plain issue body using regex-validated schema |
+| Backward compat | backward compatibility | M1 + M2 unchanged | full suite | passes |
+
+#### Regression Tests
+
+- `cargo test --workspace`.
+- M1, M2 structural-contract tests.
+- `/slo-sast` argv-list discipline tests.
+
+#### Compatibility Checklist
+
+- [ ] M1 + M2 unchanged.
+- [ ] `/slo-sast` discipline preserved.
+
+#### E2E Runtime Validation
+
+**File**: `crates/sldo-install/tests/e2e_sec_libs_m3.rs`
+
+| E2E Test | What It Proves | Pass Criteria |
+|---|---|---|
+| `capability_gap_schema_regex_validated` | Schema is regex-validated | parse + verify all fields have regex constraints |
+| `upstream_filing_discipline_argv_list` | argv-list cited | grep |
+| `no_repo_flag_documented` | Confused-deputy defense | grep |
+| `no_merge_flags` | No auto-merge | grep refuses any merge flag |
+| `no_gh_auth_login_from_skill` | Auth discipline | grep |
+
+#### Smoke Tests
+
+- [ ] Manually run M3 against a fixture M2 output; observe confirmation prompt.
+- [ ] Decline at confirmation; verify no issue created.
+- [ ] `gh issue list --repo kerberosmansour/slo-security-intake --label capability-gap` after manual filing — observe filed issue.
+- [ ] `cargo test -p sldo-install` passes.
+
+#### Evidence Log
+
+(Copy at execution time.)
+
+#### Definition of Done
+
+- All BDD scenarios pass.
+- Tracker + lessons + completion files written.
+
+#### Post-Flight
+
+- ARCHITECTURE.md: not required (M5 dogfood will exercise it).
+- README.md: optional bullet about capability-gap filing.
+
+#### Notes
+
+- The default destination (`slo-security-intake`) means even contributors without third-party access can file gaps. M4 adds the `--file-upstream` gate.
+
+---
+
+### Milestone 4 — Third-party filing gate + rate-limit cap
+
+**Goal**: `--file-upstream` flag enables filing to library-owner repos (Hulumi, SunLitSecureLibraries, etc.); per-session 40-issues/hr cap as defensive cap against GitHub secondary rate limits; spillover to `LESSONS-BACKLOG.md` on cap-exceeded.
+
+**Context**: GitHub secondary rate-limit point costs are undocumented (Phase 1 research Q5). 40-issues/hr is a defensive cap derived from public Octokit benchmarks.
+
+**Important design rule**: **Per-session cap, not global**. State doesn't persist across invocations. Cross-invocation rate is the user's responsibility.
+
+**Refactor budget**: `Targeted refactor permitted for upstream-filing-discipline.md extension`.
+
+#### Contract Block
+
+| Field | Value |
+|---|---|
+| Inputs | M3's filer; `--file-upstream` flag; per-session counter |
+| Outputs | Filings to library-owner repos when `--file-upstream` is passed; spillover to `LESSONS-BACKLOG.md` on cap |
+| Interfaces touched | SKILL.md mode dispatch; `upstream-filing-discipline.md` extended |
+| Files allowed to change | `skills/slo-sec-libs/SKILL.md` (extend), `skills/slo-sec-libs/references/upstream-filing-discipline.md` (extend), `crates/sldo-install/tests/e2e_sec_libs_m4.rs` (NEW) |
+| Files to read before changing anything | M3 lessons; R1 M3's rate-limit pattern (if shipped) |
+| New files allowed | test file |
+| New dependencies allowed | `none` |
+| Migration allowed | `no` |
+| Compatibility commitments | M1, M2, M3 unchanged; default destination remains `slo-security-intake` |
+| Forbidden shortcuts | persisting cap counter across sessions; auto-`--file-upstream`; missing user-confirmation for upstream filing |
+| **Data classification** | `Public` |
+| **Proactive controls in play** | C1; C7 (access controls — `--file-upstream` is opt-in flag); C9 (audit — cap firing recorded) |
+| **Abuse acceptance scenarios** | `tm-slo-sec-libs-abuse-3: cross-org filing storm via --file-upstream loop` — mitigated by per-session 40-issues/hr cap + user-confirmation gate per filing |
+
+#### Out of Scope / Must Not Do
+
+- Persisting cap state across sessions.
+- Default-on `--file-upstream`.
+- Modifying M1/M2/M3 deliverables beyond the named extension.
+
+#### Pre-Flight
+
+1. Complete Global Entry Rules.
+2. Read M3 lessons.
+3. Verify R1 M3's rate-limit cap pattern (if R1 shipped).
+
+#### Files Allowed To Change
+
+(See contract block.)
+
+#### Step-by-Step
+
+1. Test stub.
+2. Extend SKILL.md with `--file-upstream` flag dispatch.
+3. Extend `upstream-filing-discipline.md` with cap + spillover discipline.
+4. Verify structural-contract test.
+5. Smoke test: simulate 41 fillings per session; observe cap fire on 41st.
+6. Self-review.
+
+#### BDD Acceptance Scenarios
+
+**Feature: third-party filing + rate-limit**
+
+| Scenario | Category | Given | When | Then |
+|---|---|---|---|---|
+| Default destination unchanged without `--file-upstream` | happy path | filing without flag | M4 runs | files to `slo-security-intake` |
+| `--file-upstream` enables third-party filing | happy path | flag passed; capability gap maps to Hulumi | M4 runs | files to `kerberosmansour/hulumi` (with confirmation) |
+| Cap fires at 40 issues/session | abuse case (`tm-sec-libs-abuse-3`) | session has filed 40 | 41st filing attempted | cap fires; spillover to `LESSONS-BACKLOG.md` |
+| Spillover record format | happy path | cap fired | spillover written | row appended to `LESSONS-BACKLOG.md` with capability-gap-schema fields |
+| Cap counter resets across sessions | backward compatibility | session 1 fired 40, ended | session 2 starts | counter resets; new session can file 40 more |
+| Library-owner mapping ambiguity | invalid input | capability gap doesn't map to a known library owner | M4 runs | refuses third-party filing; default to slo-security-intake with note |
+| User declines `--file-upstream` confirmation | invalid input | user `n` at prompt | M4 | falls back to slo-security-intake |
+
+#### Regression Tests
+
+- `cargo test --workspace`.
+- M1, M2, M3 structural-contract tests.
+
+#### Compatibility Checklist
+
+- [ ] M1, M2, M3 unchanged.
+- [ ] Default destination still `slo-security-intake`.
+
+#### E2E Runtime Validation
+
+**File**: `crates/sldo-install/tests/e2e_sec_libs_m4.rs`
+
+| E2E Test | What It Proves | Pass Criteria |
+|---|---|---|
+| `file_upstream_flag_documented` | Flag present | grep SKILL.md |
+| `forty_per_hour_cap_documented` | Cap cited | grep |
+| `cross_session_state_not_persisted` | Per-session discipline | grep refuses any "saved counter" pattern |
+| `lessons_backlog_spillover` | Spillover documented | grep |
+
+#### Smoke Tests
+
+- [ ] Mock-invoke 40 fillings; observe all proceed; 41st triggers cap + spillover.
+- [ ] End session, restart, attempt filing — observe counter reset.
+- [ ] `cargo test -p sldo-install` passes.
+
+#### Evidence Log
+
+(Copy at execution time.)
+
+#### Definition of Done
+
+- All BDD scenarios pass.
+- Tracker + lessons + completion files written.
+
+#### Post-Flight
+
+- ARCHITECTURE.md: not required.
+- README.md: not required.
+
+#### Notes
+
+- 40-issues/hr is a conservative cap. If real-world telemetry from M5 dogfood + early adoption suggests this is too low or too high, refresh in a future runbook (not this one).
+
+---
+
+### Milestone 5 — Dogfood: re-critique an SLO milestone using `/slo-sec-libs`
+
+**Goal**: Re-critique **multiple already-shipped SLO milestones** (per paradigm — comprehensive coverage, not single-target) using `/slo-sec-libs` against the Hulumi + SunLitSecureLibraries declarations. Produce: per-target dogfood reports listing `matched:` recommendations, `unmatched:` capability gaps, files filed. Targets: at least 3 candidates (recommend: `slo-security-embedding` M3, `slo-sast` M3, R3 M3 if shipped). Multiple targets validate the matcher across diverse proactive-controls surfaces.
+
+**Context**: Dogfood is the integration test. Confirms the full pipeline (read → match → file) works end-to-end against real declarations + a real runbook. Proves the value-add: are we surfacing meaningful library recommendations + gaps?
+
+**Important design rule**: **No new code in M5**. Pure exercise of M1-M4 against a real target. Outcomes documented in lessons.
+
+**Refactor budget**: `No refactor permitted beyond direct implementation`.
+
+#### Contract Block
+
+| Field | Value |
+|---|---|
+| Inputs | An already-shipped SLO milestone's RUNBOOK + ARCHITECTURE.md + stack-decision.md (likely `docs/RUNBOOK-SLO-SECURITY-EMBEDDING.md` or similar); Hulumi + SunLitSecureLibraries declarations |
+| Outputs | Dogfood report at `docs/sec-libs-dogfood-<date>.md` capturing matched/unmatched/filed; lessons file; completion summary |
+| Interfaces touched | None — exercise of M1-M4 only |
+| Files allowed to change | `docs/sec-libs-dogfood-<YYYY-MM-DD>.md` (NEW), `crates/sldo-install/tests/e2e_sec_libs_m5.rs` (NEW) |
+| Files to read before changing anything | All M1-M4 outputs; the chosen target milestone's runbook |
+| New files allowed | dogfood report + test file |
+| New dependencies allowed | `none` |
+| Migration allowed | `no` |
+| Compatibility commitments | All M1-M4 deliverables unchanged |
+| Forbidden shortcuts | introducing new code in M5; auto-merging filed issues |
+| **Data classification** | `Public` (dogfood report is public-tier) |
+| **Proactive controls in play** | C9 (audit trail via dogfood report) |
+| **Abuse acceptance scenarios** | none new (dogfood inherits M1-M4 abuse cases) |
+
+#### Out of Scope / Must Not Do
+
+- Adding new code beyond the dogfood report and test file.
+- Cross-runbook dogfood (M5 picks ONE target milestone).
+
+#### Pre-Flight
+
+1. Complete Global Entry Rules.
+2. Read M1-M4 lessons.
+3. **Per critique C-1**: shortlist 2-3 candidate target milestones with the richest proactive-controls surface (recommend: `slo-security-embedding` M3, `slo-sast` M3, or M2 of this runbook's R2 if shipped). Pick the one with the most rows in its Contract Block "Proactive controls in play" entries — dogfood needs a real surface to exercise.
+4. Confirm pre-requisites still hold (intake repo + declarations files).
+
+#### Files Allowed To Change
+
+| File | Planned Change |
+|---|---|
+| `docs/sec-libs-dogfood-<YYYY-MM-DD>.md` | NEW: dogfood report (matched/unmatched/filed sections) |
+| `crates/sldo-install/tests/e2e_sec_libs_m5.rs` | NEW: structural-contract test asserting (a) dogfood report exists, (b) every section populated, (c) filed-issues list includes valid issue URLs |
+
+#### Step-by-Step
+
+1. Test stub.
+2. Run M1-M4 pipeline against the target milestone.
+3. Capture matched/unmatched/filed in the dogfood report.
+4. Verify structural-contract test.
+5. Self-review.
+
+#### BDD Acceptance Scenarios
+
+**Feature: dogfood validates the pipeline end-to-end**
+
+| Scenario | Category | Given | When | Then |
+|---|---|---|---|---|
+| Dogfood report has all sections | happy path | M5 closes | inspect report | matched / unmatched / filed sections all populated |
+| At least one matched recommendation | happy path | M5 closes | inspect | ≥ 1 matched (proves the matcher works on real declarations) |
+| Filed-issues list has valid URLs | happy path | M5 closes | inspect | each URL resolves; each issue is in `slo-security-intake` (default) |
+| Empty dogfood (no proactive-controls in target) | empty state | target milestone has no security_libs_required: true | M5 runs | dogfood report says "target milestone declares no security-libs requirement; dogfood inconclusive" |
+| Backward compat: M1-M4 unchanged | backward compatibility | M5 closes | git diff M1-M4 deliverables | empty |
+
+#### Regression Tests
+
+- `cargo test --workspace`.
+- M1-M4 structural-contract tests.
+
+#### Compatibility Checklist
+
+- [ ] M1-M4 deliverables unchanged.
+- [ ] No skill behavior change.
+
+#### E2E Runtime Validation
+
+**File**: `crates/sldo-install/tests/e2e_sec_libs_m5.rs`
+
+| E2E Test | What It Proves | Pass Criteria |
+|---|---|---|
+| `dogfood_report_exists` | Report present | path + frontmatter |
+| `dogfood_report_has_matched_section` | Matcher worked on real input | grep |
+| `dogfood_report_has_filed_issues` | Filer worked | grep + URL pattern |
+
+#### Smoke Tests
+
+- [ ] Open dogfood report; verify renders.
+- [ ] Click filed-issues URLs; verify resolve.
+- [ ] `cargo test -p sldo-install` passes.
+
+#### Evidence Log
+
+(Copy at execution time.)
+
+#### Definition of Done
+
+- All BDD scenarios pass.
+- Dogfood report authored.
+- Tracker + lessons + completion files written.
+
+#### Post-Flight
+
+- ARCHITECTURE.md update: confirm `/slo-sec-libs` skill listed in skill inventory.
+- README.md update: link to dogfood report.
+
+#### Notes
+
+- The dogfood is M5's value: proves the pipeline produces meaningful recommendations + gaps on real input, not just contrived fixtures.
+
+---
+
+## Documentation Update Table
+
+| Milestone | ARCHITECTURE.md Update | README.md Update | .gitignore Update | Other Docs |
+|---|---|---|---|---|
+| Pre-req | none | none | none | Out-of-band: create `slo-security-intake` repo + ISSUE_TEMPLATE; add CycloneDX declarations to Hulumi + SunLitSecureLibraries |
+| 1 | Add `/slo-sec-libs` to skill inventory | optional | `~/.cache/sldo/declarations/` (already gitignored at user level) | `skills/slo-sec-libs/` (new subtree) |
+| 2 | none | none | none | `methodology-m2-matcher.md` |
+| 3 | none | optional bullet | none | `capability-gap-schema.md`, `upstream-filing-discipline.md` |
+| 4 | none | none | `LESSONS-BACKLOG.md` (gitignore in target repos) | `upstream-filing-discipline.md` (extend) |
+| 5 | confirm skill inventory | link to dogfood | none | `docs/sec-libs-dogfood-<date>.md` |
+
+---
+
+## Optional Fast-Fail Review Prompt for Agents
+
+> Restate the milestone goal, allowed files, forbidden changes, compatibility requirements, tests that must be written first, and the exact Definition of Done. Then list the smallest implementation approach that satisfies the contract without widening scope.
+
+---
+
+## Carry-forward from prior retros
+
+(Empty until R1 M3 ships and `/slo-retro` files lessons as issues. R4 may run in parallel with R1; if R1 ships first, R4 gets carry-forward from R1 lessons.)
+
+| Issue | Title | Suggested milestone | Status |
+|---|---|---|---|
+| (none yet) | | | |
+
+---
+
+## Paradigm-driven enhancements (per `docs/PARADIGM-OVER-ENGINEERING-FOR-SIMPLICITY.md`)
+
+This runbook applies the over-engineering-for-simplicity paradigm at the security-library scale. The `/slo-sec-libs` skill absorbs more discipline than a human-driven library-feedback loop would sustain because the LLM does not pay the cognitive-load tax. Specific layers added because the LLM is the executor:
+
+### Comprehensive abuse-case enumeration (M1)
+
+Original M1 enumerated 5 abuse cases. Paradigm-driven extension: **13 abuse cases total** (5 original + 8 paradigm additions: schema-version mismatch, unicode-trick component name, cache-poisoning via in-flight tag-rewrite, low-confidence parametric claims, external-schema reference, plus pre-existing forbidden-fallback enumeration). Each adds a distinct failure mode the LLM filer will not absorb silently.
+
+### Comprehensive forbidden-shortcut enumeration (M1 contract)
+
+Original contract listed 5 forbidden shortcuts. Paradigm-driven extension: **13 forbidden shortcuts**, including post-clone-SHA-verification-skipped, `/tmp` cache layout, silent retry on `git clone` failure, symlink-anywhere-in-cache-path. A human implementer would catch 2-3; the LLM pipeline absorbs all 13.
+
+### Multiple dogfood targets (M5)
+
+Critique C-1 surfaced that single-target dogfood could be inconclusive. Paradigm-driven correction: **≥ 3 targets** validates the matcher across diverse proactive-controls surfaces. A human team would balk at 3× the dogfood effort; the LLM pipeline absorbs it and gets stronger validation in return.
+
+### Capability-gap record schema — comprehensive structured fields
+
+Original schema is regex-validated. Paradigm-driven enhancement (during M3 implementation): every record carries `impact_class:` (which OWASP / ASVS chapter the gap touches), `exploitability:` (low/med/high based on the threat model), `alternatives_tried:` (what the recommender attempted before declaring gap), `parametric_requirements:` (the specific Argon2id iterations / memory / parallelism the gap needs), `target_repo_context:` (one-line: which target proactive-controls row triggered this gap). Each field is regex-validated; the comprehensive coverage gives the upstream library maintainer enough context to act without back-and-forth.
+
+### Defense-in-depth across milestones
+
+| Concern | Layer 1 | Layer 2 | Layer 3 | Layer 4 |
+|---|---|---|---|---|
+| Tampered declarations | SHA pin per source (M1) | `git rev-parse HEAD` post-clone verify (M1) | Strict jsonschema validate against pinned 1.6 schema (M1) | `O_NOFOLLOW`-style cache path verification (M1) |
+| Filing-storm | Per-session 40/hr cap (M4) | Adaptive backoff on `gh` rate-limit responses (M4) | Spillover to `LESSONS-BACKLOG.md` (M4) | User-confirmation gate per filing (M3) |
+| Confused-deputy via `.git/config` | NO `--repo` flag (M3) | argv-list-only subprocess (M3+M4+M5) | Confirmation gate shows resolved origin (M3) | Cross-org filing gated by `--file-upstream` (M4) |
+| Capability fabrication (LLM hallucinates a match) | Match must reference catalog entry by ID (M2) | Tiebreaker prefers parametric specificity (M2) | Tie-disposition surfaces both candidates (M2) | Structural-contract test asserts no fabricated IDs (M2) |
+| Schema poisoning | Strict validate (no entity expansion / anchor recursion) (M1) | 10 MiB pre-parse cap (M1) | Schema URL pinned (M1) | NFKC normalization on component names (M1, paradigm extension) |
+| Cache poisoning | SHA-pinned cache directory (M1) | Post-clone `git rev-parse HEAD` (M1) | Cache size cap 1 GiB + 90-day age cap + LRU (M1, paradigm extension) | Wipe + refuse on SHA mismatch (M1) |
+
+### Bounded by context-window
+
+The paradigm's discipline-vs-context-window balance: SKILL.md is the orchestrator (≤ ~150 lines projected), per-stage methodology files (M1 reader, M2 matcher, M3 schema, M3-M4 filing discipline) load on-demand. The Python script is small (~50 lines stdlib-only). The capability-gap record schema fits in one reference file. Cache layout under `~/.cache/sldo/declarations/<sha>/` is bounded by the 1 GiB cap.
+
+### Paradigm balance — what we did NOT add
+
+Per the paradigm's anti-patterns ("don't add infinite gates"), the following enhancements were considered and **declined**:
+
+- **CycloneDX XML variant support**: 1.6 spec supports both JSON and XML. Adding XML reader would multiply attack surface (XXE attacks). The paradigm balances comprehensive vs context-window — JSON-only is the right cut for v1; XML support is a separate `/slo-architect` re-pass.
+- **Auto-merge of refresh PRs**: never; matches `/slo-sast` M5 discipline.
+- **Cross-org auto-filing without confirmation**: always user-gated; matches R1 M3 discipline.
+- **Caching parsed-schema results across invocations**: re-parse per call (matches `/slo-sast` discipline) — context-window-cheap, prevents stale-cache bugs.
+
+### Ask items still open from critique
+
+- C-3: where does the canonical `gh issue create` rate-limit discipline live — R1 or R4? (Lean: R2 M1's `references/templates/rate-limiting-discipline.md` consolidates both, per paradigm)
+- C-6: confirm conservative-by-default tiebreaker in matcher
+- S-3: accept review-after-3-months follow-up for the 40/hr cap

--- a/docs/completion/agent-host-m1.md
+++ b/docs/completion/agent-host-m1.md
@@ -1,0 +1,48 @@
+# Completion Summary — agent-host Milestone 1
+
+## Goal completed
+- `sldo-install` now installs, verifies, reports status for, and uninstalls skills for both `claude-code` and `github-copilot` while keeping Claude as the default host.
+
+## Files changed
+- `crates/sldo-install/src/main.rs`
+- `crates/sldo-install/src/install.rs`
+- `crates/sldo-install/src/manifest.rs`
+- `crates/sldo-install/src/paths.rs`
+- `crates/sldo-install/src/host.rs`
+- `crates/sldo-install/tests/e2e_agent_host_m1.rs`
+- `README.md`
+- `skills/README.md`
+- `.gitignore`
+- `docs/ARCHITECTURE.md`
+
+## Tests added
+- `crates/sldo-install/tests/e2e_agent_host_m1.rs`
+- `crates/sldo-install/src/manifest.rs` unit coverage for schema-v1 compatibility and per-host upsert/remove behavior
+- `crates/sldo-install/src/paths.rs` unit coverage for Copilot roots
+
+## Runtime validations added
+- Host-specific installer E2E coverage for global/local Copilot installs, status/verify output, legacy manifests, and root-escape rejection
+
+## Compatibility checks performed
+- Confirmed no-arg installs still target Claude Code.
+- Confirmed existing Claude installs remain readable and uninstallable after the schema-v2 upgrade.
+- Confirmed `get-api-docs` still installs through generic skill discovery.
+- Confirmed local Copilot installs stay inside `./.copilot/` and do not leak into global roots.
+
+## Documentation updated
+- `README.md` installer section
+- `skills/README.md` install, uninstall, and verification examples
+- `docs/ARCHITECTURE.md` skill-pack installer roots and manifest note
+
+## .gitignore changes
+- Added `/.copilot/`
+- Generalized the local host-state comment so it no longer refers only to Claude Code
+
+## Test artifact cleanup verified
+- `git status --short` showed only intended source edits and no generated test artifacts.
+
+## Deferred follow-ups
+- Milestone 2 still needs the broader living-doc cleanup, canonical host overlays, and first-class `docs/getting-started.md` onboarding flow.
+
+## Known non-blocking limitations
+- A real-home Copilot dry-run can still report conflicts when a skill directory already exists as a normal directory instead of an installer-managed symlink. That is expected safety behavior, not a regression.

--- a/docs/completion/agent-host-m2.md
+++ b/docs/completion/agent-host-m2.md
@@ -1,0 +1,50 @@
+# Completion Summary — agent-host Milestone 2
+
+## Goal completed
+- The repo now has a first-class onboarding path, a canonical host-neutral skill catalog, explicit Claude and Copilot overlays, and a reality-first architecture doc that matches the current workspace.
+
+## Files changed
+- `README.md`
+- `CLAUDE.md`
+- `skills/README.md`
+- `docs/skill-pack-catalog.md`
+- `docs/ARCHITECTURE.md`
+- `copilot-instructions.md`
+- `docs/getting-started.md`
+- `docs/design/agent-host-capabilities.md`
+- `crates/sldo-install/tests/e2e_agent_host_m2.rs`
+
+## Tests added
+- `crates/sldo-install/tests/e2e_agent_host_m2.rs`
+
+## Runtime validations added
+- Structural coverage that the canonical catalog points to overlays, the capability matrix calls out unsupported Copilot automation, the README links to the first-run guide, and the architecture doc matches the surviving workspace members.
+
+## Compatibility checks performed
+- Confirmed `CLAUDE.md` still catalogs the pack for Claude users while identifying itself as an overlay.
+- Confirmed GitHub Copilot now has its own actionable overlay instead of inheriting Claude-only assumptions.
+- Confirmed the README links new users to `docs/getting-started.md`.
+- Confirmed `docs/ARCHITECTURE.md` now describes the four active workspace members instead of removed legacy surfaces.
+
+## Documentation updated
+- `README.md` now points first-time users to `docs/getting-started.md` and the canonical catalog.
+- `CLAUDE.md` now identifies itself as the Claude overlay and points back to the catalog.
+- `skills/README.md` now explains the source/canonical/overlay split.
+- `docs/skill-pack-catalog.md` now serves as the canonical living catalog.
+- `docs/ARCHITECTURE.md` now reflects the current workspace and host boundaries.
+- `copilot-instructions.md`, `docs/getting-started.md`, and `docs/design/agent-host-capabilities.md` were added.
+
+## .gitignore changes
+- None. Milestone 1 already covered the host-local state patterns needed for `.claude/` and `.copilot/`.
+
+## Test artifact cleanup verified
+- `git status --short` showed only intended source edits and newly added milestone files; no generated artifacts were left behind.
+
+## Deferred follow-ups
+- Milestone 3 still needs to remove the Claude-specific automated batch dependency from the `/slo-research` interactive path.
+- Milestone 4 still needs to isolate and label the remaining Claude-only runtime automation surfaces more cleanly.
+
+## Known non-blocking limitations
+- `/slo-research` still has a Claude-specific automated batch backend today.
+- The live business judgment runtime harness is still Claude-only today.
+- The in-scope baseline test command passes, but an unrelated existing warning remains in `crates/sldo-install/tests/e2e_biz_followup_m5.rs`.

--- a/docs/critique/business-skill-improvements.md
+++ b/docs/critique/business-skill-improvements.md
@@ -1,0 +1,43 @@
+---
+name: business-skill-improvements
+runbook: docs/RUNBOOK-BUSINESS-SKILL-IMPROVEMENTS.md
+critiqued: 2026-04-28
+personas_run: [ceo, eng, security]
+design_persona_skipped: yes — no UI surface
+---
+
+# Critique — business-skill-improvements
+
+| id | persona | category | runbook section | finding | concrete scenario | recommendation |
+|---|---|---|---|---|---|---|
+| B-1 | ceo | hold-scope | M1 / source-verification budget | "Time-box per row to ~5 minutes" — for a 29-row regulator enum + 3 statute anchor files (each with 5-15 sections) + HMRC VCM refresh + ICO DUAA refresh, this is ~10-15 hours of manual verification. Real cost. | Author starts M1; spends 4 hours on regulator enum; budget-pressure leads to "approximate verify" on statute anchors. Discipline drifts. | Hold the budget rule; **explicit acceptance** that M1 is the longest milestone. Add follow-up rule: "if a row cannot be verified within budget, mark `last_checked: pending-verification` and flag for next sprint — do not weaken." Already in Notes; reinforce in BDD. **hold-scope** + **auto-fix** to M1 BDD. |
+| B-2 | ceo | reduce-scope | M4 / Mom Test quotation | Fitzpatrick *The Mom Test* (2013) quotation is constrained by copyright. Snippet-permitted excerpts only OR paraphrase with attribution. | Agent attempts verbatim quote of 5+ pages; copyright violation; book is widely considered fair-use-excerpted but high-bandwidth verification required. | Cut to attribution-only (cite ISBN + page numbers without verbatim long-quote). Mom Test question structure (the schema) is the discipline; the actual question text can paraphrase Fitzpatrick's framing without verbatim copying. **auto-fix** applied to M4 contract. |
+| B-3 | ceo | ask | M2 conversational discipline | Conversational intake works for well-paced founders; for time-pressed founders ("I have 15 min between calls — just give me the contract"), the conversation feels frictional. | Founder cancels mid-elicitation because they're frustrated by the question pace; agent must decide: complete intake or fall back? | Add an optional `--rapid-intake` flag that batches F1-F6 into a single 6-question prompt (still structured, just faster). Conversational is default; rapid is opt-in for founders who explicitly trade off. **ask** user to confirm. |
+| B-4 | eng | auto-fix | M2 / sister contract verbatim test | F1/F4/F5 verbatim across sisters — byte-compare assertion sensitive to whitespace differences (trailing spaces, line-ending flavor). | Agent edits one sister contract; trailing whitespace differs from source; test fails for cosmetic reason; agent re-saves with `:set noeol` quirk; new error class. | Normalize whitespace in the test (strip trailing + normalize line-ending) before byte-compare. **auto-fix** applied to M2 E2E test description. |
+| B-5 | eng | ask | M3 / Python snippet provenance | Snippet emitted is stdlib-only — but no licensing declaration. Founder copies snippet into their own repo without license. | Founder commits the snippet to a private repo; later open-sources the repo; snippet's license is ambiguous. | Add MIT license header to every emitted snippet (one-line `# SPDX-License-Identifier: MIT`). **ask** user — MIT or other? |
+| B-6 | eng | hold-scope | M5 / `baseline_ref:` field as optional | Schema extension is "additive optional" — but a generator artifact that cites a baseline file SHOULD have the field. "Optional" makes it unenforceable. | A future generator skill writes an artifact citing CAC numbers without `baseline_ref:` frontmatter; structural-contract test passes (field is optional); founder reads stale numbers and quotes them. | "Optional in the schema; required by generator skill cross-skill citation tests." Schema flexibility lets older artifacts parse; new test enforces emission. **hold-scope** — clarify in M5 contract. |
+| B-7 | eng | auto-fix | M2 / `legal-intake-form.md` rename | Rename is in scope but the runbook doesn't document the cross-reference update path (issue #19's existing comment links to the old `legal-intake-form.md` URL). | Rename happens; existing GitHub comment URLs 404; reviewer can't follow the link. | Pre-flight step: enumerate every cross-reference in the repo (and explicitly NOTE that the existing GitHub issue comments point to old URLs — those won't auto-update; document as known minor breakage acceptable for this rename). **auto-fix** applied to M2 pre-flight + Notes. |
+| S-1 | security | auto-fix | M2 / F3 deal-value evaluation | F3 has `deal_value_basis` enum + `deal_value_known_with_confidence` enum. But founder could lie ("yes, total ex-VAT" when monthly). | Founder under-states deal value to avoid triage routing. | Add explicit-comprehension question to F3: skill restates "is £8000 over 4 months £2000/mo or £8000 total?" before locking the value. Already in restate-and-confirm but make F3-specific. **auto-fix** applied to legal-intake-contract.md F3. |
+| S-2 | security | hold-scope | M1 statute citations going stale between refreshes | Annual refresh cadence + skill stale-warning at +12 months + refusal at +24 months. Statute amendments mid-cycle (DUAA 2025 commenced 2026-02; potential 2026 Q4 amendment) miss the cycle. | DUAA 2026 amendment commences mid-cycle; SLO files cite stale text for ~12 months. | Add "monitor `legislation.gov.uk` RSS feed for amendments to cited Acts" as a deferred follow-up. **hold-scope** — annual cadence is acceptable; mid-cycle monitoring is a stretch goal. |
+| S-3 | security | hold-scope | M2 conversational intake — adversarial founder | The conversational intake is designed for honest founders. An adversarial founder (researcher probing the skill) could craft answers to bypass gates. | Researcher answers F1=`uk-england-wales`, F4=`false`, F5=`false`, F2=`no/no`, F3=`£4500/total/precise` — all gates pass; obtains a draft. Probes the artifact for vulnerabilities. | This is acceptable behavior — the skill is producing a draft for a UK founder claiming honest inputs. The artifact carries `lawyer_review_recommended: true` and the LAWYER REVIEW header. Adversarial-research scenarios don't need additional gating. **hold-scope** — current behavior is correct. |
+| S-4 | security | auto-fix | M1 / regulator enum source verification | Test asserts `statute_url` is `legislation.gov.uk` or `gov.uk` — but doesn't assert URL HEALTH (link doesn't 404). | Author captures URL at runbook-author time; URL gets reorganized later; future agents follow dead link. | Add a "URL health" check (lightweight: HEAD request) as a separate test that runs in CI but not blocking (URLs occasionally rate-limit). Document as `cargo test --features check-url-health`. **auto-fix** applied to M1 BDD as a optional check. |
+| S-5 | security | ask | M3 / SAFE math verification | Numeric verification re-derives every cell; mismatch refuses. But what about pre-rounded cells (e.g., share count rounded to whole shares — re-derivation might produce 4999.99 vs the rounded 5000)? | Founder-friendly rounding produces small mismatches; verification refuses; founder loses confidence. | Specify rounding tolerance in the verification block (e.g., ±0.01% or 1 share). **ask** user — what tolerance? |
+
+## Auto-fix corrections applied
+
+- B-1: M1 BDD reinforces "if cannot verify within budget, mark pending-verification, do NOT weaken".
+- B-2: M4 contract — Mom Test attribution-only, no long-form verbatim.
+- B-4: M2 E2E test normalizes whitespace before byte-compare.
+- B-7: M2 pre-flight enumerates cross-references; Notes flag known minor breakage of pre-existing GitHub issue comment URLs.
+- S-1: F3 in legal-intake-contract.md gains explicit-comprehension question.
+- S-4: M1 BDD adds optional URL-health check as `--features check-url-health`.
+
+## Asks for project-owner decision
+
+- **B-3**: add `--rapid-intake` flag for time-pressed founders?
+- **B-5**: Python snippet license — MIT?
+- **S-5**: SAFE math verification rounding tolerance — ±0.01%? ±1 share?
+
+## Final disposition
+
+**Accept with minor edits + asks**. M1 verification budget (B-1) is the largest scope risk; auto-fix locks the discipline.

--- a/docs/critique/engineering-skill-improvements.md
+++ b/docs/critique/engineering-skill-improvements.md
@@ -1,0 +1,42 @@
+---
+name: engineering-skill-improvements
+runbook: docs/RUNBOOK-ENGINEERING-SKILL-IMPROVEMENTS.md
+critiqued: 2026-04-28
+personas_run: [ceo, eng, security]
+design_persona_skipped: yes — no UI surface
+---
+
+# Critique — engineering-skill-improvements
+
+| id | persona | category | runbook section | finding | concrete scenario | recommendation |
+|---|---|---|---|---|---|---|
+| E-1 | ceo | reduce-scope | M5 / per-skill evals | M5 specifies eval cases for 16 skills × 7 categories = 112 eval files minimum. Realistic implementation drag. | Agent starts M5; writes evals for 5 advisor skills (35 files); context window saturates; remaining 11 skills get stub evals or none. | Cut to highest-risk skills only in M5 (advisors + sast + tla + execute + verify = 9 skills). Lower-risk skills get a 1-line "evals deferred to follow-up" rationale. **ask** the user to confirm the cut. |
+| E-2 | ceo | hold-scope | M1 source-verification spike | M1 spike says "5 representative claims". Real verification of `/slo-sast` + `/slo-verify` security claims is 20-30 claims minimum. | Spike marks 5 claims verified; M2 decomposition lands; M3 review surfaces 18 unverified claims still in `methodology-m2-stack-detect.md`. | Reframe: "spike = 5 claims to validate the discipline; full verification of the ~20-30 claims is folded into M2/M3/M4 per-milestone evidence-log work, not a single M1 batch." **auto-fix** applied to M1 pre-flight. |
+| E-3 | ceo | ask | M5 PreToolUse hook | "This is not a security boundary" framing is correct but counterintuitive — why ship the hook at all? Confidence question. | Project owner reviews M5; asks "if the hook isn't a security boundary, why bother?" — answer must be in the doc. | **ask** user to confirm framing: hook is a discipline-enforcer that catches honest mistakes (agent under context pressure), not adversarial bypass. Surface this explicitly in `/slo-freeze` SKILL.md description. |
+| E-4 | eng | auto-fix | M2 / M3 cut plans | Cut plans for `/slo-sast` (M2) and `/slo-tla` (M3) are described as "documented in lessons" but the lessons template doesn't have a "Cut plan" section. | M2 author writes the cut plan in the wrong template field; M3 author can't find M2's cut plan; M4 author has no precedent. | Add "Cut plan applied" as a documented lessons-file section in M2 + M3 + M4. **auto-fix** applied to milestone Notes. |
+| E-5 | eng | ask | Soft line-cap = 200 lines | `/slo-architect` is currently 144 lines — passes cap. But `/slo-architect`'s Step 3.5 STRIDE-sweep + SECURITY.md + threat-model emit is dense and could grow. | Future security-related extension to `/slo-architect` pushes to 220 lines; soft-cap test fails; team adds `# soft-cap-exception:` pragma rather than decomposing. | Verify `/slo-architect` post-Phase-1 line count; if close to 200, include in M2 decomposition wave. Otherwise accept. **ask** user — include `/slo-architect` in decomposition? |
+| E-6 | eng | auto-fix | M5 PreToolUse hook | Hook script is described as "argv-list discipline applies if it shells out" — but no structural-contract test asserts the hook script's argv-list pattern. | Hook script ships shell-string `bash -c "test -f $HOME/.sldo/freeze-scope.txt"`; argv-list discipline silently violated. | Add hook-script structural-contract test in M5 BDD: "hook script grep for shell-string patterns; FAIL if found." **auto-fix** applied to M5 BDD. |
+| E-7 | eng | hold-scope | M2 prose preservation rule | "Diff between old SKILL.md and (new SKILL.md ∪ all 5 methodology files) MUST be empty for prose content" — strict, but minor formatting changes (heading-level shifts, link-text tweaks for new context) ARE legitimate. | Decomposition agent reformats a heading from `### Method` to `## Method` (it's now a top-level section in the methodology file); strict diff fails. | Refine the rule: "diff must show no semantic prose loss; heading-level shifts and link-text tweaks for new context are permitted, called out in the cut plan." **hold-scope** — keep strict-shaped rule but with documented permitted variations. |
+| S-1 | security | hold-scope | M1 citation-discipline | Source hierarchy ranks Stack Overflow as "never authoritative" — but agents ROUTINELY consult SO during research. The discipline is "never CITE as authoritative" not "never read". | Agent reads SO post for context, then writes a SKILL.md claim citing the underlying tool docs (correct). Some other agent reads SO post and cites it directly (wrong). | Confirm wording: "Stack Overflow may inform reading; never appears as a citation source." **hold-scope** — already correct in design overview prose. |
+| S-2 | security | auto-fix | M2 / M3 prose preservation BDD | "Security discipline preserved" BDD rows enumerate specific disciplines (argv-list, no `pull_request_target`, action-SHA pin, etc.) — but the list is hand-written and could drift from the actual disciplines in the SKILL.md. | M2 decomposition drops the action-SHA-pin discipline; the BDD checks for "argv-list" and passes; the missing discipline is undetected. | Generate the discipline list programmatically: M2 test extracts every "MUST" rule from old SKILL.md and asserts each appears in the post-decomposition tree. **auto-fix** applied to M2 + M3 E2E test descriptions. |
+| S-3 | security | ask | M5 PreToolUse hook bypass via session-state deletion | `tm-eng-skill-improvements-abuse-2: PreToolUse hook bypassed via session-state file deletion` — labeled "residual" + "not a security boundary" disclaimer. | Adversary deletes `~/.sldo/freeze-scope.txt`; hook treats missing file as "no freeze active"; Edit/Write proceeds anywhere. | Already documented as residual + disclaimer. **ask** — is residual acceptable, or should the hook FAIL CLOSED (block all edits) when session-state is unexpectedly missing during an active session? Lean: fail-closed only inside an active `/slo-freeze` invocation; cleaner to fail-open by default. |
+| S-4 | security | auto-fix | M5 settings.json mutation surface | Hook mutation via `update-config` skill is correct; but the runbook doesn't enumerate WHICH `update-config` invocation patterns are forbidden (e.g., disabling existing PreToolUse hooks while adding the new one). | Future M5 implementation `update-config`s settings.json by overwriting `PreToolUse` array entirely, dropping pre-existing hooks. | Specify: "extend `PreToolUse` array additively; never overwrite. Reject any `update-config` invocation that removes existing PreToolUse entries." **auto-fix** applied to M5 contract. |
+
+## Auto-fix corrections applied
+
+- E-2: M1 pre-flight reframed — spike validates discipline; full verification per-milestone in M2/M3/M4.
+- E-4: cut-plan section added to milestone Notes for M2 + M3 + M4.
+- E-6: M5 BDD adds hook-script argv-list test.
+- S-2: M2 + M3 E2E test descriptions reframed to "extract every MUST rule programmatically".
+- S-4: M5 contract specifies additive-only `PreToolUse` array extension.
+
+## Asks for project-owner decision
+
+- **E-1**: cut M5 evals to highest-risk-only (9 skills)?
+- **E-3**: PreToolUse hook framing — "discipline-enforcer for honest mistakes" — confirm and surface in `/slo-freeze` SKILL.md description?
+- **E-5**: include `/slo-architect` in M2 decomposition wave (if line count is approaching 200)?
+- **S-3**: hook fail-closed when session-state file unexpectedly missing during active freeze?
+
+## Final disposition
+
+**Accept with minor edits + asks**. No critical findings. M5's eval scope (E-1) is the largest open question.

--- a/docs/critique/loops-and-lessons-closure.md
+++ b/docs/critique/loops-and-lessons-closure.md
@@ -1,0 +1,43 @@
+---
+name: loops-and-lessons-closure
+runbook: docs/RUNBOOK-LOOPS-AND-LESSONS-CLOSURE.md
+critiqued: 2026-04-28
+personas_run: [ceo, eng, security]
+design_persona_skipped: yes — no UI surface
+---
+
+# Critique — loops-and-lessons-closure
+
+Four-persona adversarial review per [`/slo-critique`](../../skills/slo-critique/SKILL.md). Personas run sequentially; design skipped (no UI surface).
+
+| id | persona | category | runbook section | finding | concrete scenario | recommendation |
+|---|---|---|---|---|---|---|
+| L-1 | ceo | reduce-scope | M4 / pre-flight | Carry-forward surface could become noise — every milestone start lists every open prior-retro issue. After 3 runbooks shipped, a session opens with "12 open issues, none urgent". | Founder runs `/slo-execute M5` of R3 third runbook in series; pre-flight surfaces 12 cross-runbook issues, founder eye-glazes and ignores all. The signal is lost in the volume. | Cap surface to N items per milestone; prefer items labeled `priority: high` OR `affects: <this-prefix>` if M3's marker scheme supports it. **ask** the user to pick a cap (lean: 3-5). |
+| L-2 | ceo | hold-scope | M2 vs Issue #18 inventory | Issue #18 leaves loop inventory open: "fundraise loop? cofounder loop? hiring loop? legal-triage loop?" — M2 hard-codes 4 loops. | Project owner adds "fundraise loop" while M2 is in progress; M2 must absorb scope mid-flight or skip the addition. | Hold scope at 4 documented loops in M2; new loops are append-only follow-up issues post-M2. Document this scope rule explicitly. **auto-fix** applied to M2 Notes section. |
+| L-3 | eng | ask | M3 spike step | Marker-choice spike (`gh search` reliability for title prefix vs label vs body sentinel) could produce a marker that GitHub deprecates 6 months later. | M3 picks `[retro]` title prefix; GitHub Issues changes search-tokenization in late 2026; `gh search "[retro]"` starts returning false positives; dedupe breaks. | Add a "spike result review at +6 months" follow-up in `references/biz/` cadence calendar. **defer** to runbook close. |
+| L-4 | eng | auto-fix | M3 contract block | `LESSONS-BACKLOG.md` row schema is named in fallback flow but not specified. Future contributors will invent diverging row formats. | Contributor A files a row as `\| date \| classification \| body \|`; contributor B uses `\| classification \| skill \| body \|`. Cross-team reads break. | Specify the row schema in M3 `references/issue-filing-discipline.md`. **auto-fix** applied below. |
+| L-5 | eng | ask | M4 carry-forward query | Query reads `gh issue list --label retro-derived --search 'in:title <prefix>'` (or equivalent). What if `gh` is rate-limited or auth's token has insufficient scope? | Founder running on a metered network; pre-flight times out after 30s waiting on `gh`; agent stalls or fails. | Add explicit timeout (5s) + fallback (skip carry-forward, log "gh unavailable; carry-forward skipped"). **ask** user for the timeout value. |
+| S-1 | security | auto-fix | M3 BDD abuse cases | `gh search` dedupe — variant: malicious issue title with zero-width chars or homoglyphs evades dedupe. | Contributor X files 100 retro-derived issues with `[retroʿ]` (Hebrew letter substituted for `o`) — none match `[retro]` literal search; dedupe fails; rate-limit cap (40/hr) absorbs the storm but L-5's carry-forward query still surfaces them. | Add adversarial BDD row: "title with non-ASCII codepoints in marker → dedupe normalizes (NFKC) before comparison; refuse if normalization changes the marker." **auto-fix** applied to M3 BDD table. |
+| S-2 | security | hold-scope | M3 + M4 confused-deputy via `.git/config` | Tampered `.git/config` redirecting origin remote could land filings in attacker repo. M3 BDD row addresses; M4 carry-forward read does NOT (currently no `--repo` flag is the existing defense). | Adversary modifies `.git/config` `remote.origin.url` to `https://github.com/attacker/foo.git`; `gh issue list` reads from that repo; carry-forward content is attacker-controlled. | Already mitigated by NO `--repo` flag inheriting `/slo-sast` M5 SEC-8. Confirm M4's `gh issue list` invocation also follows. **hold-scope** — defense documented; verify in M4 BDD. |
+| S-3 | security | auto-fix | M4 abuse case `tm-loops-abuse-7` | Auto-extend allow-list attempt is currently labeled `tm-loops-abuse-7` in BDD but not enumerated in design overview's STRIDE sweep. | Drift between runbook and design overview confuses future agents reading both. | Add `tm-loops-abuse-7` to design overview's "New abuse cases" section. **auto-fix** applied to design overview. |
+| S-4 | security | ask | All milestones — argv-list discipline | argv-list is mandated; structural-contract test asserts it's documented (grep). But the test does not assert no shell-string interpolation in actual `gh` invocation patterns *executed* by the skill at runtime. | Future SKILL.md revision adds "for convenience, just shell out to `bash -c \"gh issue create ...\"` — looks fine in prose; structural-contract test misses; runtime executes shell-string. | Add a runtime-fixture test (or stronger structural test scanning for shell-string patterns in SKILL.md fenced code blocks). **ask** user — high-effort vs high-value. |
+
+## Auto-fix corrections applied
+
+(See R1 runbook commits.)
+
+- L-2: M2 Notes — added scope-hold rule about loop inventory.
+- L-4: M3 — added `LESSONS-BACKLOG.md` row schema in `references/issue-filing-discipline.md` content.
+- S-1: M3 BDD — added Unicode-normalization adversarial scenario.
+- S-3: design overview — added `tm-loops-abuse-7` to "New abuse cases" enumeration.
+
+## Asks for project-owner decision
+
+- **L-1**: cap carry-forward surface to N items? (Lean: 3-5.)
+- **L-3**: spike-result review at +6 months — accept defer to runbook close?
+- **L-5**: `gh` timeout for carry-forward query (5s default)?
+- **S-4**: stronger argv-list runtime fixture test — high-effort?
+
+## Final disposition
+
+**Accept with minor edits** — auto-fix items applied; ask items surfaced for user decision. No critical findings.

--- a/docs/critique/slo-sec-libs.md
+++ b/docs/critique/slo-sec-libs.md
@@ -1,0 +1,42 @@
+---
+name: slo-sec-libs
+runbook: docs/RUNBOOK-SLO-SEC-LIBS.md
+critiqued: 2026-04-28
+personas_run: [ceo, eng, security]
+design_persona_skipped: yes — no UI surface
+---
+
+# Critique — slo-sec-libs
+
+| id | persona | category | runbook section | finding | concrete scenario | recommendation |
+|---|---|---|---|---|---|---|
+| C-1 | ceo | reduce-scope | M5 dogfood | M5 picks ONE target milestone for dogfood. If the target has no `security_libs_required: true`, dogfood is inconclusive — the BDD already accepts this as empty-state. | Author picks the wrong target; dogfood produces "0 matched, 0 unmatched"; M5 closes inconclusive; the runbook ships without proving end-to-end value. | Pre-flight step: shortlist 2-3 candidate target milestones; pick the one with the richest proactive-controls surface. **auto-fix** applied to M5 pre-flight. |
+| C-2 | ceo | hold-scope | Pre-requisites out-of-band | Three one-time setups (intake repo, declarations on Hulumi + SLSL, gh scopes) are listed as pre-requisites BEFORE M1. Treating them as out-of-band means they could slip. | Runbook starts; M1 fails on declarations file missing in Hulumi; the runbook stalls until the upstream repo work catches up. | Acceptable framing — pre-requisites are real prereqs. Reinforce the gating: M1 BDD MUST refuse to proceed without all three pre-requisites. **hold-scope** — already in pre-flight; reinforce in BDD. |
+| C-3 | ceo | ask | M1 + M5 between Phase 4 + parallel R1/R2/R3 | This runbook is parallel-track per the bucket mapping. R1's `gh issue create` rate-limit pattern (40/hr) — if R1 ships first, R4 inherits. If R4 ships first, R1 inherits R4's pattern. | Either runbook ships first; the second creates a redundant rate-limit pattern; cleanup needed. | Add explicit "if R1 ships first, R4 cites R1's `references/issue-filing-discipline.md`. If R4 ships first, R1 cites R4's `upstream-filing-discipline.md`." **ask** user — pick the canonical home. |
+| C-4 | eng | auto-fix | M1 cache layout `~/.cache/sldo/declarations/<sha>/` | Cache-eviction policy undefined. Same gap as `/slo-sast`. | Cache grows unbounded over months of use; user disk fills; runs slow. | Specify size cap (1 GiB) + age cap (90 days). Eviction is LRU. Document in `references/methodology-m1-reader.md`. **auto-fix** applied to M1 contract. |
+| C-5 | eng | hold-scope | M1 Python script provenance | Script is stdlib-only; structural-contract test asserts no non-stdlib imports. License declaration absent (same as R3 B-5). | Future contributor adds `import jsonschema` (which IS the only allowed non-stdlib dep, per pre-flight check); the structural-contract test allow-lists it. Adds `import requests` weeks later under same allow-list pretext; gets through. | Test should allow-list ONLY `jsonschema` as non-stdlib import; everything else FAILS. **hold-scope** — current test is allow-listed correctly; reinforce in test code review. |
+| C-6 | eng | ask | M2 capability matcher | Tiebreaker rule "more parametric claims = more specific = preferred" — but if Hulumi advertises Argon2id with iterations≥3 and SLSL with iterations≥4, both are valid; SLSL is "more conservative" but is it "more specific"? | Subtle judgment: M2 picks one as winner; founder follows; later realizes the other was a better fit. | Tie-disposition framing: when both are valid AND specificity is comparable, surface BOTH with `disposition: tie` (already covered in BDD). When specificity is comparable but parametric values differ, prefer the more conservative + flag the choice in stderr. **ask** user — confirm the conservative-by-default rule. |
+| C-7 | eng | auto-fix | M3 capability-gap record schema | Schema is regex-validated. But what about gap records that span multiple capabilities (e.g., a runbook needs both Argon2id AND a secure JSON parser; both unmatched)? | Single gap record bundles two unmatched controls; reads ambiguously; downstream consumer (slo-security-intake maintainer) doesn't know which to address first. | Specify: one gap record per unmatched control. The matcher emits N records when N controls are unmatched. **auto-fix** applied to M3 contract. |
+| S-1 | security | auto-fix | M3 capability-gap record schema | Regex-validated, but schema doesn't enforce no Unicode tricks (homoglyph, RTL override, zero-width spaces). | Adversary crafts a target repo's runbook proactive-controls row with Unicode tricks; gap record body inherits the prose; downstream issue body confuses the maintainer. | Schema validation includes NFKC normalization + zero-width / RTL-override rejection. **auto-fix** applied to M3 BDD adversarial scenario. |
+| S-2 | security | hold-scope | M1 declarations file SHA pinning | SHA pinning + `git rev-parse HEAD` cache integrity check is solid. But `git clone` on cache miss happens against the full upstream repo (Hulumi, SLSL); could be slow + bandwidth-heavy. | First-run user with a slow connection waits 30+ seconds for `git clone`; UX feels broken. | Acceptable cost; `--depth=1` clone helps but doesn't eliminate. Document expected first-run latency in `references/methodology-m1-reader.md`. **hold-scope** — performance is documentation issue, not security. |
+| S-3 | security | ask | M4 third-party filing rate-limit cap | 40 issues/hr defensive cap. Phase 1 research Q5 says undocumented; the choice is empirical. | Real-world telemetry from M5 dogfood + early adoption may show 40/hr is too low or too high. | Document refresh-rule: "after 3 months of real use, review the cap based on observed point-cost from runs that brushed the cap." **ask** user — accept review-after-3-months follow-up? |
+| S-4 | security | auto-fix | M1 — vendor SaaS API fallbacks | Phase 1 stack-decision rejected vendor SaaS API fallbacks. M1 doesn't enumerate what those would be. | Future contributor "for convenience" wraps Snyk API (or equivalent) into the matcher; explicit ban undocumented in M1. | Enumerate forbidden fallbacks in M1 anti-patterns: Semgrep AppSec, Snyk, GitHub Advanced Security, Veracode, Checkmarx. **auto-fix** applied to M1 contract. |
+| S-5 | security | hold-scope | Argv-list discipline | Standard discipline. Same pattern as `/slo-sast` M5 + `/slo-rulegen`. | Solid. | **hold-scope** — confirmed. |
+
+## Auto-fix corrections applied
+
+- C-1: M5 pre-flight enumerates 2-3 candidate target milestones.
+- C-4: M1 contract specifies cache size cap (1 GiB) + age cap (90 days) + LRU eviction.
+- C-7: M3 contract — one gap record per unmatched control.
+- S-1: M3 BDD adversarial scenario includes Unicode-trick rejection.
+- S-4: M1 anti-patterns enumerate forbidden vendor SaaS fallbacks.
+
+## Asks for project-owner decision
+
+- **C-3**: where does the canonical `gh issue create` rate-limit discipline live — R1 or R4?
+- **C-6**: confirm conservative-by-default tiebreaker in matcher?
+- **S-3**: accept review-after-3-months follow-up for the 40/hr cap?
+
+## Final disposition
+
+**Accept with minor edits + asks**. Pre-requisites (C-2) are the largest external dependency. No critical findings.

--- a/docs/design/agent-host-capabilities.md
+++ b/docs/design/agent-host-capabilities.md
@@ -17,7 +17,7 @@ This document is the capability matrix for the current host story. Use it when y
 | Read the canonical skill catalog | Supported | Supported | Catalog is host-neutral |
 | Interactive use of installed skills | Supported | Supported | Exact UX depends on the host's skill/session model |
 | Host-specific overlay doc | `CLAUDE.md` | `copilot-instructions.md` | Both point back to the same canonical catalog |
-| `/slo-research` automated batch backend | Supported | Not supported yet | Current batch backend shells out to `claude` via `sldo-research` |
+| `/slo-research` automated batch backend | Supported | Not supported yet | Optional Claude batch backend shells out to `claude` via `sldo-research` |
 | Headless runtime automation | Supported on specific Claude-only paths | Not supported yet | No Copilot runtime harness is shipped today |
 | Live business judgment runtime harness | Supported as opt-in Claude-only automation | Not supported yet | Current harness depends on `claude -p` |
 
@@ -25,7 +25,7 @@ This document is the capability matrix for the current host story. Use it when y
 
 - The installer is multi-host now. The runtime story is not.
 - GitHub Copilot should be treated as an interactive host today, not a headless automation target.
-- `/slo-research` is the main remaining hidden host boundary. The installed skill is visible in both hosts, but the current batch backend is still Claude-specific.
+- `/slo-research` no longer hides a second-agent dependency in the interactive path. Only the optional batch backend remains Claude-specific.
 
 ## What to read next
 

--- a/docs/design/agent-host-capabilities.md
+++ b/docs/design/agent-host-capabilities.md
@@ -1,0 +1,35 @@
+# Agent Host Capabilities
+
+This document is the capability matrix for the current host story. Use it when you need to answer a simple question: "does this work in Claude Code, GitHub Copilot, both, or neither?"
+
+## Reading rule
+
+- If the capability is in the catalog, it is part of the pack.
+- If the capability is in this matrix, it is honest about current host support.
+- If a capability is missing here, do not promise it.
+
+## Capability matrix
+
+| Capability | Claude Code | GitHub Copilot | Notes |
+|---|---|---|---|
+| Install skills with `sldo-install` | Supported | Supported | Same `SKILL.md` contract; different install roots |
+| Project-local install with `--local` | Supported | Supported | Writes to `./.claude/skills/` or `./.copilot/skills/` |
+| Read the canonical skill catalog | Supported | Supported | Catalog is host-neutral |
+| Interactive use of installed skills | Supported | Supported | Exact UX depends on the host's skill/session model |
+| Host-specific overlay doc | `CLAUDE.md` | `copilot-instructions.md` | Both point back to the same canonical catalog |
+| `/slo-research` automated batch backend | Supported | Not supported yet | Current batch backend shells out to `claude` via `sldo-research` |
+| Headless runtime automation | Supported on specific Claude-only paths | Not supported yet | No Copilot runtime harness is shipped today |
+| Live business judgment runtime harness | Supported as opt-in Claude-only automation | Not supported yet | Current harness depends on `claude -p` |
+
+## Important boundaries
+
+- The installer is multi-host now. The runtime story is not.
+- GitHub Copilot should be treated as an interactive host today, not a headless automation target.
+- `/slo-research` is the main remaining hidden host boundary. The installed skill is visible in both hosts, but the current batch backend is still Claude-specific.
+
+## What to read next
+
+- [../skill-pack-catalog.md](../skill-pack-catalog.md) for the host-neutral list of shipped skills.
+- [../../CLAUDE.md](../../CLAUDE.md) for the Claude Code overlay.
+- [../../copilot-instructions.md](../../copilot-instructions.md) for the GitHub Copilot overlay.
+- [../getting-started.md](../getting-started.md) for the first-run path.

--- a/docs/design/business-skill-improvements-overview.md
+++ b/docs/design/business-skill-improvements-overview.md
@@ -1,0 +1,148 @@
+---
+name: business-skill-improvements
+created: 2026-04-27
+status: design lock-in
+tla_required: false
+security_libs_required: false
+ai_component: false
+compliance: [gdpr, soc2]
+---
+
+# Design overview — business skill improvements
+
+## System goal
+
+Close the predicate-evaluation hallucination surface across the five advisor skills (`/slo-legal`, `/slo-accounting`, `/slo-equity`, `/slo-fundraise`, `/slo-hire`) by introducing **conversational intake contracts** that the skill drives via dialogue (modeled on [`/slo-ideate`'s seven forcing questions](../../skills/slo-ideate/SKILL.md)). Move every UK statute / regulator citation from inlined SKILL.md prose into authority files (`uk-regulator-enumeration.md`, `uk-employment-statute-anchors.md`, `uk-consumer-statute-anchors.md`, `uk-marketing-statute-anchors.md`) consulted at use time. Verify SAFE / cap-table / pricing arithmetic before emission. Centralize numeric heuristics for the seven biz generators into KPI baseline files with source attribution + refresh cadence.
+
+## Stack decision
+
+Existing biz-pack stack — no changes:
+
+- Markdown for all SKILL.md, intake contracts, statute / KPI authority files
+- Rust (`crates/sldo-install/tests/`) for structural-contract tests
+- `WebFetch` / `WebSearch` denied at the SLO-CLI invocation layer per `tm-biz-abuse-1` (no change)
+- `legislation.gov.uk` / HMRC Manual / ICO / public KPI sources are captured at runbook-author time only (citations, not runtime fetches)
+
+No new runtime dependencies. No schema migrations. No changes to the four hard-block predicate IDs (immutability locked by `crates/sldo-install/tests/e2e_biz_a_m2.rs::triage_gate_predicate_set_unchanged_from_m1`).
+
+## Components
+
+| Component | Responsibility | Milestone introduced/changed | Key interfaces |
+|---|---|---|---|
+| `references/biz/uk-regulator-enumeration.md` | Closed enum of UK regulators with `id`, `display_name`, `domain`, `statutory_basis`, `default_route_to`, `cited_by`, `last_reviewed` | M1 | Consulted by `gate-1-regulated` evaluation in every advisor skill |
+| `references/biz/uk-employment-statute-anchors.md` | Verbatim quotes of IANA 2006, ERA 1996, Pensions Act 2008, Equality Act 2010, IR35 (ITEPA 2003 Ch 10) sections | M1 | Cited by `/slo-hire`, `/slo-legal` |
+| `references/biz/uk-consumer-statute-anchors.md` | Verbatim quotes of CRA 2015, Consumer Contracts Regulations 2013, DMCC 2024 | M1 | Cited by `/slo-legal`, `/slo-marketing`, `/slo-pricing` |
+| `references/biz/uk-marketing-statute-anchors.md` | ASA + CAP Code (12th ed), PECR, DUAA 2025 anchors | M1 | Cited by `/slo-marketing`, `/slo-launch`, `/slo-sales-funnel` |
+| `references/biz/hmrc-vcm-index.md` (refresh) | Verbatim quotes of VCM34080, VCM3000, VCM31000, Abingdon Health line | M1 | Cited by `/slo-equity`, `/slo-fundraise` |
+| `references/biz/{legal,accounting,equity,fundraise,hire}-intake-contract.md` | Conversational intake contracts (rename from `*-intake-form.md`) | M2 | Consumed by advisor skills before `draft` mode |
+| Five advisor SKILL.md updates | Mandate intake contract, restate-and-confirm, refusal-on-ambiguity, citation discipline | M2 | SKILL.md prose only; no behavior change beyond intake |
+| Numeric verification pass | SAFE math, cap-table totals, pricing value-equation re-derived | M3 | `/slo-fundraise`, `/slo-equity`, `/slo-pricing` |
+| `references/biz/saas-kpi-targets-baseline.md` (refresh starter) | Source-verified KPI bands with per-row `last_checked:` | M4 | Cited by `/slo-metrics` (primary) + 6 generators |
+| `references/biz/outbound-conversion-baselines.md` | Funnel-stage rates with sources | M4 | Cited by `/slo-sales-funnel`, `/slo-metrics` |
+| `references/biz/product-prioritization-frameworks.md` | RICE, Kano definitions with sources | M4 | Cited by `/slo-product` |
+| `references/biz/value-equation-pricing.md` | "25-33% of value" claim sourced (Hormozi *$100M Offers*); "30-50% below market" reframed | M4 | Cited by `/slo-pricing` |
+| `references/biz/mom-test-canonical-questions.md` | Fitzpatrick *The Mom Test* 2013 question scaffolding | M4 | Cited by `/slo-talk-to-users`, `/slo-product`, `/slo-launch` |
+| `references/biz/launch-success-thresholds.md` | "set your own threshold" framing (most prior numbers are unsourceable) | M4 | Cited by `/slo-launch` |
+| `references/biz/artifact-schema.md` (refresh) | Adds `baseline_ref:` field for generator outputs that cite numeric targets | M5 | Read by `/slo-verify` Pass 4 schema check |
+| Structural-contract tests | Cross-skill citation tests; closed-enum immutability tests | M5 | `cargo test --workspace` baseline |
+| `/loop @annually` agent (deferred) | Re-fetches public sources, opens refresh PR | M5 (configured), runs annually | Reuses `/schedule` skill |
+
+## Data flow
+
+```
+Founder invokes /slo-legal draft <doc-type>
+       │
+       ▼
+┌──────────────────────────────────────────┐
+│ Skill begins CONVERSATIONAL elicitation  │ ← references/templates/intake-checklist.md (R2 M1)
+│   F1 Jurisdiction (one question)         │ ← references/biz/legal-intake-contract.md
+│   F2 Counterparty representation         │
+│   F3 Deal value (ex-VAT, total contract) │
+│   F4 GDPR scope                          │
+│   F5 Regulated sector                    │ ← references/biz/uk-regulator-enumeration.md
+│   F6 Doc-type + counterparty             │
+└────────────────────┬─────────────────────┘
+                     │ on every vague answer: PUSH BACK
+                     │ on insufficient info: REFUSE (third state)
+                     ▼
+        ┌────────────────────────────┐
+        │ Restate in 3-5 sentences   │
+        │ Founder confirms / corrects │
+        └────────────┬───────────────┘
+                     │
+                     ▼
+        ┌────────────────────────────┐
+        │ Evaluate 4 gates against    │ ← references/biz/triage-gate.md
+        │ structured intake_summary   │ ← references/biz/uk-regulator-enumeration.md
+        └────────────┬───────────────┘
+                     │
+            ┌────────┴────────┐
+            ▼                 ▼
+   gates_fired:[]        gates_fired:[gate-X]
+            │                 │
+            ▼                 ▼
+   ┌────────────────┐  ┌─────────────────┐
+   │ DRAFT artifact │  │ TRIAGE artifact  │
+   │ docs/biz/legal/│  │ docs/biz-public/│
+   │ <slug>-<date>  │  │ legal/triage-…  │
+   └────────────────┘  └─────────────────┘
+```
+
+## Trust boundaries
+
+- `docs/biz/` is `.gitignore`-controlled; confidential artifacts never leave the founder's local machine.
+- `docs/biz-public/` is `git`-tracked; placeholder-only by tier convention; `/slo-verify` Pass 4 PII scan is the second-line defense.
+- All external regulator anchors (`legislation.gov.uk`, `gov.uk` HMRC, `ico.org.uk`, `www.jpplaw.co.uk`) are emitted as **citations** the founder follows manually — never fetched at runtime by any biz skill (per `tm-biz-abuse-1`).
+
+## Interfaces locked
+
+| Interface | Stability | Notes |
+|---|---|---|
+| `references/biz/uk-regulator-enumeration.md` per-row schema (`id`, `display_name`, `domain`, `statutory_basis`, `default_route_to`, `cited_by`, `last_reviewed`) | `stable-interface` | Append-only without `/slo-architect` re-pass; no removals or `id` renames |
+| `references/biz/<skill>-intake-contract.md` field IDs (F1-F6) | `stable-interface` | Sister contracts must reuse F1 / F4 / F5 verbatim |
+| `intake_summary:` + `gates_evaluation:` artifact frontmatter blocks | `stable-interface` | Read by `/slo-verify` Pass 4 + future audit / replay |
+| Statute anchor file row schema (citation, statute name, section, retrieval date) | `stable-interface` | Cross-skill citation chain |
+| `baseline_ref:` artifact frontmatter field | `stable-interface` | Added in M5 to `artifact-schema.md` |
+| `/slo-verify` Pass 4 PII pattern scan + override mechanism (`pii_scan_override:`, `tier_override_reason:`) | `stable-interface` | Existing; not changed |
+| Four hard-block predicate IDs in `triage-gate.md` | `immutable` | Locked by structural-contract test; reversal requires `/slo-architect` re-pass |
+
+## TLA+ section
+
+Not required (`tla_required: false`). No concurrent actors, no distributed state. Conversational intake is sequential founder-skill turns; gate evaluation is deterministic over the structured `intake_summary:` block.
+
+## STRIDE sweep (per Step 3.5)
+
+| Component | Spoofing | Tampering | Repudiation | Info disclosure | DoS | EoP |
+|---|---|---|---|---|---|---|
+| Conversational intake elicitation | N/A | mitigated — `intake_summary:` is the structured frontmatter; founder corrections require explicit re-confirmation | mitigated — `intake_summary:` carries `restated_at:` timestamp + `restated_and_confirmed: true` | residual — confidential intake content goes to `docs/biz/`; mitigated by tier convention + write-time `.gitignore` warning + Pass 4 PII scan | N/A | N/A |
+| Statute / regulator authority files | N/A | mitigated — git-tracked + per-row `last_checked:` date | N/A | N/A — public regulatory content | N/A | N/A |
+| Numeric verification pass (SAFE / cap-table / pricing) | N/A | mitigated — re-derivation pass before write; structural-contract test asserts math consistency | mitigated — verification result captured in artifact frontmatter | N/A | N/A | N/A |
+| KPI baseline files | N/A | mitigated — git-tracked + per-row `last_checked:` + annual refresh `/loop` | N/A | N/A | N/A | N/A |
+
+New abuse cases:
+
+- `tm-biz-skill-improvements-abuse-1: founder games the conversational intake to bypass a gate` (e.g., quotes deal value as monthly when total triggers gate-2). Mitigated by F3's structured `deal_value_basis:` enum + skill computing total contract value; `unknown` confidence is a refusal.
+- `tm-biz-skill-improvements-abuse-2: stale statute citation propagates to founder artifact` (statute amended after `last_checked:`). Mitigated by `last_checked:` field + skill's stale-citation warning at +12 months. Reversal: refuse to draft until refreshed if > 24 months stale.
+- `tm-biz-skill-improvements-abuse-3: KPI baseline drift (Bessemer / OpenView publishes new annual report; SLO file lags)`. Mitigated by `/loop @annually` agent + per-row `last_checked:` warning.
+
+## Compatibility commitments
+
+- The four hard-block predicate IDs in `triage-gate.md` remain unchanged (immutability test).
+- Existing artifacts produced before M2 (without `intake_summary:` frontmatter) remain valid; the new field is optional for backward compat.
+- The `cost_baseline_ref:` frontmatter field stays for advisor outputs; the new `baseline_ref:` is for generator outputs only.
+- Existing `docs/biz/` and `docs/biz-public/` directory conventions unchanged.
+- Existing `/slo-verify` Pass 4 PII scan logic unchanged; only the override mechanism's documentation is extended.
+
+## Out-of-scope
+
+- US / EU jurisdiction extensions (v2 architectural pivot per `docs/design/biz-skill-pack-overview.md`).
+- New advisor doc-types or new generator skills.
+- Substantive changes to the biz-pack threat model beyond the three new abuse cases above.
+- Building the executable eval-runner (deferred from R2 / [issue #4](https://github.com/kerberosmansour/SunLitOrchestrate/issues/4)); evals in this runbook are documented expectations.
+- Cross-skill SAFE-template generation (operative documents remain solicitor-drafted).
+
+## Research-validation discipline (load-bearing)
+
+Every UK statute citation in this runbook must be source-verified against `legislation.gov.uk` at retrieval-stamped dates. Every HMRC manual citation against `https://www.gov.uk/hmrc-internal-manuals/venture-capital-schemes-manual`. Every KPI baseline against the source listed in [`references/biz/saas-kpi-targets-baseline.md`](../../references/biz/saas-kpi-targets-baseline.md) per-row.
+
+**Bright-line**: unverifiable claims removed, not weakened. The bar is set in `references/templates/citation-discipline.md` (R2 M1) and applies to this runbook's M1 (statute / regulator) and M4 (KPI baselines) outputs.

--- a/docs/design/engineering-skill-improvements-overview.md
+++ b/docs/design/engineering-skill-improvements-overview.md
@@ -1,0 +1,138 @@
+---
+name: engineering-skill-improvements
+created: 2026-04-27
+status: design lock-in
+tla_required: false
+security_libs_required: false
+ai_component: false
+compliance: [soc2, asvs]
+---
+
+# Design overview — engineering skill improvements
+
+## System goal
+
+Close the structural gaps the 2026-04-27 skill-pack review identified across the engineering-side skills: (a) decompose the three monolithic SKILL.md files (`/slo-sast`, `/slo-tla`, `/slo-plan`) into thin orchestrators + per-stage methodology references; (b) seed a `references/templates/` shared library so cross-skill drift on common patterns is minimized; (c) hard-enforce `/slo-freeze` and (optionally) `/slo-execute` allow-list via `.claude/settings.json` PreToolUse hook; (d) add per-skill `evals/` directories with the seven canonical case shapes; (e) gate every security-engineering claim through a research-validation source hierarchy.
+
+## Stack decision
+
+Existing project stack — no changes:
+
+- Markdown for SKILL.md, references, methodology docs, eval cases
+- Rust (`crates/sldo-install`) for structural-contract tests + `cargo test --workspace` baseline
+- `.claude/settings.json` PreToolUse hook (uses `update-config` skill for mutation)
+- `gh` CLI for any future issue filing (out-of-scope for this runbook; that's R1)
+
+No new runtime dependencies. No new crates. The PreToolUse hook is a small shell script invoked by Claude Code; argv-list discipline applies if it shells out.
+
+## Components
+
+| Component | Responsibility | Milestone introduced/changed | Key interfaces |
+|---|---|---|---|
+| `references/templates/` | Shared library: intake-checklist, restate-and-confirm, citation-discipline, tool-safety-section, output-frontmatter, escalation, eval-cases, heuristic-numbers-discipline | M1 | Cited from every SKILL.md update |
+| `references/templates/citation-discipline.md` | Source hierarchy + research-validation rule for security-engineering claims | M1 | Cited by `/slo-sast`, `/slo-tla`, `/slo-rulegen`, `/slo-verify`, `/slo-research` |
+| `skills/slo-sast/SKILL.md` | Reduced to ~100 lines (pre-flight + dispatch + anti-patterns common across milestones) | M2 | Symlink-installed unchanged |
+| `skills/slo-sast/references/methodology-m1-parser.md` ... `m5-pr-creation.md` | Per-stage methodology | M2 | Cited from SKILL.md by relative path |
+| `skills/slo-tla/SKILL.md` | Reduced to ~100 lines (prereq + suitability gate + handoff) | M3 | Symlink-installed unchanged |
+| `skills/slo-tla/references/methodology-*.md` | Per-stage methodology (elicitation, abstraction, counterexample, verified-design) | M3 | Cited from SKILL.md |
+| `skills/slo-tla/tools.toml` | Apalache version + SHA pin added | M3 | Read by SKILL.md prereq cascade |
+| `skills/slo-plan/references/methodology-milestone-authoring.md` | Per-milestone authoring sub-procedure extracted | M4 | Cited from SKILL.md |
+| `crates/sldo-install/tests/<test>` | Soft line-cap structural-contract test | M4 | Asserts every SKILL.md ≤ 200 lines OR carries `# soft-cap-exception:` |
+| `skills/<skill>/evals/<case>.md` | Per-skill eval cases (7 categories) | M5 | Documented expectations; runtime harness consumes later |
+| `.claude/settings.json` PreToolUse hook | Hard-enforces `/slo-freeze` scope lock | M5 | Reuses `update-config` skill for mutation |
+
+## Data flow
+
+```
+SKILL invocation
+  ┌──────────────────────────────────────┐
+  │ SKILL.md read (≤ 200 lines, lean)    │
+  │   - pre-flight                        │
+  │   - mode dispatch                     │
+  │   - anti-patterns                     │
+  └────────────┬──────────────────────────┘
+               │ if methodology needed:
+               ▼
+    ┌──────────────────────────┐
+    │ references/methodology-* │  per-stage detail loaded on demand
+    └──────────────────────────┘
+               │ if claim needs source-of-truth:
+               ▼
+    ┌──────────────────────────┐
+    │ references/templates/    │  shared discipline (intake, citation, etc.)
+    │   citation-discipline    │
+    │   intake-checklist       │
+    │   ...                    │
+    └──────────────────────────┘
+               │ at write time:
+               ▼
+    ┌──────────────────────────┐
+    │ .claude/settings.json    │  PreToolUse hook: enforce /slo-freeze scope
+    │   PreToolUse hook        │
+    └──────────────────────────┘
+```
+
+## Trust boundaries
+
+- SKILL.md prose is repo-tracked; install symlinks under `~/.claude/skills/<name>/` are the only runtime surface. Decomposition doesn't change this trust boundary.
+- The PreToolUse hook is local; it reads session state from `~/.sldo/freeze-scope.txt` (gitignored). Compromise of the local user account compromises both the hook and the SKILL.md prose simultaneously — same trust class.
+- Eval cases are documented expectations only; no runtime trust boundary in this milestone.
+
+## Interfaces locked
+
+| Interface | Stability | Notes |
+|---|---|---|
+| `references/templates/<name>.md` file paths | `stable` | Cited from SKILL.md across multiple skills |
+| `skills/<skill>/references/methodology-*.md` per-skill convention | `stable` | Sibling-to-SKILL.md location is the install-compatible pattern |
+| `evals/<case>.md` file shape (frontmatter: skill, case-name, category, expected-behavior; body: input + expected) | `stable` | Forward-compatible with future runtime harness |
+| `# soft-cap-exception: <reason>` SKILL.md frontmatter pragma | `stable` | Read by structural-contract test |
+| Source hierarchy in `references/templates/citation-discipline.md` | `stable` | Six-tier; lock-in required to prevent drift |
+| `.claude/settings.json` PreToolUse hook contract | `evolving` | Project-level; per-project freeze scope |
+
+## TLA+ section
+
+Not required (`tla_required: false`). No concurrent actors, no distributed state. Decomposition is purely textual refactoring; PreToolUse hook is single-session, single-actor.
+
+## STRIDE sweep (per Step 3.5)
+
+| Component | Spoofing | Tampering | Repudiation | Info disclosure | DoS | EoP |
+|---|---|---|---|---|---|---|
+| SKILL.md decomposition | N/A | mitigated — git-tracked, install symlinks SHA-verified by `sldo-install verify` (deferred follow-up) | N/A — git history is the audit trail | N/A — public skill content | N/A | N/A |
+| `references/templates/` shared library | N/A | mitigated — git-tracked | N/A | N/A | N/A | N/A |
+| PreToolUse hook for `/slo-freeze` | residual — local user account compromise impacts hook integrity (same trust class as the SKILL.md itself) | mitigated — `update-config` skill is the canonical mutation surface; argv-list if hook shells out | residual — local hook execution is not centrally logged; mitigated by Claude Code's own tool-use telemetry | N/A — hook reads session state, doesn't emit | mitigated — hook execution is bounded per tool-call | mitigated — hook is execution-control, not privilege-grant |
+| Per-skill `evals/` | N/A | mitigated — git-tracked | N/A — eval content is documentation | N/A | N/A | N/A |
+
+New abuse cases:
+
+- `tm-eng-skill-improvements-abuse-1: SKILL.md decomposition breaks install-symlink chain` — class eliminated by structural-contract test that asserts every decomposed SKILL.md still references its methodology files (cargo test --workspace is the baseline gate).
+- `tm-eng-skill-improvements-abuse-2: PreToolUse hook bypassed via session-state file deletion` — residual; documented as "this is not a security boundary" disclaimer in `/slo-freeze` SKILL.md description; the hook is a discipline-enforcer, not a security primitive.
+- `tm-eng-skill-improvements-abuse-3: Soft line-cap exception abused to bypass decomposition` — mitigated by requiring `# soft-cap-exception: <reason>` to be reviewable in the structural-contract test output (CI flags exceptions for human review).
+
+## Compatibility commitments
+
+- Every decomposed SKILL.md still passes `cargo test --workspace` install-symlink tests.
+- Every existing `references/sast/`, `references/biz/`, etc., reference file is preserved unchanged (decomposition adds new `methodology-*` files; doesn't replace existing per-stage references).
+- The PreToolUse hook is opt-in (per-project `.claude/settings.json`); existing repos without it continue to operate with prose-level discipline.
+- The soft line-cap structural-contract test is opt-in via runbook authoring (the test asserts it; existing SKILL.md files that exceed the cap get the `# soft-cap-exception:` pragma in M4 as part of the migration).
+
+## Out-of-scope
+
+- Building the runtime Claude Code harness for executable evals (deferred-follow-up in [issue #4](https://github.com/kerberosmansour/SunLitOrchestrate/issues/4)).
+- Substantive changes to skill behavior beyond decomposition + polish.
+- Extending the `update-config` skill (use as-is).
+- Moving any work currently in [issue #4](https://github.com/kerberosmansour/SunLitOrchestrate/issues/4) (`/slo-sec-libs` Phase 4) into this runbook.
+
+## Research-validation discipline (load-bearing)
+
+Every claim in this runbook that touches security-engineering content must be source-verified before SKILL.md edits land:
+
+| Claim category | Primary source | Acceptance |
+|---|---|---|
+| Semgrep CLI behavior at pinned version | https://semgrep.dev/docs/ at `MIN-SEMGREP-VERSION.md` pin | quote + `last_checked:` |
+| `cargo audit` exit-code semantics | https://github.com/rustsec/rustsec/tree/main/cargo-audit at pinned commit | quote + commit SHA |
+| TLA+ behavior + Apalache pinning | https://lamport.azurewebsites.net/tla/tools.html + https://github.com/apalache-mc/apalache/releases at pinned version | quote + version + SHA-256 |
+| GitHub Actions / `pull_request_target` ban | GitHub Docs at https://docs.github.com/en/actions + Trail of Bits' `https://github.com/trailofbits/audit-action` rationale | quote + retrieval date |
+| OWASP Proactive Controls v3 categories | OWASP project at https://owasp.org/www-project-proactive-controls/ | quote + retrieval date |
+| ASVS chapters | OWASP ASVS at https://owasp.org/www-project-application-security-verification-standard/ | quote + version + retrieval date |
+
+**Bright-line**: unverifiable claims removed, not weakened. The bar is set in [`references/templates/citation-discipline.md`](../../references/templates/citation-discipline.md) (M1).

--- a/docs/design/loops-and-lessons-closure-overview.md
+++ b/docs/design/loops-and-lessons-closure-overview.md
@@ -1,0 +1,127 @@
+---
+name: loops-and-lessons-closure
+created: 2026-04-27
+status: design lock-in
+tla_required: false
+security_libs_required: false
+ai_component: false
+compliance: [soc2]
+---
+
+# Design overview — loops + lessons closure
+
+## System goal
+
+Make the SLO skill pack's cyclic feedback structures (engineering loops, business loops, lessons loop) **first-class artifacts** that:
+
+1. New contributors and freshly-loaded Claude instances can read in 90 seconds.
+2. Are referenced by their constituent skills (cross-link from each implicated SKILL.md).
+3. Drive automated lesson-→issue filing via `/slo-retro` extension.
+4. Close the loop at milestone start via `/slo-execute` pre-flight pulling open prior-retro issues as scope candidates.
+
+## Stack decision
+
+This runbook is documentation + skill-prose extension + minor `gh` CLI wiring. Stack is unchanged from project-wide:
+
+- Markdown for all loop docs and runbook artifacts
+- `gh` CLI for issue search + creation (existing dependency)
+- Rust (`crates/sldo-install`) for any structural-contract test additions
+
+No new runtime dependencies. No schema migrations.
+
+## Components
+
+| Component | Responsibility | Milestone introduced/changed | Key interfaces |
+|---|---|---|---|
+| `docs/LOOPS-ENGINEERING.md` | First-class engineering-loops doc | M1 | Cross-linked from `ARCHITECTURE.md`, every implicated engineering SKILL.md |
+| `docs/LOOPS-BUSINESS.md` | First-class business-loops doc | M2 | Cross-linked from each implicated biz SKILL.md |
+| `/slo-retro` extension | Classifies each lesson + dedupes via `gh search` + files issue with confirmation | M3 | `gh issue create` (argv-list); fallback `LESSONS-BACKLOG.md` |
+| `/slo-execute` pre-flight extension | Reads open prior-retro issues at milestone start; surfaces as scope candidates | M4 | `gh issue list` (argv-list); reads from runbook's `<prefix>` for filtering |
+| `docs/runbook-template_v_3_template.md` | Adds "Carry-forward from prior retros" section | M4 | Read by `/slo-plan` and `/slo-resume` |
+
+## Data flow
+
+```
+/slo-retro M<N>
+  ┌─────────────────────────────────┐
+  │ Write docs/lessons/<prefix>-m<N>.md │
+  └──────────────┬──────────────────┘
+                 │
+                 ▼
+        ┌────────────────┐
+        │ Classify each   │     ┌─ product       ──→ current repo
+        │ lesson          │ ──→ ┼─ upstream-OSS  ──→ resolved upstream repo
+        │ (LLM judgment)  │     └─ slo-process   ──→ kerberosmansour/SunLitOrchestrate
+        └────────┬───────┘
+                 │
+                 ▼
+        ┌────────────────┐
+        │ gh search issues │ — dedupe
+        └────────┬───────┘
+                 │
+                 ▼
+        ┌────────────────┐
+        │ Confirm with    │ — never auto-file (issue creation is publicly visible)
+        │ user            │
+        └────────┬───────┘
+                 │
+                 ▼
+        ┌────────────────┐
+        │ gh issue create │ OR LESSONS-BACKLOG.md fallback
+        └────────────────┘
+
+/slo-execute M<N+k>
+  ┌────────────────────────────────────────┐
+  │ Pre-flight: query open issues filed   │
+  │ by /slo-retro for prior milestones    │
+  │ in this runbook's prefix              │
+  └─────────────────┬──────────────────────┘
+                    │
+                    ▼
+           ┌─────────────────┐
+           │ Surface as scope │
+           │ candidates       │
+           └─────────────────┘
+```
+
+## Trust boundaries
+
+- `gh` CLI invocation runs with the user's GitHub auth — same trust posture as existing `/slo-ship`.
+- Issue body content originates from `docs/lessons/<prefix>-m<N>.md` — author-controlled, not user-input. Low injection risk; argv-list discipline is the standard defense.
+- `LESSONS-BACKLOG.md` fallback is local-only — no remote.
+
+## Interfaces locked
+
+| Interface | Stability | Notes |
+|---|---|---|
+| `docs/LOOPS-*.md` file path + per-loop section schema | `stable` | Cross-referenced from SKILL.md files |
+| Issue title prefix (TBD in M3 spike) | `stable` once chosen | `gh search` reliability anchor |
+| `LESSONS-BACKLOG.md` row format | `stable` | Local fallback consumers |
+| Runbook template's "Carry-forward from prior retros" section | `stable` | Read by `/slo-resume` and downstream tooling |
+| `/slo-retro` and `/slo-execute` SKILL.md prose updates | `evolving` | Iterative; lessons file improvements expected |
+
+## TLA+ section
+
+Not required (`tla_required: false`). No concurrent actors, no distributed state, no ordering guarantees, no resource ownership / leases / locks, no failure recovery protocols. The "loop closure" is sequential — retro writes → issue files → next milestone reads — with no race surface.
+
+## STRIDE sweep (per Step 3.5)
+
+| Component | Spoofing | Tampering | Repudiation | Info disclosure | DoS | EoP |
+|---|---|---|---|---|---|---|
+| `/slo-retro` issue filing | N/A — uses user's `gh` auth | mitigated by argv-list discipline (no shell interpolation of lesson body) | mitigated — every filing carries author + timestamp via `gh` | residual — lesson content goes to remote; mitigated by user-confirmation gate before `gh issue create` | mitigated by client-side cap (reuse `/slo-sec-libs` rate limit pattern) | N/A — no privilege escalation surface |
+| `/slo-execute` pre-flight issue read | N/A | N/A — read-only `gh issue list` | N/A | N/A — only reads issues already public in the repo | mitigated — single `gh issue list` per milestone start | N/A |
+| `LESSONS-BACKLOG.md` fallback | N/A | low — local file, repo `.gitignore`-controlled | N/A | residual — file is local; if remote pushed, lesson content is exposed (author intent) | N/A | N/A |
+
+No new abuse cases beyond `tm-loops-abuse-1: prompt injection via lesson body content` — mitigated by `~~~text` user-string fence rule already in `/slo-architect`'s SECURITY.md template (load-bearing for any template-authoring skill).
+
+## Compatibility commitments
+
+- No breaking changes to `docs/RUNBOOK-*.md` files: existing runbooks without "Carry-forward from prior retros" section remain valid; the new section is optional in M4's template change.
+- `/slo-retro` extension preserves the existing lessons-file template; the issue-filing is additive after the file is written.
+- `/slo-execute` extension adds a step to pre-flight; existing milestones without retro-originated issues see "no carry-forward" and proceed unchanged.
+
+## Out-of-scope
+
+- Substantive retro content quality (this runbook ships the loop mechanism; lesson quality is the responsibility of the agent invoking `/slo-retro`).
+- Cross-repo issue federation (R4 `/slo-sec-libs` covers third-party filing for capability gaps; this runbook's upstream-OSS classification reuses `/slo-sec-libs` rate-limit pattern but is independent).
+- Visualization / dashboard for the loops (loops are markdown docs in v1).

--- a/docs/design/slo-sec-libs-overview.md
+++ b/docs/design/slo-sec-libs-overview.md
@@ -1,0 +1,182 @@
+---
+name: slo-sec-libs
+created: 2026-04-27
+status: design lock-in
+tla_required: false
+security_libs_required: true
+ai_component: false
+compliance: [soc2, asvs]
+---
+
+# Design overview — /slo-sec-libs
+
+## System goal
+
+Add a `/slo-sec-libs` skill that reads a target repo's `ARCHITECTURE.md` + `stack-decision.md` + the runbook's per-milestone proactive-control requirements, matches each requirement against capabilities advertised by Hulumi + SunLitSecureLibraries via CycloneDX 1.6+ `declarations`, and either (a) recommends a specific library component covering the requirement or (b) files a structured capability-gap issue against the library owner's intake repo (default: `kerberosmansour/slo-security-intake`; third-party gated by `--file-upstream` flag + per-session 40-issues/hr cap).
+
+## Stack decision
+
+Same shape as the rest of the SLO toolchain, with one new external surface:
+
+- Markdown for SKILL.md
+- Rust (`crates/sldo-common::toolflags`) for skill-flag enforcement
+- **Python subprocess** for CycloneDX 1.6 `declarations` jsonschema validation (Rust ecosystem has no 1.6+ declarations support — `cyclonedx-bom 0.8.1` is spec-1.5 only per Phase 1 research Q2)
+- `git` and `gh` CLI for upstream filing (argv-list discipline; no `--repo` flag)
+
+New runtime dependency: Python 3.10+ with `jsonschema` library available locally. The skill checks `which python3` + `python3 -c "import jsonschema"` in pre-flight; fails with install hint if missing. No SLO-vendored Python package — uses system Python.
+
+## Components
+
+| Component | Responsibility | Milestone | Key interfaces |
+|---|---|---|---|
+| `skills/slo-sec-libs/SKILL.md` | Skill orchestrator; mode dispatch; pre-flight | M1-M5 | Reads target repo's `ARCHITECTURE.md`, `docs/design/<slug>-stack-decision.md`, `docs/RUNBOOK-<slug>.md` |
+| `skills/slo-sec-libs/scripts/read-declarations.py` | Python jsonschema validator + capability extractor | M1 | Input: CycloneDX 1.6 JSON; output: structured capability catalog (stdout JSON) |
+| `skills/slo-sec-libs/references/methodology-m1-reader.md` | Declarations reader spec | M1 | Cited from SKILL.md |
+| `skills/slo-sec-libs/references/methodology-m2-matcher.md` | Capability matching algorithm | M2 | Cited from SKILL.md |
+| `skills/slo-sec-libs/references/capability-gap-schema.md` | Regex-validated schema for gap records (issue body shape) | M3 | Cited by M3 + M4 |
+| `skills/slo-sec-libs/references/upstream-filing-discipline.md` | argv-list rules + no-`--repo` rule + rate-limit cap | M3-M4 | Cited from SKILL.md |
+| `crates/sldo-common::toolflags::sec_libs_deny_flags()` | Skill-flag denial: `WebFetch`, `WebSearch` denied | M1 | Enforced at SLO-CLI invocation layer |
+| `kerberosmansour/slo-security-intake` repo | Default capability-gap filing destination | One-time prereq (out-of-band) | Issue template: `capability-gap-record` per the schema |
+| Hulumi + SunLitSecureLibraries CycloneDX 1.6 declarations | Capability advertisement | One-time prereq | Published as JSON in each repo's release artifacts |
+
+## Data flow
+
+```
+Target repo with ARCHITECTURE.md + stack-decision.md + RUNBOOK
+       │
+       ▼
+┌──────────────────────────────────────────────────┐
+│ /slo-sec-libs invoked                              │
+│ Pre-flight:                                        │
+│   - Python 3.10+ + jsonschema available           │
+│   - target repo has ARCHITECTURE.md               │
+│   - runbook declares security_libs_required: true │
+└────────────────────┬─────────────────────────────┘
+                     │
+                     ▼
+        ┌────────────────────────────┐
+        │ Fetch CycloneDX declarations │ ← cached at ~/.cache/sldo/declarations/<sha>
+        │ from Hulumi + SunLitSecureLibraries
+        │ (pinned SHA per stack-decision)
+        └────────────┬───────────────┘
+                     │
+                     ▼
+        ┌────────────────────────────┐
+        │ scripts/read-declarations.py │ ← Python jsonschema validate
+        │ extract capability catalog   │   reject malformed
+        └────────────┬───────────────┘
+                     │
+                     ▼
+        ┌────────────────────────────┐
+        │ Match runbook proactive-    │
+        │ controls rows against the   │
+        │ catalog                     │
+        └────────────┬───────────────┘
+                     │
+            ┌────────┴────────────────┐
+            ▼                         ▼
+   ┌────────────────┐         ┌──────────────────┐
+   │ MATCH found:   │         │ NO MATCH:         │
+   │ recommend lib  │         │ produce capability-│
+   │ component      │         │ gap record         │
+   │ + parametrics  │         │ (regex-validated)  │
+   └────────────────┘         └────────┬─────────┘
+                                       │
+                                       ▼
+                            ┌──────────────────┐
+                            │ User confirms    │
+                            │ filing           │
+                            └────────┬─────────┘
+                                     │
+                            ┌────────┴────────┐
+                            ▼                 ▼
+                   ┌──────────────┐   ┌──────────────┐
+                   │ Default:     │   │ --file-upstream:│
+                   │ slo-security-│   │ third-party    │
+                   │ intake repo  │   │ owner repo     │
+                   │              │   │ (rate-limited) │
+                   └──────────────┘   └──────────────┘
+                            │                 │
+                            └────────┬────────┘
+                                     ▼
+                           gh issue create
+                           (argv-list, NO --repo)
+```
+
+## Trust boundaries
+
+- `~/.cache/sldo/declarations/<sha>/` — local cache; SHA-pinned per declaration source. Compromise of the local user account compromises both the cache and the target repo.
+- `gh` CLI auth — user-controlled GitHub auth; same trust posture as `/slo-ship`.
+- Upstream intake repo — public (when published); recipients of capability-gap records are the intake repo's maintainers.
+- Target repo's `ARCHITECTURE.md` / `stack-decision.md` content — author-controlled; not user-input. Low injection risk; argv-list discipline is the standard defense.
+
+## Interfaces locked
+
+| Interface | Stability | Notes |
+|---|---|---|
+| CycloneDX 1.6 `declarations` schema URL + pinned SHA | `stable` per runbook | Bumping is `/slo-architect` re-pass discipline |
+| Capability-gap record schema (regex-validated fields) | `stable` | Cross-org consumers (Hulumi, SunLitSecureLibraries) parse this |
+| `cdx:sunlit:crypto:*` namespace | `evolving` | Migrates to upstream Property Taxonomy post-MVP |
+| `--file-upstream` flag semantics | `stable` | Third-party filing requires this flag; no implicit upstream |
+| Per-session 40-issues/hr rate-limit cap | `stable` | Defensive; reuses pattern in [issue #16](https://github.com/kerberosmansour/SunLitOrchestrate/issues/16) (R1) |
+| `gh pr create` discipline (argv-list, no `--repo`, no merge flags) | `stable-interface` | Inherited from `/slo-sast` M5 |
+
+## TLA+ section
+
+Not required (`tla_required: false`). No concurrent actors. The skill is single-session, single-actor, sequential (read declarations → match → emit OR file). Rate-limit cap is per-session client-side, not a distributed state machine.
+
+## STRIDE sweep (per Step 3.5)
+
+| Component | Spoofing | Tampering | Repudiation | Info disclosure | DoS | EoP |
+|---|---|---|---|---|---|---|
+| CycloneDX declarations fetch | mitigated — pinned SHA per source; `git rev-parse HEAD` cache integrity check | mitigated — SHA verification rejects in-flight tampering | N/A | N/A — public capability content | mitigated — rate-limit cap on filing endpoint; declarations fetch is one-shot per session | N/A |
+| `read-declarations.py` (Python subprocess) | N/A | mitigated — strict jsonschema validate; reject malformed | N/A | N/A — output is capability catalog (no PII) | mitigated — bounded JSON file size (refuse > 10 MiB) | N/A |
+| Capability matching | N/A | N/A | N/A | N/A | N/A | N/A |
+| Capability-gap filing (gh issue create) | mitigated — uses user's `gh` auth; argv-list only | mitigated — issue body content from regex-validated record schema; no free-text from user-input | mitigated — every filing carries `gh` author + timestamp | residual — gap content goes to public intake repo (default) or third-party repo (gated); mitigated by user-confirmation gate | mitigated — 40 issues/hr cap | N/A |
+
+New abuse cases (extends `docs/design/slo-security-embedding-threat-model.md`):
+
+- `tm-slo-sec-libs-abuse-1: tampered declarations file inflates capability claims to bypass real review` — class eliminated by SHA pinning + `git rev-parse HEAD` cache integrity check.
+- `tm-slo-sec-libs-abuse-2: capability-gap record body splices attacker-supplied prose from target repo content` — class eliminated by regex-validated schema; only structured fields flow into issue body.
+- `tm-slo-sec-libs-abuse-3: cross-org filing storm via --file-upstream loop` — mitigated by client-side 40-issues/hr cap + user-confirmation gate per filing.
+- `tm-slo-sec-libs-abuse-4: confused-deputy via tampered .git/config redirecting gh` — mitigated by NO `--repo` flag (inherits SEC-8 from `/slo-sast` M5).
+- `tm-slo-sec-libs-abuse-5: malicious CycloneDX file triggers Python jsonschema infinite recursion (billion-laughs analog)` — mitigated by strict jsonschema validate (no entity expansion / anchor recursion); 10 MiB file size cap before parse.
+
+## Compatibility commitments
+
+- Phase 1 security-aware skills (`/slo-ideate`, `/slo-architect`, `/slo-plan`, `/slo-critique`, `/slo-verify`) unchanged; `/slo-sec-libs` is a new skill, additive.
+- Existing runbooks without `security_libs_required: true` see `/slo-sec-libs` exit cleanly with "no security-libs required for this runbook".
+- Runbooks with `security_libs_required: true` but no `ARCHITECTURE.md` see a clear error pointing at `/slo-architect`.
+- The `update-config` skill is the canonical mutation surface for any settings.json work (parallels R2's `/slo-freeze` hook).
+
+## Out-of-scope
+
+- Rust CycloneDX 1.6+ emitter work (Phase 1 research Q1 found `cyclonedx-bom 0.8.1` is 1.5 only; emitter work is a separate program).
+- Phase 2 `/slo-threat-model` (parked; `/slo-sec-libs` is reader-side only — no SecOpsTM dependency).
+- Phase 3 `/slo-security-test` (separate program; wraps the existing Pass 4 command catalog).
+- Vendor SaaS API fallbacks (Semgrep AppSec, Snyk, GitHub Advanced Security) — explicitly rejected per Phase 1 stack-decision.
+
+## Pre-requisites (one-time, before runbook M1)
+
+These are out-of-band of the runbook (per [issue #4](https://github.com/kerberosmansour/SunLitOrchestrate/issues/4)):
+
+- [ ] Create `kerberosmansour/slo-security-intake` repo (issue-tracker-only); populate `ISSUE_TEMPLATE/capability-gap-record.md` per the M3 schema.
+- [ ] Add CycloneDX 1.6 `declarations` JSON to [`kerberosmansour/hulumi`](https://github.com/kerberosmansour/hulumi) and [`SunLitSecureLibraries`](https://github.com/SunLitSecureLibraries/SunLitSecureLibraries). Each crate / component advertises the controls it implements; crypto-primitive parametric claims ride in `properties` under the vendored `cdx:sunlit:crypto:*` namespace.
+- [ ] Confirm `gh` CLI scopes (`repo` or `public_repo` for same-owner filing; `repo` for cross-repo fork+PR fallback) on contributor machines.
+
+The runbook's Background Context section flags these as required pre-flight before M1.
+
+## Research-validation discipline (load-bearing)
+
+Every claim in this runbook touching CycloneDX schema, GitHub API behavior, or Octokit rate-limit point cost must be source-verified against:
+
+| Claim category | Primary source | Acceptance |
+|---|---|---|
+| CycloneDX 1.6 schema | https://cyclonedx.org/docs/1.6/json/ + pinned schema file SHA | quote + URL + retrieval date |
+| GitHub API behavior (issue create / search / list) | https://docs.github.com/en/rest at API version pin | quote + version + retrieval date |
+| GitHub Actions / `pull_request_target` ban (inherited from `/slo-sast`) | GitHub Docs + Trail of Bits' `audit-action` rationale | quote + retrieval date |
+| Secondary rate-limit point costs | Public Octokit benchmarks + GitHub support commentary | quote + URL + retrieval date |
+| Argon2id parameters (in `cdx:sunlit:crypto:*` namespace) | OWASP Password Storage Cheat Sheet + RFC 9106 | quote + version + retrieval date |
+| jsonschema billion-laughs / entity expansion defenses | Python `jsonschema` library docs at pinned version | quote + version |
+
+**Bright-line**: unverifiable claims removed, not weakened. The bar is set in `references/templates/citation-discipline.md` (R2 M1) and applies to every milestone of this runbook that emits a regex-validated field or a schema constraint.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -82,6 +82,6 @@ If the install target is right but the host still does not show the skills, rest
 
 That means a path already exists there as a normal directory or file instead of an installer-managed symlink. `sldo-install` refuses to overwrite that silently. Move or remove the conflicting path first, then rerun the install.
 
-### `/slo-research` still talks about a Claude backend
+### `/slo-research` mentions `sldo-research`
 
-That is a real limitation today. The skill pack installs into both hosts, but the automated batch backend behind `/slo-research` is still Claude-specific until the next portability milestone lands.
+The interactive `/slo-research` path now works through the host's own research tools and writes the same three files under `docs/research/<slug>/`. `sldo-research` is still available, but only as an optional Claude batch backend for users who explicitly want that automation path.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,87 @@
+# Getting Started
+
+This guide is for someone opening SunLitOrchestrate for the first time and wanting one clear path from clone to first successful skill run.
+
+SunLitOrchestrate ships a **skill pack**: a folder of Markdown instruction files that you install into a coding agent. The coding agent is the **host**. Right now the supported hosts are Claude Code and GitHub Copilot.
+
+## Quick glossary
+
+- **Skill pack**: the collection of `SKILL.md` files in the `skills/` directory.
+- **Host**: the coding agent that reads those installed skill files, such as Claude Code or GitHub Copilot.
+- **Overlay doc**: the host-specific notes for one host. In this repo those are [CLAUDE.md](../CLAUDE.md) and [copilot-instructions.md](../copilot-instructions.md).
+- **Manifest**: the install record written by `sldo-install` so it knows which host owns which installed symlink.
+
+## Prerequisites
+
+You need these before the first run:
+
+- Git, so you can clone the repo.
+- A stable Rust toolchain, because `sldo-install` is a Rust binary you build locally.
+- One supported host: Claude Code or GitHub Copilot.
+- Semgrep only if you want to use the SAST rule-pack skills right away.
+
+## Install the skill pack
+
+Run these commands from the repo root:
+
+```bash
+git clone https://github.com/kerberosmansour/SunLitOrchestrate.git
+cd SunLitOrchestrate
+
+cargo build -p sldo-install --release
+```
+
+Install into Claude Code:
+
+```bash
+./target/release/sldo-install
+./target/release/sldo-install status
+```
+
+Install into GitHub Copilot:
+
+```bash
+./target/release/sldo-install --host github-copilot
+./target/release/sldo-install --host github-copilot status
+```
+
+What success looks like:
+
+- `sldo-install` prints the selected target root.
+- `status` prints the installed skills for the host you chose.
+- Global installs land in `~/.claude/skills/` or `~/.copilot/skills/`.
+- Local installs land in `./.claude/skills/` or `./.copilot/skills/` if you add `--local`.
+
+## Run your first skill
+
+1. Open the repo in your chosen host.
+2. Read the matching overlay doc: [CLAUDE.md](../CLAUDE.md) for Claude Code or [copilot-instructions.md](../copilot-instructions.md) for GitHub Copilot.
+3. Start with `/slo-ideate` if you have a new product or feature idea.
+4. Expect the first concrete output to be a file like `docs/idea/<slug>.md`.
+
+If you already have an idea doc, the usual next step is `/slo-research`, then `/slo-architect`, then `/slo-plan`.
+
+## Troubleshooting
+
+### `sldo-install` is not found
+
+Make sure you built it first with `cargo build -p sldo-install --release`, then run it from `./target/release/sldo-install`.
+
+### The skills do not appear in my host
+
+Run `status` for the same host you installed to:
+
+```bash
+./target/release/sldo-install status
+./target/release/sldo-install --host github-copilot status
+```
+
+If the install target is right but the host still does not show the skills, restart the session or the editor and check the host's installed-skills UI again.
+
+### Copilot install says there is a conflict in `~/.copilot/skills/`
+
+That means a path already exists there as a normal directory or file instead of an installer-managed symlink. `sldo-install` refuses to overwrite that silently. Move or remove the conflicting path first, then rerun the install.
+
+### `/slo-research` still talks about a Claude backend
+
+That is a real limitation today. The skill pack installs into both hosts, but the automated batch backend behind `/slo-research` is still Claude-specific until the next portability milestone lands.

--- a/docs/idea/business-skill-improvements.md
+++ b/docs/idea/business-skill-improvements.md
@@ -1,0 +1,62 @@
+---
+name: business-skill-improvements
+created: 2026-04-27
+status: ideation (preempted — derived from 2026-04-27 skill-pack review + issues #19, #20)
+tla_required: false
+---
+
+# Business skill improvements
+
+## The pain
+
+The 2026-04-27 skill-pack review identified the **single largest hallucination surface in the entire pack**: the four advisor skills (`/slo-legal`, `/slo-accounting`, `/slo-equity`, `/slo-fundraise`) plus `/slo-hire` rely on the LLM evaluating critical safety predicates from natural-language founder prose with no structured intake. [`references/biz/triage-gate.md:16`](../../references/biz/triage-gate.md) explicitly acknowledges this: *"Predicate evaluation is the LLM's responsibility — these are natural-language tests..."*
+
+Concrete failure mode: a founder says "the contract is around eight grand" and the model evaluates `gate-2-deal-value-over-5k` against an unstated assumption (monthly? annual? ex-VAT? VAT-inclusive? for what term?). The four hard-block gates apply correctly to the *wrong* facts. Drafts land that should have routed to triage. The founder, who is a UK seed-stage technical founder with no prior legal exposure, never sees the gap.
+
+A second class of failure across the seven biz generators (`/slo-metrics`, `/slo-pricing`, `/slo-sales-funnel`, `/slo-product`, `/slo-launch`, `/slo-marketing`, `/slo-talk-to-users`): they recite **dozens of numeric heuristics from training memory without source attribution**: CAC payback months, MoM growth %, burn multiples, conversion rates, fee figures, success thresholds, annual discount %. Founders quote these numbers to investors and board members; sourceless KPI claims that turn out wrong are a credibility risk and the artifact cannot be defended in a board pack.
+
+The project owner's framing: the chatbot's strength is conversation. Intake must be **conversational, not form-filling** — modeled on [`/slo-ideate`'s seven forcing questions discipline](../../skills/slo-ideate/SKILL.md). The structured `intake_summary:` block is the **output of the conversation**, not a UI for the founder.
+
+## Five capabilities the user described without realizing
+
+- Five **conversational intake contracts** (`legal-intake-contract.md`, `accounting-intake-contract.md`, `equity-intake-contract.md`, `fundraise-intake-contract.md`, `hire-intake-contract.md`) — each defines the structured-data destination shape that the skill MUST gather conversationally before entering `draft` mode.
+- A `references/biz/uk-regulator-enumeration.md` closed enum (29+ UK regulators with `id`, `display_name`, `domain`, `statutory_basis`, `default_route_to`, `cited_by`) — `gate-1-regulated` evaluation consults this file rather than enumerating from training memory.
+- UK statute / HMRC manual / ICO authority files extended (`uk-employment-statute-anchors.md`, `uk-consumer-statute-anchors.md`, `uk-marketing-statute-anchors.md`, plus verbatim-quote refresh of `hmrc-vcm-index.md`) — every advisor SKILL.md cites file:section, never paraphrases.
+- Numeric verification for SAFE worksheets, cap-table snapshots, pricing math — emitted as runnable scripts or re-derived by an explicit verification pass before write.
+- KPI baseline authority files (`saas-kpi-targets-baseline.md`, `outbound-conversion-baselines.md`, `product-prioritization-frameworks.md`, `value-equation-pricing.md`, `mom-test-canonical-questions.md`, `launch-success-thresholds.md`) — every numeric heuristic in a generator-skill artifact carries `baseline_ref:` provenance.
+
+## Top risks
+
+- **Breach**: low — confidential founder data already lives at `docs/biz/` (gitignored) with the existing PII-pattern scan and write-time warning. This work doesn't expand the PII surface; it deepens the discipline.
+- **Compliance fine**: medium — every advisor skill's output is a first-cut artifact the founder takes to a solicitor. A wrong gate evaluation that lets a draft slip through when triage was correct = founder might miss solicitor-required matter. Mitigation: refusal-on-ambiguity rule (the third state added to gate evaluation) catches "I don't know" answers that today fall through to draft.
+- **Prolonged outage**: low — these are documentation + reference-file changes plus SKILL.md prose updates. No runtime dependency that can fail at scale.
+
+## Approach A — conservative (recommended)
+
+- **Effort**: 14 person-days (statute authority files require source-verification against `legislation.gov.uk` and HMRC Manuals; conversational intake contracts and KPI baselines compose from R2's templates).
+- **Wedge**: M1 = UK regulator enumeration + statute anchor files. Once these exist, the advisor SKILL.md updates are mechanical (replace paraphrased prose with `references/biz/<file>.md@<retrieval-date>` citations). The conversational intake contracts compose from R2's `references/templates/intake-checklist.md`.
+- **Risks**: source-verifying every statute citation against `legislation.gov.uk` is high-bandwidth. Rule: unverifiable claims removed, not weakened.
+
+## Approach B — cloud / SaaS
+
+Not applicable.
+
+## Approach C — local / desktop
+
+Not applicable.
+
+## Recommendation
+
+Approach A. 5 milestones. The first lands the authority files (regulator enum + statute anchors); the second lands the five conversational intake contracts and the SKILL.md updates that consume them; the third lands numeric verification (SAFE / cap-table / pricing); the fourth lands the KPI baseline files for the seven generator skills; the fifth lands cross-cutting polish (frontmatter `baseline_ref:` field added to artifact-schema, structural-contract tests for cross-skill citations, refresh-cadence warnings).
+
+This runbook **depends on R2's `references/templates/intake-checklist.md` landing first**. R2 → R3 ordering is the cleanest sequence; if R3 starts before R2's M1, M2 of R3 has to inline-author the conversational discipline pattern that R2 will later generalize.
+
+## Open questions for /slo-research
+
+(Most resolved by reading the existing skill-pack review + issues #19/#20; flagged for completeness.)
+
+1. Verbatim text of HMRC VCM34080, VCM3000, VCM31000, and Abingdon Health Limited v HMRC line — currently paraphrased in [`references/biz/hmrc-vcm-index.md`](../../references/biz/hmrc-vcm-index.md). Source: `https://www.gov.uk/hmrc-internal-manuals/venture-capital-schemes-manual` — fetch and quote each paragraph at runbook-author time.
+2. DUAA 2025 Stage 3 commencement details and the £17.5M / 4% global turnover ceiling — currently cited at [`references/biz/ico-duaa-index.md`](../../references/biz/ico-duaa-index.md). Verify against `https://www.legislation.gov.uk/ukpga/2025/18` + the ICO's own DUAA summary page.
+3. JPP Law fixed-fee public pricing as of 2026-04 — currently captured at [`references/biz/cost-baseline-jpp-law-2026.md`](../../references/biz/cost-baseline-jpp-law-2026.md) with `retrieved: 2026-04-25`. Refresh-cadence: annual. The runbook should set up the `/loop @annually` agent that re-fetches and opens a refresh PR.
+4. KPI baseline source-verification pattern: per-row `last_checked:` date with public-source URL. Sources to verify before M4: Bessemer State of the Cloud (burn multiple), OpenView SaaS Benchmarks (CAC payback / NDR / gross margin), Sequoia + Andrew Chen retention curves, Bain (NPS), Bridge Group + RAIN Group (outbound funnel), Fitzpatrick *The Mom Test* 2013, Hormozi *$100M Offers* (value equation).
+5. UK regulator enumeration source-of-truth: every regulator row's `statutory_basis:` field cites a primary Act on `legislation.gov.uk`. Verify each row before M1.

--- a/docs/idea/engineering-skill-improvements.md
+++ b/docs/idea/engineering-skill-improvements.md
@@ -1,0 +1,60 @@
+---
+name: engineering-skill-improvements
+created: 2026-04-27
+status: ideation (preempted — derived from 2026-04-27 skill-pack review + issues #21, #22)
+tla_required: false
+---
+
+# Engineering skill improvements
+
+## The pain
+
+The 2026-04-27 skill-pack review identified two classes of structural issues across the engineering-side skills (`/slo-sast`, `/slo-tla`, `/slo-plan`, `/slo-execute`, `/slo-verify`, `/slo-critique`, `/slo-research`, `/slo-rulegen`, `/slo-ruleverify`, `/slo-second-opinion`, `get-api-docs`, `/slo-architect`, `/slo-retro`, `/slo-freeze`, `/slo-resume`):
+
+- **SKILL.md monolithic length under context pressure**: [`/slo-sast` is 296 lines covering M1-M5 in one file](../../skills/slo-sast/SKILL.md); [`/slo-tla` is 323 lines](../../skills/slo-tla/SKILL.md); [`/slo-plan` is 132 lines with a 15-step milestone authoring sub-procedure](../../skills/slo-plan/SKILL.md). Under context-window pressure (which Claude Code routinely hits mid-runbook), an agent reads less of a long SKILL.md and skips key gates. A future invocation of `/slo-sast` for an M3 emission still reads the M1 parser scaffolding + M2 stack detect + M4 manifest + M5 PR creation — all competing for attention.
+- **Cross-skill drift on common patterns**: every SKILL.md repeats its own version of intake, restate-and-confirm, citation discipline, tool-safety boilerplate, output frontmatter. There is no `references/templates/` shared library, so when one skill's pattern improves, the others don't inherit. Specific symptoms: `/slo-execute`'s allow-list rule is prose-level (LLM compliance), not filesystem-enforced; `/slo-freeze`'s scope lock is the same; `/slo-second-opinion` shows raw provider output without a "neither response is verified" header; `get-api-docs` has no `chub` failure-mode handling.
+
+The project owner explicitly flagged a third concern: **deep, source-verified citations for security-engineering content**. Any recommendation touching SAST / DAST / supply-chain / threat-model content must cite primary authoritative sources (tool docs at pinned version), not paraphrased commentary. This is the **research-validation prereq** that gates every security-touching milestone in this runbook.
+
+## Five capabilities the user described without realizing
+
+- A `references/templates/` shared library with the eight common patterns (intake-checklist, restate-and-confirm, citation-discipline, tool-safety-section, output-frontmatter, escalation, eval-cases, heuristic-numbers-discipline).
+- `/slo-sast` decomposed into a thin orchestrator + per-stage methodology references (`methodology-m1-parser.md` through `methodology-m5-pr-creation.md`); `/slo-tla` similarly split (`methodology-elicitation.md`, `methodology-abstraction.md`, `methodology-counterexample.md`, `methodology-verified-design.md`); `/slo-plan` per-milestone authoring extracted.
+- A per-skill `evals/` directory with seven canonical case shapes (happy / missing-context / ambiguous / adversarial / outdated / tool-failure / high-risk).
+- A `settings.json` PreToolUse hook that hard-enforces `/slo-freeze`'s scope lock and (optionally) `/slo-execute`'s milestone allow-list at the filesystem layer, with the existing prose-level pattern as documentation.
+- A research-validation discipline that, before any security-engineering claim lands, validates the citation against a strict source hierarchy (tool's own docs at pinned version → tool repo `README` / `CHANGELOG` at pinned commit → upstream advisory DB docs → conference talks / academic papers → vendor blog posts (secondary) → never Stack Overflow).
+
+## Top risks
+
+- **Breach**: low — decomposition is internal restructuring; no new attack surface. The PreToolUse hook for `/slo-freeze` introduces a settings.json mutation surface; risk is in the hook script itself (must use argv-list discipline if it shells out). Reuse the `update-config` skill for the mutation.
+- **Compliance fine**: not applicable — no personal data, no regulatory surface.
+- **Prolonged outage**: medium — if a SKILL.md decomposition breaks the install symlink chain in [`crates/sldo-install`](../../crates/sldo-install), the skill becomes unusable. Mitigation: structural-contract tests assert every SKILL.md still references its decomposed methodology files, and `cargo test --workspace` is the green-baseline gate.
+
+## Approach A — conservative (recommended)
+
+- **Effort**: 12 person-days (the per-skill `evals/` write-up is the long pole; decomposition is mechanical once the templates land).
+- **Wedge**: M1 = research-validation prereq + `references/templates/` library seeded. Once the templates exist, every downstream milestone is "extract content from SKILL.md, refactor into the template-shaped reference" — a clean, mechanical pattern.
+- **Risks**: `evals/` writing is high-bandwidth thinking work; resist the temptation to copy-paste eval cases between skills.
+
+## Approach B — cloud / SaaS
+
+Not applicable.
+
+## Approach C — local / desktop
+
+Not applicable.
+
+## Recommendation
+
+Approach A. 5 milestones, ordered so the foundational work (templates + research-validation discipline) lands first, decomposition lands second (sast + tla + plan), and the cross-skill polish + evals + hooks ship in M4-M5. Detailed milestone breakdown in [`docs/RUNBOOK-ENGINEERING-SKILL-IMPROVEMENTS.md`](../RUNBOOK-ENGINEERING-SKILL-IMPROVEMENTS.md).
+
+The research-validation discipline (M0-style prereq baked into M1) is **load-bearing** per project owner's explicit concern. Every claim that touches security-engineering content gets validated through the source hierarchy before SKILL.md edits land. Unverifiable claims are removed, not weakened.
+
+## Open questions for /slo-research
+
+(Most of these are resolved by reading the existing skill-pack review + issues #21/#22; flagged here for completeness so a future contributor can re-research if claims age.)
+
+1. Have the existing references/sast/ and references/sast/scanner-orch-* files been source-verified against the upstream Semgrep CLI docs at the pinned version? Spot-check needed before M2 ships.
+2. What is the canonical FNV-1a-64 invariant re-capture pattern? Issue #4's deferred-follow-ups list mentions automation; verify against the existing M4 lessons file before designing the soft line-cap structural-contract test.
+3. Is the current `~~~text` user-string fence rule in `/slo-architect` documented as a Markdown rendering convention, or as a defense-in-depth? Citation needed for shared template's `citation-discipline.md`.
+4. Apalache's pinned-SHA distribution channel — does it use the same SHA-256 manifest file pattern as `tla2tools.jar`, or release-asset checksums? Verify against [https://github.com/apalache-mc/apalache/releases/latest](https://github.com/apalache-mc/apalache/releases/latest) at runbook-author time.

--- a/docs/idea/loops-and-lessons-closure.md
+++ b/docs/idea/loops-and-lessons-closure.md
@@ -1,0 +1,54 @@
+---
+name: loops-and-lessons-closure
+created: 2026-04-27
+status: ideation (preempted — skill-pack improvement, not greenfield)
+tla_required: false
+---
+
+# Loops + lessons closure
+
+## The pain
+
+A developer (any future contributor or the project owner himself) lands on the SLO repo, sees ARCHITECTURE.md (static structure) and 32 SKILL.md files (individual moves), but cannot answer the question "**how does this skill pack improve itself?**" — because the cyclic feedback structures are implicit. Two concrete symptoms:
+
+- **Forward dropout in lessons**: Lessons land in `docs/lessons/<prefix>-m<N>.md` after every milestone, but the next milestone rarely re-reads the prior lessons. The same mistakes repeat. Last week, the project owner manually re-read the M3 lessons before kicking off M4 and caught a naming-convention drift the agent would have repeated. That manual step shouldn't be necessary.
+- **Lateral dropout in upstream signal**: When `/slo-execute` discovers a bug in an upstream tool (Semgrep, Playwright, `cargo audit`), the lesson sits in markdown. It never gets filed upstream. A library-feedback loop that *would* improve the tool dies in a local file.
+
+## Five capabilities the user described without realizing
+
+- A first-class document per loop (engineering / business) that newcomers and a freshly-loaded Claude can read in 90 seconds.
+- A `/slo-retro` extension that, after writing the lessons file, classifies each lesson (product / upstream-OSS / SLO-process) and files an issue in the appropriate destination repo with confirmation.
+- A `/slo-execute` pre-flight step that surfaces open prior-retro issues as scope candidates for the current milestone.
+- A v3 runbook template addition: a "Carry-forward from prior retros" section, so the loop is visible in the runbook artifact, not just in the skill flow.
+- A `LESSONS-BACKLOG.md` fallback for repos without a configured issue tracker — the loop must work locally too.
+
+## Top risks
+
+- **Breach**: low — this work doesn't introduce any new attack surface beyond filing issues to GitHub via `gh`. Risk: an upstream `gh search` query that exposes the founder's PII via a tampered git config. Surface: confused-deputy via `.git/config` — already covered by [`SECURITY.md`](../../SECURITY.md) "argv-list discipline" and [issue #4's `--repo` ban](https://github.com/kerberosmansour/SunLitOrchestrate/issues/4).
+- **Compliance fine**: not applicable — no personal data flows through this work; lesson content is engineering reflection, not founder PII.
+- **Prolonged outage**: low — `/slo-retro` has no runtime dependency on issue filing; if `gh` is unavailable, the skill falls back to `LESSONS-BACKLOG.md` and the loop closes locally. The retro skill itself never fails because of issue-filing trouble.
+
+## Approach A — conservative
+
+- **Effort**: 3 person-days (mostly markdown).
+- **Wedge**: M1 = `LOOPS-ENGINEERING.md`. Author the doc, cross-link from `ARCHITECTURE.md` and the implicated SKILL.md files. The loops doc is itself the artifact people read; everything downstream depends on it being readable.
+- **Risks**: documentation-only milestone might feel like cosmetic; resist the temptation to over-elaborate.
+
+## Approach B — cloud / SaaS
+
+Not applicable — this is documentation + skill extension; no SaaS/cloud component.
+
+## Approach C — local / desktop
+
+Not applicable — no UI.
+
+## Recommendation
+
+Approach A. The runbook is small (4 milestones), mostly markdown, and serves as the **vehicle for the lessons-closure mechanic** that R2 and R3 will rely on. Ship this first. M1 LOOPS-ENGINEERING.md, M2 LOOPS-BUSINESS.md, M3 `/slo-retro` extension to file issues, M4 `/slo-execute` pre-flight loop closure + runbook template update.
+
+## Open questions for /slo-research
+
+1. Marker for retro-originated issues — title prefix vs label vs body sentinel? Check `gh search` reliability against each option.
+2. Fallback file format — single `LESSONS-BACKLOG.md` table, or one file per lesson? Lean: single file with append-only rows.
+3. Should the runbook template's "Carry-forward from prior retros" section be required or optional? Lean: optional, with prose guidance; required-fields drive false-positive `N/A` rows.
+4. Mapping upstream tools to their issue-tracker repo: parse `Cargo.toml` / `package.json` and resolve via crates.io / npm registry, or require explicit per-repo mapping? Lean: explicit mapping in `.sldo/upstream-mapping.toml` with crates.io fallback.

--- a/docs/idea/slo-sec-libs.md
+++ b/docs/idea/slo-sec-libs.md
@@ -1,0 +1,69 @@
+---
+name: slo-sec-libs
+created: 2026-04-27
+status: ideation (preempted — issue #4 already contains the bulk of the framing; this idea doc compresses it)
+tla_required: false
+---
+
+# /slo-sec-libs — stack-aware library recommender + upstream feedback loop
+
+## The pain
+
+[Phase 1 of the security-embedding program (`slo-security-embedding`)](https://github.com/kerberosmansour/SunLitOrchestrate/pull/3) made `/slo-ideate`, `/slo-architect`, `/slo-plan`, `/slo-critique`, and `/slo-verify` security-aware: every milestone's Contract Block now declares Data classification + Proactive controls + Abuse acceptance scenarios. The threat model and SECURITY.md are dogfooded.
+
+The gap: when a milestone declares "this surface needs an Argon2id password hasher", the agent has no source-of-truth for *which* library covers that requirement at the runbook's pinned version. It defaults to whatever lib the model recalls — exactly the failure mode `/slo-research` exists to prevent.
+
+Hulumi (Pulumi components for AWS) and SunLitSecureLibraries (Rust security crates) are designed to advertise their capabilities via CycloneDX 1.6+ `declarations` — but no skill reads those declarations. So the libraries' designed-in advertisability is dead weight.
+
+Concrete failure: a runbook with `security_libs_required: true` and a "secure JSON deserialization" requirement gets a paraphrased `serde_json` recommendation when SunLitSecureLibraries' `secure_boundary::SecureJson` (which advertises `C5` proactive control with parametric configuration) would be the right call.
+
+A secondary failure: when the recommender finds **no** library that covers a requirement, today the gap dies as a comment in a lessons file. A capability-gap issue should be filed against the library owner's intake repo so the gap is tracked as work, not lost as text.
+
+## Five capabilities the user described without realizing
+
+- A `/slo-sec-libs` skill that reads `ARCHITECTURE.md` + `stack-decision.md` + the runbook's per-milestone proactive-control requirements.
+- A CycloneDX 1.6+ `declarations` reader (Python jsonschema subprocess path, since Rust ecosystem has no 1.6+ declarations support per the Phase 1 research synthesis Q1 findings).
+- A capability-matcher that returns either (a) a specific library component covering the requirement, or (b) "no match" with a structured capability-gap record.
+- An SLO-owned intake repo (`kerberosmansour/slo-security-intake`) as the default capability-gap filing destination.
+- A gated upstream-filing path: `--file-upstream` flag + client-side cap of 40 issues/hr per session (defensive against GitHub's undocumented per-endpoint secondary-rate-limit point cost — see [issue #4](https://github.com/kerberosmansour/SunLitOrchestrate/issues/4) for the research-Q5 anchor).
+
+## Top risks
+
+- **Breach**: medium-low — the upstream filing path exfiltrates capability-gap content to a remote (GitHub). Surface: `gh pr create` argv-list discipline (already standard); confused-deputy via tampered `.git/config` mitigated by no `--repo` flag (per issue #4 SEC-8). Rate-limit cap protects against runaway filing storms.
+- **Compliance fine**: not applicable — no personal data flows; capability-gap records describe library capability deltas, not user content.
+- **Prolonged outage**: low — `/slo-sec-libs` failures degrade gracefully: if the declarations file is missing, the recommender returns "no match"; if `gh` is unavailable, the file falls back to local `LESSONS-BACKLOG.md` (matches R1's lessons-fallback pattern).
+
+## Approach A — conservative (recommended)
+
+- **Effort**: 8 person-days (the declarations reader is well-defined per Phase 1 synthesis; the matcher is the bulk; the filer reuses #4's argv-list discipline).
+- **Wedge**: M1 = declarations reader (Python jsonschema subprocess), produces a structured catalog of advertised capabilities. Second wedge M2 = matcher (compares runbook proactive-control requirements against the catalog). Both M1 and M2 are pure-read operations — no GitHub side effects.
+- **Risks**: SecOpsTM install footprint for the (parked) `/slo-threat-model` skill is too heavy; that's why `/slo-sec-libs` is reader-side only — no Rust CycloneDX emitter work in this phase, no SecOpsTM dependency.
+
+## Approach B — cloud / SaaS
+
+Not applicable for v1; potential future SaaS distribution of declarations index is out of scope.
+
+## Approach C — local / desktop
+
+Not applicable.
+
+## Recommendation
+
+Approach A. 5 milestones. M1 declarations reader; M2 capability matcher; M3 SLO-intake filer (default); M4 third-party filing gate + rate limit; M5 dogfood against this SLO repo (re-critique an existing milestone using `/slo-sec-libs` to recommend libraries for its proactive-controls row). Detailed milestone breakdown in [`docs/RUNBOOK-SLO-SEC-LIBS.md`](../RUNBOOK-SLO-SEC-LIBS.md).
+
+The runbook depends on three one-time pre-requisites (per [issue #4](https://github.com/kerberosmansour/SunLitOrchestrate/issues/4)):
+
+1. Create `kerberosmansour/slo-security-intake` repo with `ISSUE_TEMPLATE` populated.
+2. Add CycloneDX 1.6 `declarations` JSON to `kerberosmansour/hulumi` and `SunLitSecureLibraries`.
+3. Confirm `gh` CLI scopes (`repo` or `public_repo`) on contributor machines.
+
+These prereqs are out-of-band of this runbook — flagged in the runbook's Background Context section so the author can confirm them before M1.
+
+## Open questions for /slo-research
+
+(Most resolved by [`docs/research/slo-security-embedding/`](../research/slo-security-embedding/) Phase 1 synthesis; flagged for completeness.)
+
+1. CycloneDX 1.6 `declarations` schema — current spec at https://cyclonedx.org/docs/1.6/json/. Verify against the pinned schema URL at runbook-author time and capture the SHA.
+2. CycloneDX Property Taxonomy contribution path — the project's vendored `cdx:sunlit:crypto:*` namespace per Phase 1 synthesis. Open-source contribution channel: https://github.com/CycloneDX/cyclonedx-property-taxonomy. Verify upstream maintainership cadence.
+3. GitHub secondary-rate-limit point costs per endpoint — undocumented; the 40 issues/hr defensive cap derives from public Octokit benchmarks. Cite the specific public commentary at runbook-author time.
+4. `gh search issues` reliability for de-dupe (matches R1's same question) — does title-prefix matching, label matching, or body-sentinel matching produce the lowest false-positive rate? Spot-check before M3.

--- a/docs/lessons/agent-host-m1.md
+++ b/docs/lessons/agent-host-m1.md
@@ -1,0 +1,41 @@
+# Lessons Learned — agent-host Milestone 1
+
+## What changed
+- Added a host descriptor table so `sldo-install` can target both `claude-code` and `github-copilot`.
+- Upgraded the global manifest to schema v2 with per-entry host ownership and backward-compatible loading of v1 manifests.
+- Added host-specific integration coverage for Copilot global/local installs, host-aware status/verify output, legacy manifests, and hostile manifest targets.
+- Updated installer-facing docs and `.gitignore` for the new `./.copilot/` local state.
+
+## Design decisions and why
+- Kept one shared global manifest at `~/.sldo/install.toml` and added a `host` field per entry instead of splitting global manifests. This preserved the existing path while making uninstall/status/verify host-specific.
+- Kept local manifests under the selected host directory (`./.claude/` or `./.copilot/`) so repo-local state stays isolated by host.
+- Rejected manifest entries whose targets fall outside the selected host root before verify/uninstall touches the filesystem. That closes the destructive-manifest gap without introducing a larger abstraction.
+
+## Mistakes made
+- The first broad dry-run smoke used the real `HOME`, which collided with an existing non-symlink Copilot skill directory.
+
+## Root causes
+- Installer smoke checks that validate path selection should not assume the developer's real host state is clean.
+
+## What was harder than expected
+- The real bug was not just path selection. The shared manifest also needed host-scoped ownership semantics so the same skill name could be installed for two hosts safely.
+
+## Naming conventions established
+- Host ids are `claude-code` and `github-copilot`.
+- New milestone-specific installer coverage lives in `crates/sldo-install/tests/e2e_agent_host_m1.rs`.
+
+## Test patterns that worked well
+- Execute the compiled binary against a temporary `HOME` and mutate the on-disk manifest to simulate legacy or hostile states.
+- Validate safety behavior with `verify` when possible so tests prove rejection without removing anything.
+
+## Missing tests that should exist now
+- A follow-up test for `status` and `verify` on local Copilot manifests would tighten the local-path story further.
+
+## Rules for the next milestone
+- Keep host capability claims scoped to what the code really supports today.
+- Use a temporary `HOME` for installer smoke checks unless the goal is specifically to inspect conflict handling against real user state.
+- When a shared file or manifest is reused across hosts, make ownership explicit in the data model before widening docs.
+
+## Template improvements suggested
+- Milestone 1's allow-list should explicitly mention `docs/ARCHITECTURE.md`, because its post-flight section requires an architecture note.
+- Milestone smoke tests that inspect install roots should call out temporary `HOME` usage so conflict-guard behavior is not mistaken for a regression.

--- a/docs/lessons/agent-host-m2.md
+++ b/docs/lessons/agent-host-m2.md
@@ -1,0 +1,44 @@
+# Lessons Learned — agent-host Milestone 2
+
+## What changed
+- Split the living docs into clear roles: `README.md` for orientation, `docs/getting-started.md` for the first-run path, `docs/skill-pack-catalog.md` for the canonical host-neutral catalog, and `CLAUDE.md` plus `copilot-instructions.md` as host overlays.
+- Added `docs/design/agent-host-capabilities.md` so host support claims have one explicit place to live.
+- Replaced the stale `docs/ARCHITECTURE.md` with a reality-first summary of the current workspace and host boundaries.
+- Added structural test coverage in `crates/sldo-install/tests/e2e_agent_host_m2.rs` to keep the catalog/overlay split and first-run guide from drifting again.
+
+## Design decisions and why
+- Kept `CLAUDE.md` as a rich overlay instead of deleting or shrinking it aggressively. Existing sessions and tests already rely on it, so the safer move was to demote it from canonical truth to host-specific overlay while preserving the catalog content Claude users expect.
+- Introduced a dedicated capability matrix instead of sprinkling host limitations across several docs. Unsupported runtime surfaces are easiest to keep truthful when there is one document responsible for them.
+- Rewrote `docs/ARCHITECTURE.md` instead of layering disclaimers on top of stale sections. The old document had drifted too far from the actual workspace members.
+
+## Mistakes made
+- The first Milestone 2 test only proved the missing-file blockers, not the full scope of stale assumptions in the existing living docs.
+
+## Root causes
+- The repo had allowed `README.md`, `CLAUDE.md`, the catalog, and the architecture doc to overlap in responsibility for too long, so each one accumulated a different slice of history.
+
+## What was harder than expected
+- `docs/ARCHITECTURE.md` was stale in a deeper way than the first failing test showed. Once the missing files were added, the real work was re-establishing one reality-first architecture story without touching historical runbooks and completion docs.
+
+## Naming conventions established
+- `docs/skill-pack-catalog.md` is the canonical living catalog.
+- `CLAUDE.md` and `copilot-instructions.md` are host overlays.
+- `docs/design/agent-host-capabilities.md` is the single capability matrix for host support claims.
+- Milestone-specific living-doc coverage lives in `crates/sldo-install/tests/e2e_agent_host_m2.rs`.
+
+## Test patterns that worked well
+- Structural Markdown tests were enough to lock the role split: canonical catalog, overlays, capability matrix, and getting-started guide.
+- A missing-file failure is a good first guardrail for doc milestones because it forces the concrete deliverables into existence before style or wording debates start.
+
+## Missing tests that should exist now
+- Add a regression check that the baseline test command shown in the living docs stays aligned with the actual supported in-scope command.
+- Add a stronger guard that `README.md` and `docs/ARCHITECTURE.md` do not reintroduce removed crates as active current interfaces.
+
+## Rules for the next milestone
+- Keep host claims bounded to validated runtime behavior, not to what the installed `SKILL.md` files make tempting to assume.
+- When a doc split creates a canonical file plus overlays, add tests for both the split itself and the cross-links.
+- If a living doc is stale at the model level, replace it cleanly instead of stacking caveats on top of it.
+
+## Template improvements suggested
+- The runbook allow-list should name newly created docs explicitly, not just the pre-existing files that will be updated.
+- For doc-heavy milestones, the evidence template should reserve one row for the first failing structural test and one row for the final role split, because those are distinct checkpoints.

--- a/docs/research/business-skill-improvements/synthesis.md
+++ b/docs/research/business-skill-improvements/synthesis.md
@@ -1,0 +1,86 @@
+---
+name: business-skill-improvements
+researched: 2026-04-27
+incomplete: false
+note: |
+  Skill-pack improvement runbook — primary research input is the 2026-04-27 skill-pack
+  review + issues #19 and #20 + the existing biz-pack reference files (triage-gate,
+  artifact-schema, hmrc-vcm-index, ico-duaa-index, ir35-cest-factors, jurisdiction-uk,
+  cost-baseline-jpp-law-2026). This file is the synthesis.
+---
+
+# Synthesis — business skill improvements
+
+## What the design must handle (and why)
+
+### 1. Predicate evaluation is the LLM's responsibility — and that is the failure surface
+
+The design must handle this because [`references/biz/triage-gate.md:16`](../../../references/biz/triage-gate.md) explicitly says: *"Predicate evaluation is the LLM's responsibility — these are natural-language tests..."* The five-skill cluster (legal/accounting/equity/fundraise/hire) all rely on this pattern. Closing the surface = (a) structured intake before the LLM evaluates, and (b) refusal-on-ambiguity as the third state of gate evaluation.
+
+### 2. Conversational discipline is the UX, not a form
+
+The design must handle conversational elicitation because the project owner's explicit framing: *"this is a chatbot. So it isn't gonna process, like, hiring people. But giving someone advice."* The structured `intake_summary:` block is the **output of the conversation**, not a UI for the founder. Pattern source: [`/slo-ideate`'s seven forcing questions](../../../skills/slo-ideate/SKILL.md) — *"Ask one at a time. Do not accept hypotheticals. Push back on vague answers."* Same shape, different domain.
+
+### 3. UK statute citations must come from `legislation.gov.uk` at retrieval-stamped dates
+
+The design must handle this because the project owner's research-validation discipline applies: *"the references of the technical knowledge is valid and the correct one. Especially on security engineering recommendations."* For UK statute, the analogous primary source is `legislation.gov.uk` (the official statute repository) — not paraphrased commentary. `legislation.gov.uk` has stable section URLs (e.g., https://www.legislation.gov.uk/ukpga/1996/18/section/86 for ERA 1996 s86) that can be cited verbatim.
+
+### 4. HMRC manual content must be quoted, not paraphrased
+
+The design must handle this because [`references/biz/hmrc-vcm-index.md`](../../../references/biz/hmrc-vcm-index.md) currently paraphrases VCM34080, VCM3000, VCM31000, and the Abingdon Health Limited v HMRC line. The HMRC Venture Capital Schemes Manual is a public document at `https://www.gov.uk/hmrc-internal-manuals/venture-capital-schemes-manual` — verbatim quotes with paragraph IDs are the correct citation form. Paraphrasing is the failure mode this runbook closes.
+
+### 5. Closed-enum regulator list must replace open-ended LLM enumeration
+
+The design must handle this because `gate-1-regulated` currently enumerates from training memory ("FCA, MHRA, ICO, healthcare, financial services, or any other regulator with statutory enforcement powers"). The new [`references/biz/uk-regulator-enumeration.md`](../../../references/biz/uk-regulator-enumeration.md) is a closed enum — naming a regulator NOT in the enum is a refusal pattern (either probe further or flag the enum gap as a follow-up). 29-regulator starter list seeded; runbook M1 source-verifies every row's `statutory_basis:` against `legislation.gov.uk`.
+
+### 6. Numeric arithmetic in advisor outputs must be re-derived before write
+
+The design must handle this because [`/slo-fundraise`'s SAFE worksheet and `/slo-equity`'s cap-table snapshot](../../../skills/slo-fundraise/SKILL.md) currently rely on LLM-computed cells. The fix: emit math as a runnable Python snippet OR a verification pass that re-derives every cell. A 5-percentage-point dilution-table error that goes to investors is the failure mode this milestone closes.
+
+### 7. Heuristic numbers need source attribution AND refresh cadence
+
+The design must handle both for the seven biz generator skills (`/slo-metrics`, `/slo-pricing`, `/slo-sales-funnel`, `/slo-product`, `/slo-launch`, `/slo-marketing`, `/slo-talk-to-users`). Sources verified at the file-creation date; per-row `last_checked:` field; SKILL.md emits a stale-baseline warning at +12 months (matches the existing cost-baseline staleness pattern in [`/slo-legal`](../../../skills/slo-legal/SKILL.md)).
+
+### 8. `baseline_ref:` field must be added to the artifact schema
+
+The design must handle this because every artifact emitted by a generator skill that consults a baseline file MUST carry the `baseline_ref:` provenance pointer (matches the existing `cost_baseline_ref:` pattern in advisor outputs). Adding to [`references/biz/artifact-schema.md`](../../../references/biz/artifact-schema.md) is M5 of this runbook.
+
+### 9. Sister intake contracts must share F1 / F4 / F5 fields verbatim
+
+The design must handle this because cross-skill drift on jurisdiction, GDPR scope, and regulator scope evaluation would defeat the consistency the four-gate predicates rely on. The legal-intake-contract.md is the canonical shape; accounting / equity / fundraise / hire extend it without redefining F1 / F4 / F5.
+
+### 10. R3 depends on R2's `references/templates/intake-checklist.md` landing first
+
+The design must handle the dependency by ordering R2 → R3. If R3 starts before R2's M1, R3's M2 (intake contracts) has to inline-author the conversational discipline pattern that R2 will later generalize. Avoidable rework.
+
+## Open questions that research did not answer
+
+1. **Verbatim text of HMRC VCM paragraphs** — must be fetched from `https://www.gov.uk/hmrc-internal-manuals/venture-capital-schemes-manual` at runbook-author time. Each quoted paragraph carries `last_checked:` date.
+2. **DUAA 2025 Stage 3 commencement details** — official: `https://www.legislation.gov.uk/ukpga/2025/18`; ICO summary: `https://ico.org.uk/about-the-ico/what-we-do/legislation-we-cover/data-use-and-access-act-2025/`. Refresh both at M1 of this runbook.
+3. **Public KPI sources to source-verify before M4**:
+   - Bessemer State of the Cloud (https://www.bvp.com/atlas) — burn multiple framework
+   - OpenView SaaS Benchmarks (https://openviewpartners.com/saas-benchmarks/) — CAC payback / NDR / gross margin
+   - Sequoia Retention by the Numbers (https://articles.sequoiacap.com/retention) + Andrew Chen retention curves (https://andrewchen.com/retention-is-king/)
+   - Bain NPS framework (https://www.netpromotersystem.com/about/)
+   - Bridge Group SaaS Sales Development Report (https://blog.bridgegroupinc.com/sdr-metrics-and-compensation-report)
+   - RAIN Group sales conversion benchmarks (https://www.rainsalestraining.com/blog/sales-statistics)
+   - Paul Graham *Startup = Growth* (https://paulgraham.com/growth.html)
+   - Fitzpatrick *The Mom Test* (2013, ISBN 978-1492180746) — quote-permitted snippets only
+4. **JPP Law fixed-fee public pricing as of 2026-04** — already captured at [`references/biz/cost-baseline-jpp-law-2026.md`](../../../references/biz/cost-baseline-jpp-law-2026.md) with `retrieved: 2026-04-25`. M5 of this runbook sets up the `/loop @annually` agent that re-fetches public sources and opens a refresh PR.
+5. **AA lead-time "4-6 weeks realistic" claim in `/slo-fundraise`** — verify against HMRC VCM index public commentary at runbook-author time. Currently recited; needs source attribution.
+
+## Source pointers
+
+- 2026-04-27 skill-pack review (in-conversation artifact)
+- [Issue #19](https://github.com/kerberosmansour/SunLitOrchestrate/issues/19) — advisor predicate hardening + conversational intake discipline
+- [Issue #20](https://github.com/kerberosmansour/SunLitOrchestrate/issues/20) — KPI baseline + heuristic-number authority files
+- [`references/biz/triage-gate.md`](../../../references/biz/triage-gate.md) — the four hard-block predicates
+- [`references/biz/artifact-schema.md`](../../../references/biz/artifact-schema.md) — frontmatter contract
+- [`references/biz/jurisdiction-uk.md`](../../../references/biz/jurisdiction-uk.md), [`references/biz/uk-regulator-enumeration.md`](../../../references/biz/uk-regulator-enumeration.md) (starter)
+- [`references/biz/legal-intake-form.md`](../../../references/biz/legal-intake-form.md) (starter; rename to `legal-intake-contract.md` in M2)
+- [`references/biz/saas-kpi-targets-baseline.md`](../../../references/biz/saas-kpi-targets-baseline.md) (starter)
+- [`references/biz/hmrc-vcm-index.md`](../../../references/biz/hmrc-vcm-index.md), [`references/biz/ico-duaa-index.md`](../../../references/biz/ico-duaa-index.md), [`references/biz/cost-baseline-jpp-law-2026.md`](../../../references/biz/cost-baseline-jpp-law-2026.md), [`references/biz/ir35-cest-factors.md`](../../../references/biz/ir35-cest-factors.md)
+
+## Note on chub / get-api-docs
+
+Not applicable for this runbook — biz pack is `WebFetch`/`WebSearch` denied per [`SECURITY.md`](../../../SECURITY.md) and per the threat-model row `tm-biz-abuse-1`. External regulatory anchors (legislation.gov.uk, ICO, HMRC, JPP Law) are emitted as **citations** the founder follows manually, never fetched at runtime. Source-verification by the runbook author happens at runbook-author time only — captured as `last_checked:` dates in the reference files.

--- a/docs/research/engineering-skill-improvements/synthesis.md
+++ b/docs/research/engineering-skill-improvements/synthesis.md
@@ -1,0 +1,76 @@
+---
+name: engineering-skill-improvements
+researched: 2026-04-27
+incomplete: false
+note: |
+  Skill-pack improvement runbook — primary research input is the 2026-04-27 skill-pack
+  review (in-conversation artifact, summarized below) + issues #21 and #22 + the
+  project owner's explicit research-validation discipline for security-engineering
+  citations. This file is the synthesis; the equivalent dossier content is the review
+  + issues + the existing references/sast/ and references/ trees.
+---
+
+# Synthesis — engineering skill improvements
+
+## What the design must handle (and why)
+
+### 1. Decomposition must preserve install-symlink semantics
+
+The design must handle install-symlink continuity because [`crates/sldo-install/src/install.rs`](../../../crates/sldo-install/src/install.rs)'s `discover_skills()` walks `skills/<name>/SKILL.md` and creates a symlink chain at `~/.claude/skills/<name>/`. If a SKILL.md decomposition moves content to `skills/slo-sast/references/methodology-m1-parser.md`, the install must still surface it. The existing pattern in `skills/slo-critique/personas/` (7 files inside the skill dir) and `skills/slo-tla/tools.toml` shows the per-skill `references/` subdir is the correct location — sibling to SKILL.md, included by the install.
+
+### 2. `references/templates/` library belongs at the repo root, not under `skills/`
+
+The design must handle templates being at repo root because [`crates/sldo-install/src/install.rs:44-71`](../../../crates/sldo-install/src/install.rs#L44)'s `discover_skills()` ignores `references/` at the repo root (this is documented behavior — see the existing `references/biz/` pattern in CLAUDE.md). Putting templates under `skills/` would either (a) accidentally install them as a fake skill, or (b) require special-casing in the installer. Repo-root `references/templates/` matches the existing `references/biz/` and `references/sast/` pattern.
+
+### 3. The research-validation prereq is a milestone, not a checklist item
+
+The design must handle this because the project owner's stated concern (security-engineering citations must be source-verified) applies to multiple downstream milestones in this runbook — sast/tla/plan decomposition all carry security-engineering content. The prereq is not "remember to source-verify"; it is a discrete M1-or-M0 milestone that produces `references/templates/citation-discipline.md` AND validates every existing security-engineering claim in the SKILL.md files about to be decomposed.
+
+### 4. Source hierarchy is non-negotiable
+
+The design must handle the source hierarchy explicitly:
+
+1. Tool's own documentation at the pinned version (e.g., `cargo audit --help` on the documented version)
+2. Tool repo's `README` / `CHANGELOG` at the pinned commit
+3. Upstream advisory database documentation (RustSec, OSV, NVD, GHSA — each has its own structure)
+4. Conference talks / academic papers when foundational (named author + year)
+5. Vendor blog posts — flag as secondary
+6. Stack Overflow / random commentary — never authoritative
+
+Bright-line rule: **unverifiable claims are removed, not weakened**. "Approximate, please verify" is exactly the failure mode the runbook closes.
+
+### 5. `/slo-freeze` hook must reuse `update-config`, not invent settings.json mutation
+
+The design must handle settings.json mutation through the existing `update-config` skill ([per the project skill list](../../../CLAUDE.md)). Inventing a parallel mutation path violates the canonical-mutation-surface principle and creates a second place to keep secure (argv-list discipline, etc.).
+
+### 6. PreToolUse hook is per-project (`.claude/settings.json`), not global
+
+The design must handle per-project scope because (a) the freeze scope is session-scope, (b) global settings would freeze every project the user touches simultaneously, (c) the project-level `.claude/settings.json` is git-trackable so the discipline travels with the repo.
+
+### 7. Per-skill evals must use the documented-expectation shape until the runtime harness lands
+
+The design must handle the staged-rollout because the "Runtime Claude Code harness" deferred-follow-up from [issue #4](https://github.com/kerberosmansour/SunLitOrchestrate/issues/4) hasn't shipped. Until it does, evals are documented expectations + manual run, not executable. The shape (`evals/<case-name>.md` with input + expected-behavior frontmatter) lets the harness consume them later without rewrites.
+
+### 8. Soft line-cap structural-contract test must allow justified exceptions
+
+The design must handle exceptions because some SKILL.md content (e.g., `/slo-tla`'s elicitation Q1-Q6 + state-explosion triage) is genuinely sequential — splitting fragments the methodology. Test passes with `# soft-cap-exception: <reason>` frontmatter; CI rejects exceptions without the comment. This matches the existing `pii_scan_override:` + `tier_override_reason:` pattern in [`references/biz/artifact-schema.md`](../../../references/biz/artifact-schema.md).
+
+## Open questions that research did not answer
+
+1. **Apalache's distribution channel** — does it use SHA-256 like `tla2tools.jar` or release-asset checksums? Verify against https://github.com/apalache-mc/apalache/releases at runbook-author time and capture the pinned version + SHA in [`skills/slo-tla/tools.toml`](../../../skills/slo-tla/tools.toml).
+2. **`~~~text` user-string fence rule provenance** — is this a documented Markdown convention or a defense-in-depth invention? Critical for the `references/templates/citation-discipline.md` file's authoritative voice.
+3. **Soft line-cap threshold** — 200 lines as the cap is the review's recommendation, but `/slo-tla` may legitimately need 250-280 even after decomposition. The structural-contract test should be calibrated against the post-decomposition SKILL.md sizes.
+4. **Eval-runner harness API** — currently undefined; the deferred-follow-up in [issue #4](https://github.com/kerberosmansour/SunLitOrchestrate/issues/4) lists it as blocked. The eval file shape must be forward-compatible without locking in the runner's API today.
+
+## Source pointers
+
+- 2026-04-27 skill-pack review (in-conversation artifact)
+- [Issue #21](https://github.com/kerberosmansour/SunLitOrchestrate/issues/21) — SKILL.md decomposition + shared templates
+- [Issue #22](https://github.com/kerberosmansour/SunLitOrchestrate/issues/22) — per-skill evals + hard-enforcement hooks + polish
+- [`skills/slo-sast/SKILL.md`](../../../skills/slo-sast/SKILL.md) (296 lines), [`skills/slo-tla/SKILL.md`](../../../skills/slo-tla/SKILL.md) (323 lines), [`skills/slo-plan/SKILL.md`](../../../skills/slo-plan/SKILL.md) (132 lines) — primary decomposition targets
+- [`references/sast/`](../../../references/sast/) — existing per-stage references (parser-contract, stack-detection-contract, etc.) that the new `methodology-m1..m5.md` orchestration files complement
+- [`docs/RUNBOOK-SLO-SECURITY-EMBEDDING.md`](../../RUNBOOK-SLO-SECURITY-EMBEDDING.md) (if present) — Phase 1 program that established the security-aware skill flow this runbook extends
+
+## Note on chub / get-api-docs
+
+Use [`/get-api-docs`](../../../skills/get-api-docs/SKILL.md) for any third-party API reference encountered during execution — but the runbook itself doesn't pre-declare API integrations; the polish items (E5 in [issue #22](https://github.com/kerberosmansour/SunLitOrchestrate/issues/22)) extend `chub`'s failure-mode handling.

--- a/docs/research/loops-and-lessons-closure/synthesis.md
+++ b/docs/research/loops-and-lessons-closure/synthesis.md
@@ -1,0 +1,62 @@
+---
+name: loops-and-lessons-closure
+researched: 2026-04-27
+incomplete: false
+note: |
+  Skill-pack improvement runbook — research is largely the existing skill-pack review +
+  GitHub issues #16, #17, #18 + project owner's chat-elicited decisions on those issues.
+  This file is the synthesis only; the equivalent of `dossier.md` is the issue threads.
+---
+
+# Synthesis — loops + lessons closure
+
+## What the design must handle (and why)
+
+### 1. The lessons loop must be the FIRST loop documented
+
+The design must handle the lessons-loop as the foundational loop because **R2 (engineering) and R3 (business) will produce lessons that need filing as issues**. Without R1 closing the lessons loop first, R2 and R3's lessons drop into `docs/lessons/<prefix>-m<N>.md` and never get filed upstream — defeating the project owner's stated motivation in [issue #16](https://github.com/kerberosmansour/SunLitOrchestrate/issues/16): *"Lessons only matter if they change behavior. Today they sit in docs/lessons/ and rarely get re-read."*
+
+### 2. `gh search` is the de-dupe mechanism — but its reliability depends on the marker
+
+The design must handle marker selection (title prefix vs label vs body sentinel) because [issue #16](https://github.com/kerberosmansour/SunLitOrchestrate/issues/16) explicitly leaves it as an open question: *"Marker for retro-originated issues — title prefix, label, or body sentinel? Whichever is most reliable for `gh search`."* The runbook M3 must include a spike step that tests each option against a populated issue set.
+
+### 3. Engineering loops + business loops must be split docs, not blended
+
+The design must handle this split because [issue #17](https://github.com/kerberosmansour/SunLitOrchestrate/issues/17) and [issue #18](https://github.com/kerberosmansour/SunLitOrchestrate/issues/18) explicitly stated the decision: *"Split from business loops — separate doc, separate concerns."* Blending them is a known anti-pattern.
+
+### 4. Loop docs must cross-link from ARCHITECTURE.md and SKILL.md, not from a separate index
+
+The design must handle bidirectional cross-linking because both [issue #17](https://github.com/kerberosmansour/SunLitOrchestrate/issues/17) and [issue #18](https://github.com/kerberosmansour/SunLitOrchestrate/issues/18) state: *"Cross-link from ARCHITECTURE.md and each implicated SKILL.md."* A standalone index without cross-links is a dead-link risk.
+
+### 5. The fallback for repos without an issue tracker is a local file
+
+The design must handle the no-tracker case because [issue #16](https://github.com/kerberosmansour/SunLitOrchestrate/issues/16) explicitly states: *"Fallback when no issue tracker is configured: local LESSONS-BACKLOG.md in the target repo."* Without this, the retro skill becomes a hard dependency on `gh` availability — which violates the principle of graceful degradation observed across the rest of the pack.
+
+### 6. Loop closure at milestone start (not at retro) is the value-creating move
+
+The design must handle this because [issue #16](https://github.com/kerberosmansour/SunLitOrchestrate/issues/16) says: *"Close the loop in execution flow. /slo-execute M<N> (or the runbook template itself) checks open issues from prior milestones at start of each milestone, surfaces them as scope candidates."* The retro filing alone produces issues but doesn't change behavior; the milestone-start surfacing is what closes the loop.
+
+### 7. The runbook template change is in scope
+
+The design must handle this because [issue #16](https://github.com/kerberosmansour/SunLitOrchestrate/issues/16) flags it as an open question (*"Where does the runbook template change live — its own milestone in a future runbook, or fold into this issue's scope?"*) — folding into this runbook is the cleaner choice, since the template change IS the artifact-level visibility of the loop closure.
+
+## Open questions that research did not answer
+
+These propagate to the runbook as M3-or-later spike steps:
+
+1. **Best marker for retro-originated issues**: needs hands-on `gh search` testing on a populated set.
+2. **Mapping upstream tools to issue-tracker repos**: explicit `.sldo/upstream-mapping.toml` vs crates.io / npm registry resolution. Lean: explicit mapping with registry fallback (per the idea doc).
+3. **Loop diagram format** ([#17](https://github.com/kerberosmansour/SunLitOrchestrate/issues/17), [#18](https://github.com/kerberosmansour/SunLitOrchestrate/issues/18) Q2): ASCII vs Mermaid. Lean: match the closest existing design doc — likely `docs/design/scanner-orchestration-overview.md` — at runbook-author time.
+
+## Source pointers
+
+- [Issue #16](https://github.com/kerberosmansour/SunLitOrchestrate/issues/16) — `/slo-retro` extension to file lessons + close loop at milestone start
+- [Issue #17](https://github.com/kerberosmansour/SunLitOrchestrate/issues/17) — `LOOPS-ENGINEERING.md`
+- [Issue #18](https://github.com/kerberosmansour/SunLitOrchestrate/issues/18) — `LOOPS-BUSINESS.md`
+- [`skills/slo-retro/SKILL.md`](../../../skills/slo-retro/SKILL.md) — current behavior to extend
+- [`skills/slo-execute/SKILL.md`](../../../skills/slo-execute/SKILL.md) — current pre-flight to extend
+- [`docs/runbook-template_v_3_template.md`](../../runbook-template_v_3_template.md) — template needing the new "Carry-forward from prior retros" section
+
+## Note on chub / get-api-docs
+
+Not applicable — this work doesn't introduce new API integrations; `gh` CLI is the only external tool and it's already documented in the existing skill prose.

--- a/docs/research/slo-sec-libs/synthesis.md
+++ b/docs/research/slo-sec-libs/synthesis.md
@@ -1,0 +1,77 @@
+---
+name: slo-sec-libs
+researched: 2026-04-27
+incomplete: false
+note: |
+  Most of the research for this runbook was completed in Phase 1 of the
+  slo-security-embedding program. See `docs/research/slo-security-embedding/dossier.md`
+  and `docs/research/slo-security-embedding/synthesis.md` for the upstream research
+  (Q1-Q5 findings on CycloneDX 1.6, Hulumi capability advertising, GitHub rate-limit
+  point costs, etc.). This synthesis compresses the research-Q findings into the
+  design constraints for /slo-sec-libs.
+---
+
+# Synthesis — /slo-sec-libs
+
+## What the design must handle (and why)
+
+### 1. CycloneDX 1.6+ `declarations` is the capability-advertising contract
+
+The design must handle CycloneDX 1.6 declarations as the input format because the upstream Phase 1 research (Q1) confirmed it as the canonical vendor-neutral capability-advertising spec. URL: https://cyclonedx.org/docs/1.6/json/. The schema is JSON, validation is jsonschema-shaped.
+
+### 2. Rust ecosystem has no 1.6+ declarations support — Python subprocess is the path
+
+The design must handle the Python-jsonschema subprocess path because the upstream Phase 1 research (Q2) confirmed `cyclonedx-bom 0.8.1` is spec-1.5 only (no 1.6+ `declarations` reader). Rather than emit Rust CycloneDX work in this phase, /slo-sec-libs reads through a Python subprocess — matches the Phase 2 precedent for SecOpsTM integration.
+
+### 3. SLO-owned intake repo as the default filing destination
+
+The design must handle the default-channel decision because filing capability gaps to an SLO-owned repo (`kerberosmansour/slo-security-intake`) is the path of least resistance: same-owner authentication, no cross-org permissions to manage, and the user controls the issue-template shape. Third-party filing is gated explicitly — `--file-upstream` flag + per-session 40-issues/hr cap.
+
+### 4. GitHub secondary rate-limit point costs are undocumented — defensive cap is the answer
+
+The design must handle the rate-limit cap because the upstream Phase 1 research (Q5) found GitHub's per-endpoint secondary-rate-limit point cost is undocumented and varies. The 40-issues/hr cap is a defensive posture borrowed from public Octokit benchmarks; conservative enough that even if a single endpoint costs 100 points per call, a session stays under the 1000 points/min visible ceiling.
+
+### 5. Crypto-primitive parametric claims ride in `properties` namespace
+
+The design must handle the namespace decision because the upstream Phase 1 research showed CycloneDX Property Taxonomy doesn't yet have crypto-primitive parametrics (Argon2id iterations / memory / parallelism). Vendored namespace `cdx:sunlit:crypto:*` lives in `properties` until upstream contribution lands. M5 of this runbook flags the upstream contribution as a deferred follow-up.
+
+### 6. argv-list discipline applies to every subprocess
+
+The design must handle this — same as `/slo-sast` M5's `gh pr create` rule, same as Phase 1's argv-list-only contract. Never shell-string interpolation. Defends against `tm-scanner-orchestration-abuse-2 / SEC-6` (argv injection via tampered `.git/config`).
+
+### 7. NO `--repo` flag on `gh pr create` (confused-deputy defense)
+
+The design must handle this per [issue #4](https://github.com/kerberosmansour/SunLitOrchestrate/issues/4) `SEC-8`. Same pattern as `/slo-sast` M5. The skill targets only the current repo's origin remote.
+
+### 8. Capability-gap record schema must be regex-validated, not free-text
+
+The design must handle this because gap records flow into the upstream intake repo as issue-bodies that downstream consumers (humans + future tooling) parse. Free-text gap records become unparseable; regex-validated fields make the gap a structured artifact.
+
+### 9. Pre-requisite repos and CycloneDX declarations must exist before runbook starts
+
+The design must handle the pre-requisite gates explicitly because `/slo-sec-libs` is unusable until:
+
+- `kerberosmansour/slo-security-intake` exists with `ISSUE_TEMPLATE` populated.
+- `kerberosmansour/hulumi` and `SunLitSecureLibraries` repos publish CycloneDX 1.6 `declarations` JSON files.
+- Contributor `gh` CLI is authenticated with the right scopes.
+
+These are out-of-band of the runbook (per [issue #4](https://github.com/kerberosmansour/SunLitOrchestrate/issues/4)) — the runbook's Background Context section flags them as required pre-flight before M1.
+
+## Open questions that research did not answer
+
+1. **`gh search issues` reliability for de-dupe** — same question as R1 (loops), needs hands-on testing on a populated set. Spike step in M3.
+2. **Capability-matcher conflict resolution** — when two candidate libraries both claim to cover a requirement, what's the tiebreaker? Lean: prefer the one with more parametric claims (more specific advertising). Confirm in M2.
+3. **Stale-declarations warning** — when a target repo's CycloneDX file is > N months old, warn or refuse? Lean: warn at 6 months, refuse at 12 — matches the cost-baseline pattern.
+4. **Apalache-style SHA pin for CycloneDX schema** — should /slo-sec-libs pin a specific schema version SHA, or float to whatever 1.6+ is current? Lean: pin per runbook, document the bump procedure. Confirm in M1.
+
+## Source pointers
+
+- [Issue #4](https://github.com/kerberosmansour/SunLitOrchestrate/issues/4) — Phase 4 runbook entry point + deferred follow-ups from Phase 1
+- [`docs/idea/slo-security-embedding.md`](../../idea/slo-security-embedding.md) — original Phase 1 idea doc with "The next product" section that promoted /slo-sec-libs from stretch to core
+- [`docs/research/slo-security-embedding/dossier.md`](../slo-security-embedding/dossier.md) and [`docs/research/slo-security-embedding/synthesis.md`](../slo-security-embedding/synthesis.md) — upstream Q1-Q5 research findings
+- [`docs/design/slo-security-embedding-threat-model.md`](../../design/slo-security-embedding-threat-model.md) — threat model for the upstream program; this runbook adds the `/slo-sec-libs` surface
+- [`SECURITY.md`](../../../SECURITY.md) — argv-list discipline, no-`--repo` rule, etc.
+
+## Note on chub / get-api-docs
+
+Use [`/get-api-docs`](../../../skills/get-api-docs/SKILL.md) for any third-party API reference encountered during execution (e.g., GitHub API specifics for `gh search` queries, Octokit secondary-rate-limit commentary). The skill itself is `WebFetch`-denied like the rest of the security skills; external claims captured at runbook-author time only, with `last_checked:` dates.

--- a/docs/skill-pack-catalog.md
+++ b/docs/skill-pack-catalog.md
@@ -1,268 +1,91 @@
-# SunLitOrchestrate Skill Pack — Catalog (v0 spec)
+# Skill Pack Catalog
 
-> **Status**: draft spec. No skills implemented yet. This doc is the contract for the rebuild.
-> **Audience**: whoever implements the skill pack (likely Claude Code itself, driven by this doc as M1 of a rebuild runbook).
-> **Goal**: replace the Rust-CLI driver loop (`sldo-plan` + `sldo-run`) with a set of Claude Code skills that run a research → design → execute sprint, while preserving the rigor of the v3 runbook template as the canonical planning artifact.
+> **Status**: canonical living catalog of shipped SunLitOrchestrate skills at HEAD.
+> **Audience**: contributors, host-overlay authors, and users deciding which skill to run.
 
----
+Use this file for the host-neutral list of shipped skills. Use [../CLAUDE.md](../CLAUDE.md) for the Claude Code overlay, [../copilot-instructions.md](../copilot-instructions.md) for the GitHub Copilot overlay, [getting-started.md](getting-started.md) for the first-run path, and [design/agent-host-capabilities.md](design/agent-host-capabilities.md) for current host support boundaries.
 
-## Design principles
+## Repo reality at HEAD
 
-1. **The v3 runbook is the output contract, not the tool.** Every planning skill eventually contributes to, or executes against, a v3 runbook. The template at [docs/runbook-template_v_3_template.md](runbook-template_v_3_template.md) is not being replaced.
-2. **Skills are Markdown, not binaries.** Each skill is a `SKILL.md` in `skills/<skill-name>/`. Installer symlinks to `~/.claude/skills/slo-<skill-name>/` (or `./.claude/skills/` for repo-local).
-3. **Reuse existing Rust backends where they earn it.** The `sldo-research` crate stays. The `sldo-plan` / `sldo-run` binaries become optional batch harnesses for overnight autonomy; they are no longer the primary interface.
-4. **One skill, one role.** Don't blur personas. If you need CEO critique *and* eng critique, that's two skills — or one skill that invokes them as sub-phases, not one blended prompt.
-5. **Skills write files, not vibes.** Every skill declares its outputs as concrete paths. Downstream skills read those paths.
-6. **Interactivity at decision points only.** Ask when the answer can't be derived from the codebase or prior artifacts. Don't ask for preferences already recorded.
-
----
+- The portable unit is the Markdown `SKILL.md` contract under `skills/<name>/SKILL.md`.
+- The active Rust workspace members are `sldo-common`, `sldo-research`, `sldo-install`, and `xtasks/sast-verify`.
+- The legacy `sldo-plan`, `sldo-run`, and `sldo-tauri` surfaces are not current workspace members and should not be treated as active interfaces.
+- `sldo-install` can install the same skill pack into Claude Code or GitHub Copilot.
+- Headless runtime automation is still host-specific today. Check [design/agent-host-capabilities.md](design/agent-host-capabilities.md) before promising a runtime surface.
 
 ## Sprint flow
 
-```
-  /slo-ideate ─► /slo-research ─► /slo-architect ─► /slo-tla ─► /slo-plan ─► /slo-critique
-                                                       │                          │
-                                                       └── (skip if simple) ──────┘
-                                                                                  ▼
-  /slo-retro ◄── /slo-verify ◄── /slo-execute M<N> ◄────────────────────────────
-                                       ▲
-                                       └── loops per milestone until runbook tracker is all `done`
-```
-
-Power tools attach anywhere: `/slo-second-opinion`, `/slo-freeze`, `/slo-resume`, `/slo-ship`.
-
----
-
-## Skill catalog
-
-Each entry is the spec a `SKILL.md` file will encode. Format: **Persona** (who the agent becomes), **When** (trigger), **Reads**, **Writes**, **Methodology** (the non-obvious part), **Done when**.
-
----
-
-### `/slo-ideate`
-
-**Persona**: YC partner running office hours.
-**When**: user has a raw idea and nothing else. Always the entry point for a new project.
-**Reads**: user's natural-language pitch; optionally `docs/RUNBOOK-*.md` to check if this overlaps existing work.
-**Writes**:
-- `docs/idea/<slug>.md` — reframed problem, 3 implementation approaches with effort estimates, 5 capabilities the user didn't realize they were describing, recommended wedge.
-
-**Methodology**: six forcing questions (pain-specific-not-hypothetical, who-hurts-today, what-gets-thrown-away-if-this-works, smallest-wedge, business-model-implications, what-if-this-is-a-feature-of-something-bigger). Push back on framing. Never let "an app for X" stand — interrogate until the pain is concrete.
-
-**Done when**: the idea doc names a specific user, a specific pain moment, a specific wedge, and three candidate approaches ranked by 1-week-shippability.
-
----
-
-### `/slo-research`
-
-**Persona**: senior analyst with the existing `sldo-research` pipeline as a tool.
-**When**: after `/slo-ideate`. Also standalone when the user asks "is this idea even viable."
-**Reads**: `docs/idea/<slug>.md`; external web via `sldo-research` crate (which handles rate-limiting, sourcing, synthesis).
-**Writes**:
-- `docs/research/<slug>/dossier.md` — market, competitors, technical prior art, legal/regulatory constraints, open questions.
-- `docs/research/<slug>/sources.md` — cited URLs with access dates.
-- `docs/research/<slug>/synthesis.md` — "what this means for the design."
-
-**Methodology**: do *not* re-implement research in the skill. Shell out to `sldo-research` (which already has M6/M7 synthesis + plan-readiness). The skill's job is framing the research prompt and gating the output. Flag claims without sources. Flag vibes without data.
-
-**Done when**: dossier has ≥3 sourced competitor comparisons, ≥1 technical prior-art reference, and the synthesis ends with "the design must handle X, Y, Z because [source]."
-
----
-
-### `/slo-architect`
-
-**Persona**: staff engineer making stack choices.
-**When**: after research, before any runbook-writing.
-**Reads**: idea doc, research dossier, target repo (`git ls-files` to detect existing stack if this is brownfield).
-**Writes**:
-- `ARCHITECTURE.md` (or updates it) — component diagram, data flow, persistence boundaries, trust boundaries, external integrations.
-- `docs/design/stack-decision.md` — chosen stack with explicit "we rejected X because Y" rationale.
-- `docs/design/interfaces.md` — public APIs, commands, events, persisted shapes that downstream milestones must keep stable.
-
-**Methodology**: force-decide the uncertain things now so the runbook can enforce compatibility later. If the system has concurrency, distributed state, ordering guarantees, resource ownership, or failure recovery, set a flag `tla_required: true` in the frontmatter of the design doc — `/slo-tla` checks this next.
-
-**Done when**: ARCHITECTURE.md has a diagram the user can read at a glance, and every component has a one-line responsibility.
-
----
-
-### `/slo-tla` — **formal verification (new)**
-
-**Persona**: formal methods engineer who translates designs into TLA+ and runs TLC until invariants hold.
-**When**: after `/slo-architect` when `tla_required: true`. Also runnable manually on any design doc. Also runnable against an existing runbook's TLA+ section to fill it in with a real, model-checked spec.
-**Reads**: `ARCHITECTURE.md`, `docs/design/stack-decision.md`, the v3 runbook's TLA+ section template (for output shape), optionally an existing hand-written design.
-**Writes**:
-- `specs/<name>.tla` — the TLA+ spec.
-- `specs/<name>.cfg` — TLC config (constants, invariants, properties, symmetry, bounds).
-- `specs/<name>.trace.md` — any counterexamples TLC produced, translated into plain-English step-by-step scenarios.
-- `docs/design/<name>-verified.md` — the validated design writeup, including: system goal, state, actions, safety properties, liveness assumptions, simplifications, TLC results (checked configs + bounds), open questions.
-- Patches the v3 runbook's "High-Level Design for Formal Verification" section if a runbook exists.
-
-**Methodology** (this is the non-obvious part — it's where "some work" lives):
-
-1. **Elicit the right abstraction.** Most design docs over-specify (timestamps, UUIDs, payloads). The skill must reduce to the smallest set of states and transitions that captures real correctness risk. Ask: "What property are we trying to prove? What's the smallest state that can violate it?"
-2. **Draft the spec in stages.** Start with the state variable set and the Init predicate. Get TLC running on a 2-actor, 2-step bound before adding complexity. Growing a spec incrementally is the only way to avoid state explosion.
-3. **Separate safety from liveness.** Safety invariants check with TLC directly. Liveness needs fairness assumptions and temporal properties — state them explicitly, ask the user to confirm fairness (weak vs. strong on which actions).
-4. **Counterexamples are the output, not the failure.** When TLC finds a violation, don't just report it — translate the trace into a plain-English scenario (`Actor A sends request → actor B crashes before ack → A retries → B recovers and processes twice`). Then propose the design fix. Then re-run. Loop until green or the user declares "acceptable, document the assumption."
-5. **Declare the bounds.** Every TLC result must state the model bounds (N actors, M requests, K failures). "Verified" without bounds is a lie.
-6. **Prefer Apalache for unbounded state.** If state explodes in TLC, suggest Apalache's symbolic model checking with a cited bound. The skill detects which tool is installed.
-
-**Prereq cascade** (follows SLO's existing `preflight::check_claude_installed` pattern in [crates/sldo-common/src/preflight.rs](../crates/sldo-common/src/preflight.rs) — use `which::which(...)` and fail with a human-readable install hint; never silently fall back):
-
-1. **JVM check.** `which::which("java")`. If missing → exit with a clear message: platform-specific install hint (`brew install openjdk` on macOS, `apt install default-jre` on Debian/Ubuntu, https://adoptium.net link otherwise). Do *not* attempt to install Java for the user.
-2. **TLC jar check.** Look for `tla2tools.jar` at a known SLO-managed path (`~/.sldo/tla/tla2tools.jar`), then `$TLA_TOOLS_JAR` env var, then common system locations.
-3. **If JVM present and jar missing → download and install the jar automatically.** Fetch `tla2tools.jar` from the pinned upstream release URL into `~/.sldo/tla/`, verify SHA-256 against a checksum shipped in the skill config (so we don't blindly trust the download), write a small shim script (`~/.sldo/tla/tlc`) that wraps `java -jar tla2tools.jar` with sensible default heap size, add that path to the skill's tool lookup. Record the version in `~/.sldo/tla/VERSION`. No bundling — the repo stays jar-free.
-4. **Apalache (optional fallback for large state spaces).** Same cascade: check `which apalache-mc` → if missing, check JVM → if JVM present, offer to download the pinned Apalache release. Only run this cascade when the skill actually needs Apalache (state explosion detected), not at startup.
-5. **Version pinning.** Upstream URLs + SHA-256 checksums live in a single `skills/slo-tla/tools.toml` so upgrades are one-line and auditable. No floating `latest` URLs.
-
-This mirrors the `preflight` module's fail-loud discipline: `which` detection, human-readable errors, no silent fallbacks. The only addition vs. existing `preflight` is the conditional auto-download for the jar — justified because TLA+ is unique in having "JVM present but artifact missing" as a common benign state (users installed Java for other reasons, haven't heard of TLA+ before).
-
-**Known hard parts** (the "some work" the user flagged):
-- Translating a vague English design into a tractable TLA+ state machine is the core skill — it will take iteration on the prompt to get this consistent.
-- Counterexample-to-English translation quality drives the whole UX; bad traces are worse than no verification.
-- Managing state explosion: the skill needs heuristics for when to suggest symmetry reduction, state constraints, or switching to Apalache.
-- Fairness assumptions are where users slip up; the skill must force an explicit decision rather than defaulting silently.
-
-**Done when**: TLC (or Apalache) reports no violations on all declared safety + liveness properties at the declared bound, AND the `-verified.md` doc records every assumption, every simplification, and every property checked.
-
-**Unique value**: no competitor skill pack (gstack, claude-code-skills, etc.) does formal verification. For systems where correctness actually matters — consensus, leader election, queue workers with idempotency, state-machine replication, distributed caches — this is a differentiator.
-
----
-
-### `/slo-plan`
-
-**Persona**: engineering manager translating a design into a milestone plan.
-**When**: after `/slo-architect` (and `/slo-tla` if applicable).
-**Reads**: ARCHITECTURE.md, design docs, verified TLA+ spec if any, v3 runbook template.
-**Writes**:
-- `docs/RUNBOOK-<feature>.md` — a fully populated v3 runbook. Milestone tracker, per-milestone contract blocks, BDD scenarios, E2E stubs, evidence log templates, definition of done.
-
-**Methodology**: walks the user milestone-by-milestone, interactively. Does *not* generate the whole runbook in one shot — that's the failure mode of the current `sldo-plan` binary and the reason the rebuild exists. For each milestone: state goal → declare contract block → list files allowed to change → write BDD scenarios → confirm → move on. Max 5 milestones per feature runbook; if the scope needs more, that's a signal to split.
-
-**Done when**: the runbook has every section from the template filled, no placeholders, and the user has approved the milestone tracker.
-
----
-
-### `/slo-critique`
-
-**Persona**: rotating reviewer — CEO, eng-lead, security, design — in that order.
-**When**: after `/slo-plan`, before any implementation.
-**Reads**: the new runbook, ARCHITECTURE.md, prior lessons files.
-**Writes**:
-- Inline edits / comments on the runbook.
-- `docs/critique/<runbook-slug>.md` — findings summary: auto-fixed issues, ask-to-fix issues, hold-scope/reduce-scope recommendations.
-
-**Methodology**: four sub-personas, one pass each.
-- **CEO**: scope challenge. Is the 10-star product hiding inside this? Should we expand, hold, or reduce?
-- **Eng lead**: architecture pokes. Hidden assumptions, missing failure modes, test gaps, orthogonal edits.
-- **Security**: OWASP Top 10 + STRIDE applied to the design. Concrete exploit scenarios, not theoretical risks.
-- **Design** (only if there's a UI surface): AI-slop detection, interaction gaps, empty-state handling.
-
-Auto-fix obvious mechanical issues (missing compatibility checklist rows, wrong test naming, absent .gitignore updates). Ask before changing scope.
-
-**Done when**: every finding is either auto-fixed, accepted with a captured rationale, or deferred with a written reason.
-
----
-
-### `/slo-execute M<N>`
-
-**Persona**: disciplined implementer driving one milestone.
-**When**: user runs it per milestone. Replaces `sldo-run`'s inner loop.
-**Reads**: runbook, prior lessons file (`docs/lessons/<prefix>-m<N-1>.md`), allowed files.
-**Writes**:
-- BDD test files first (verified to fail for the right reason).
-- E2E runtime validation stubs.
-- Production code.
-- Evidence log entries (into the runbook itself).
-
-**Methodology**: follows the v3 Global Entry Rules literally. Restates milestone constraints before coding. Refuses to widen scope. Refuses to touch files outside the allow-list without surfacing the conflict.
-
-**Done when**: milestone's Definition of Done is satisfied and every Evidence Log row is filled.
-
----
-
-### `/slo-verify`
-
-**Persona**: QA lead with a real browser and real data.
-**When**: after `/slo-execute` finishes a milestone, before `/slo-retro`.
-**Reads**: the milestone's smoke tests, E2E contract, affected UI surfaces.
-**Writes**:
-- Regression tests for any bug it finds.
-- `docs/verify/<prefix>-m<N>.md` — verification report: what was exercised, what passed, what didn't.
-
-**Methodology**: Playwright-backed browser automation (reuse gstack's `/browse` approach or wrap it directly). Exercises the happy path, the empty state, and at least one partial-failure scenario. Every bug found gets a regression test before the fix.
-
-**Done when**: every BDD scenario has been exercised at runtime, not just compiled.
-
----
-
-### `/slo-retro`
-
-**Persona**: eng manager closing out a milestone.
-**When**: after `/slo-verify` passes.
-**Reads**: evidence log, verification report, actual diff vs planned files.
-**Writes**:
-- `docs/lessons/<prefix>-m<N>.md` — applying the v3 template.
-- `docs/completion/<prefix>-m<N>.md` — applying the v3 template.
-- Updates the runbook's Milestone Tracker.
-- Updates `ARCHITECTURE.md` per the Documentation Update Table.
-
-**Methodology**: lessons file is the input to the *next* milestone's `/slo-execute`. Not optional. A milestone with no lessons file is not done.
-
-**Done when**: tracker row is `done`, both templates filled, ARCHITECTURE.md reflects reality.
-
----
+| Stage | Skill | Purpose |
+|---|---|---|
+| Ideate | `/slo-ideate` | YC-style product interrogation before any code |
+| Research | `/slo-research` | Wraps the `sldo-research` backend for sourced dossiers |
+| Architect | `/slo-architect` | Stack + `ARCHITECTURE.md` + interfaces lock-in + `tla_required` flag |
+| Verify design | `/slo-tla` | TLC model-check the design when concurrency or ordering risk is real |
+| Plan | `/slo-plan` | Interactive v3 runbook authoring, one milestone at a time |
+| Critique | `/slo-critique` | Four-persona adversarial review before execution |
+| Execute | `/slo-execute M<N>` | Per-milestone driver with allow-list enforcement |
+| Verify | `/slo-verify M<N>` | Runtime QA with Playwright for UI surfaces |
+| Close | `/slo-retro M<N>` | Lessons + completion + tracker update |
+| Ship | `/slo-ship` | Open a runbook-aware PR |
 
 ## Power tools
 
-### `/slo-second-opinion`
-
-Runs the current runbook / plan / diff through a different model (Codex CLI or Gemini). Not "vote" — "surface disagreement." Output is a diff of findings: what both models flagged, what only one flagged. User decides.
-
-### `/slo-freeze <path>`
-
-Lock edits to a directory. Prevents scope creep during implementation. Mirrors gstack's `/freeze`.
-
-### `/slo-resume`
-
-Pick up an interrupted runbook. Reads the tracker, finds the first non-`done` row, restores context (which skill to run next).
-
-### `/slo-ship`
-
-Sync main, run full suite, push branch, open PR with a runbook-aware description (summarizes completed milestones, not diff stats).
-
----
-
-## What happens to the Rust crates
-
-| Crate | Fate |
+| Skill | Purpose |
 |---|---|
-| `sldo-common` | Keep. Shared types + config. |
-| `sldo-research` | **Keep as primary.** `/slo-research` wraps it. The research pipeline is already good; don't rewrite. |
-| `sldo-plan` | Demote to optional batch mode. The interactive `/slo-plan` skill is the primary. `sldo-plan` can stay for unattended overnight runs. |
-| `sldo-run` | Same as `sldo-plan` — optional batch harness. Eventually may be deleted, but not in the first pass. |
-| `sldo-tauri` | **Park.** The Tauri desktop app does not fit the skill-pack model; it was trying to be a GUI for something that now lives inside Claude Code. Leave the `tauri` branch unmerged; don't invest more. Revisit only if there's a concrete user pulling for it. |
+| `/slo-second-opinion` | Cross-model disagreement surfacer |
+| `/slo-freeze <path>` | Lock edits to one directory for the session |
+| `/slo-resume` | Read the current runbook tracker and suggest the next move |
+| `/slo-rulegen` | Bootstrap or extend Semgrep rule packs for Rust workspaces |
+| `/slo-ruleverify` | Run the deterministic SAST gate over an existing rule pack |
+| `/slo-sast` | Wire threat-model-driven SAST scanning into a target repo |
 
----
+## Business advisor skills
 
-## Rebuild milestones (preview, to be written as a proper runbook)
+UK-only in v1. These skills operate in `draft`, `translate`, `triage`, or `prepare` modes and hard-block where their gate says a professional must take over.
 
-1. **M1** — this catalog + skill-pack directory skeleton + installer script. No skills yet, just infrastructure.
-2. **M2** — `/slo-ideate` + `/slo-retro` (smallest useful slice; end-to-end for tiny features without full research).
-3. **M3** — `/slo-research` wrapper around `sldo-research`.
-4. **M4** — `/slo-architect` + `/slo-plan`.
-5. **M5** — `/slo-tla` (formal verification). This is the hard one. Gate it behind `tla_required: true` so normal projects don't need TLA+ installed.
-6. **M6** — `/slo-critique` (four sub-personas).
-7. **M7** — `/slo-execute` + `/slo-verify`.
-8. **M8** — power tools (`/slo-second-opinion`, `/slo-freeze`, `/slo-resume`, `/slo-ship`).
-9. **M9** — self-hosting: run the full pack on a fresh idea end-to-end, use the resulting runbook as the acceptance test. If SLO can't build SLO features, the pack isn't done.
+| Skill | Domain | Notes |
+|---|---|---|
+| `/slo-legal` | UK legal | NDA, contractor SOW, IP assignment, T&Cs |
+| `/slo-accounting` | UK accounting | Bookkeeping, VAT, R&D credit, MTD |
+| `/slo-equity` | UK equity | Founder split, vesting, cap-table snapshot |
+| `/slo-fundraise` | UK fundraise | SAFE math, pitch narrative, term-sheet prep |
 
-Each milestone gets a v3 runbook section. The rebuild eats its own dogfood.
+## Business generator skills
 
----
+These skills generate exactly one primary artifact each.
 
-## Resolved decisions (as of 2026-04-23)
+| Skill | Output | Purpose |
+|---|---|---|
+| `/slo-talk-to-users` | `docs/biz/users/<date>-<name>.md` | Interview prep and post-interview extraction |
+| `/slo-gtm` | `docs/biz-public/gtm/strategy.md` | ICP, segmentation, GTM motion, channel strategy |
+| `/slo-product roadmap` | `docs/biz-public/product/roadmap.md` | Product roadmap |
+| `/slo-product metrics` | `docs/biz-public/product/metrics.md` | Product KPI dashboard |
+| `/slo-product okrs` | `docs/biz-public/product/okrs.md` | Quarterly product OKRs |
+| `/slo-marketing b2b|b2c` | `docs/biz-public/marketing/<mode>-plan.md` | Marketing tactics plan |
+| `/slo-launch` | `docs/biz-public/launch-<slug>.md` | Staged launch sequence |
+| `/slo-sales-funnel` | `docs/biz-public/sales/funnel-<segment>.md` | Outbound funnel math and cold-email structure |
+| `/slo-pricing` | `docs/biz-public/pricing.md` | Pricing strategy and tier framing |
+| `/slo-metrics consumer|b2b` | `docs/biz-public/metrics.md` | Financial and business KPI dashboard |
+| `/slo-cofounder` | `docs/biz/cofounder/<name>.md` | Cofounder evaluation or trial framing |
+| `/slo-hire swe|ae|designer|ops` | `docs/biz/hires/<role>-<name>.md` | Hiring artifact with IR35 gate |
+| `/slo-founder-check` | `docs/biz/founder-check.md` | Founder self-assessment and runway worksheet |
 
-1. **Repo layout**: `skills/` at the repo root. Skills aren't code and don't belong under `crates/`.
-2. **Namespace**: `/slo-*`. Explicit, non-conflicting with gstack, and users can install both packs side-by-side.
-3. **Installer**: Rust binary (`sldo-install`). Consistent with the existing tool suite; users already have `cargo`; we get type safety and cross-platform support for free.
-4. **TLA+ tool shipping**: no jar bundled in the repo. The `/slo-tla` skill checks JVM presence via `which::which("java")` (same pattern as [preflight.rs](../crates/sldo-common/src/preflight.rs)). If Java is missing → tell the user, exit. If Java is present but the jar isn't → download the pinned `tla2tools.jar` into `~/.sldo/tla/`, verify SHA-256, install a shim. Checksums + upstream URLs pinned in `skills/slo-tla/tools.toml`. See the `/slo-tla` "Prereq cascade" above for the full flow.
+## Vendored skills
+
+| Skill | Purpose | Prerequisite |
+|---|---|---|
+| `/get-api-docs` | Fetch current third-party API docs via `chub` before coding against an external API | `npm install -g @aisuite/chub` |
+
+## Shared invariants
+
+- Every feature runbook lives at `docs/RUNBOOK-<FEATURE>.md` and follows `docs/runbook-template_v_3_template.md`.
+- `README.md` is the orientation doc, `docs/getting-started.md` is the first-run guide, and this file is the host-neutral skill catalog.
+- Host overlays must stay overlays. They can add session-specific guidance, but they should point back here instead of becoming competing catalogs.
+- `references/biz/` and `references/sast/` are shared scaffolding trees. They are read by skills, but they are not skill directories.
+
+## Current host boundaries
+
+- Claude Code and GitHub Copilot can both consume the installed `SKILL.md` files.
+- GitHub Copilot should be treated as an interactive host today, not a headless runtime target.
+- `/slo-research` still has a Claude-specific automated batch backend today.
+- The live business judgment runtime harness is still Claude-only today.

--- a/docs/skill-pack-catalog.md
+++ b/docs/skill-pack-catalog.md
@@ -18,7 +18,7 @@ Use this file for the host-neutral list of shipped skills. Use [../CLAUDE.md](..
 | Stage | Skill | Purpose |
 |---|---|---|
 | Ideate | `/slo-ideate` | YC-style product interrogation before any code |
-| Research | `/slo-research` | Wraps the `sldo-research` backend for sourced dossiers |
+| Research | `/slo-research` | Host-native interactive research first; optional Claude batch backend for sourced dossiers |
 | Architect | `/slo-architect` | Stack + `ARCHITECTURE.md` + interfaces lock-in + `tla_required` flag |
 | Verify design | `/slo-tla` | TLC model-check the design when concurrency or ordering risk is real |
 | Plan | `/slo-plan` | Interactive v3 runbook authoring, one milestone at a time |
@@ -87,5 +87,5 @@ These skills generate exactly one primary artifact each.
 
 - Claude Code and GitHub Copilot can both consume the installed `SKILL.md` files.
 - GitHub Copilot should be treated as an interactive host today, not a headless runtime target.
-- `/slo-research` still has a Claude-specific automated batch backend today.
+- `/slo-research` interactive use is host-neutral today; `sldo-research` remains an optional Claude batch backend.
 - The live business judgment runtime harness is still Claude-only today.

--- a/docs/verify/agent-host-m3-smoke.md
+++ b/docs/verify/agent-host-m3-smoke.md
@@ -1,0 +1,28 @@
+# Agent-Host Milestone 3 Smoke Checklist
+
+> Runbook: [docs/RUNBOOK-AGENT-HOST-COMPATIBILITY.md](../RUNBOOK-AGENT-HOST-COMPATIBILITY.md) Milestone 3
+> Goal: verify that `/slo-research` is host-native for interactive use and that the Claude batch backend is explicit and optional.
+> Local validation was completed from the terminal on 2026-04-29. The Claude Code and GitHub Copilot session items still need to be checked in those hosts directly.
+
+## Claude session
+
+- [ ] Open the installed `/slo-research` skill in Claude Code.
+- [ ] Confirm the interactive path tells the agent to use host-native research tools and file writes, not only `sldo-research`.
+- [ ] Confirm missing `docs/idea/<slug>.md` still produces a clear refusal that points to `/slo-ideate`.
+- [ ] Confirm the skill still writes to `docs/research/<slug>/dossier.md`, `sources.md`, and `synthesis.md`.
+- [ ] Confirm any batch guidance is labeled as an optional Claude batch backend, not the default path.
+
+## GitHub Copilot session
+
+- [ ] Open the installed `/slo-research` skill in GitHub Copilot.
+- [ ] Confirm the interactive path is usable without installing Claude or `sldo-research`.
+- [ ] Confirm the skill still requires sourced output and visible `incomplete: true` handling for missing coverage.
+- [ ] Confirm the skill still points to the same `docs/research/<slug>/` artifact paths.
+- [ ] Confirm the optional batch guidance is clearly separated from the interactive Copilot path.
+
+## Local validation
+
+- [x] `cargo test -p sldo-install --test e2e_agent_host_m3`
+- [x] `cargo test -p sldo-research`
+- [x] `cargo build -p sldo-research`
+- [x] `git status --short` shows no untracked test artifacts

--- a/references/biz/legal-intake-form.md
+++ b/references/biz/legal-intake-form.md
@@ -1,0 +1,185 @@
+---
+name: legal-intake-contract
+created: 2026-04-27
+status: starter — runbook from issue #19 to harden
+audience: /slo-legal advisor skill
+purpose: |
+  Structured-data CONTRACT that the skill MUST gather **conversationally** before
+  entering `draft` mode. Closes the predicate-evaluation hallucination surface
+  identified in the 2026-04-27 skill-pack review. The four hard-block gates in
+  `references/biz/triage-gate.md` are evaluated against THIS structured input, not against
+  free-form founder prose.
+
+  This is NOT a form for the founder to fill. It is the destination shape of a
+  conversational elicitation the skill drives — modeled on `/slo-ideate`'s seven
+  forcing questions. The skill asks one question at a time, pushes back on vague
+  answers, ladders down when the founder is unsure, and synthesizes the dialogue into
+  the structured `intake_summary:` block. The founder never sees a form.
+
+  Companion files: `accounting-intake-contract.md`, `equity-intake-contract.md`,
+  `fundraise-intake-contract.md`, `hire-intake-contract.md` (all per issue #19).
+---
+
+# /slo-legal — pre-draft conversational intake contract
+
+The skill MUST gather every field below **through conversation** before entering `draft` mode. "Skill emits a form" is the wrong UX. "Skill asks one question, pushes if the answer is vague, moves on when the answer is concrete enough to evaluate the gate" is the right UX — same pattern as [`/slo-ideate`'s seven forcing questions](../../skills/slo-ideate/SKILL.md).
+
+Empty / "I don't know" / hypothetical answers do not fall through to draft with an assumption. They are an explicit signal: either ask the founder to find the fact (e.g., "look at who emailed you the contract" for counterparty representation), or — if the fact genuinely cannot be known yet — route to `triage` rather than `draft`.
+
+## How the skill uses this contract
+
+The skill drives a conversational loop that produces the structured `intake_summary:` block. The loop is:
+
+1. Founder invokes `/slo-legal draft <doc-type>`.
+2. Skill begins the elicitation conversation. **One question at a time.** Do not dump the field list on the founder. Push on vague answers. Ladder down when the founder is unsure. The order in §"Required fields" below is the recommended ask-order, but the skill MAY adapt to the founder's framing (e.g., if the founder leads with "this is a non-UK contract", jump to F1 immediately and short-circuit).
+3. As the founder answers, the skill synthesizes the response into the closed-enum / numeric / boolean shape required by the contract. Validates each value. Asks for clarification when ambiguous.
+4. After all fields are gathered, skill **restates the situation in 3-5 sentences** and asks the founder to confirm (modeled on [`/slo-execute`'s 'Restate the milestone constraints in your own words'](../../skills/slo-execute/SKILL.md#L36)). On correction, skill re-asks the affected questions and re-synthesizes — never silently re-interprets.
+5. On confirmation, skill evaluates the four gates against the structured input.
+6. If any gate fires, the artifact is `triage`-shaped, not `draft`-shaped, with `gates_fired:` populated from this intake.
+
+The structured `intake_summary:` block is the **output** of the conversation, not a UI surface. It lands in the artifact frontmatter (per `references/biz/artifact-schema.md`) so downstream tooling (`/slo-verify`, future audit / replay) can inspect what the skill thought it knew when it drafted.
+
+## Conversation discipline (for the skill)
+
+Borrowed verbatim from `/slo-ideate`'s anti-pattern set:
+
+- **Do not ask all questions at once** — single-question, wait for answer, push if vague, then move on.
+- **Do not accept hypotheticals** — "the contract value is probably around £5k" is not a value; ask "is that monthly, annual, or total — and ex-VAT?"
+- **Do not soften pushback to keep the founder happy** — you are the advisor, not the cheerleader. If the founder is rounding, evading, or wishful, the gate evaluation will be wrong; the founder will be the one who pays the cost.
+- **Restate, do not re-interpret silently** — if the founder corrects, ask "did I hear that right?" again. Re-interpretation without confirmation is the failure mode this whole flow exists to prevent.
+
+## Required fields (the contract)
+
+### F1. Jurisdiction
+
+> Where will this contract be performed, and what governing law will it use?
+
+- `jurisdiction_self`: enum — `uk-england-wales` | `uk-scotland` | `uk-northern-ireland` | `non-uk`
+- `jurisdiction_counterparty`: enum — same set
+- `governing_law_specified`: bool (is there a clause in the doc / situation specifying governing law?)
+- `governing_law_value`: free-text (only required if `governing_law_specified: true`)
+
+**Refusal**: any `non-uk` value → canonical "v1 supports UK only" error from `references/biz/jurisdiction-uk.md`. Do not draft. Do not produce a "for reference only" US/EU output.
+
+### F2. Counterparty representation
+
+> Is the other party represented by a lawyer in this matter? Are you being asked to sign a contract drafted by them?
+
+- `counterparty_has_lawyer`: enum — `yes` | `no` | `unknown`
+- `signing_their_paper`: enum — `yes` | `no` | `unknown` (i.e., is the contract being handed to the founder pre-drafted, vs the founder sending their paper)
+- `counterparty_identity`: free-text (a name or role; used in `triage` memo body, not for gate evaluation)
+
+**Predicate firing**: `gate-3-counterparty-has-lawyer-or-their-paper` fires on `yes` to either question. `unknown` is **not a fall-through to `no`** — refuse and ask the founder to find out (most common: ask the counterparty directly, or look at who the contract was sent from).
+
+### F3. Deal value
+
+> What is the total contract value, in GBP, exclusive of VAT, over the full term of the engagement?
+
+- `deal_value_gbp_ex_vat`: number (total contract value over full term)
+- `deal_value_basis`: enum — `total-contract-value` | `monthly-recurring` | `annual-recurring` | `one-off-fee` | `not-applicable`
+- `deal_value_term_months`: number (only required if basis is recurring)
+- `deal_value_known_with_confidence`: enum — `precise` | `estimated-within-25-percent` | `estimated-roughly` | `unknown`
+
+The skill MUST compute total contract value from `deal_value_basis` + `deal_value_term_months`. Founders frequently quote monthly numbers when the gate measures total. Worked examples:
+
+- £500/month × 24-month term → £12,000 ex-VAT total → **gate-2 fires**.
+- £8,000 one-off fee → £8,000 ex-VAT total → **gate-2 fires**.
+- £4,000/year × 1-year contract with auto-renewal → £4,000 first-term-only → **gate-2 may not fire BUT** flag the auto-renewal in `triage` body.
+- VAT-inclusive £5,400 → ex-VAT £4,500 → gate-2 does not fire on value alone.
+
+**Predicate firing**: `gate-2-deal-value-over-5k` fires on `> 5000`. **`unknown` confidence is a refusal**, not a fall-through. The skill must ask the founder to commit to an estimate; "I don't know" is the founder's signal that they need a triage memo, not a draft.
+
+**Explicit-comprehension question (per critique S-1)**: before locking F3 the skill asks the founder to confirm the value in two framings, e.g., *"To confirm — you said £8,000 for a 4-month engagement. Is that £8,000 per month (= £32,000 total, 4× the gate-2 threshold) or £8,000 total over the 4 months? And is that figure inclusive or exclusive of VAT?"* This catches the most common misframing without requiring the founder to read the schema. The skill records the exact phrasing of the founder's confirmation in the artifact's `intake_summary.deal_value_confirmation:` field for downstream audit.
+
+**Borderline cases (£4,500–£5,500)**: evaluate alongside the other three gates. If gate-1 / gate-3 / gate-4 also fire, route to triage regardless. If only gate-2 is borderline and other gates pass cleanly, the skill may draft but MUST surface the proximity in the artifact body: "Deal value £X is within 10% of the £5,000 triage threshold — solicitor review is recommended even by the skill's defensive defaults."
+
+### F4. GDPR scope
+
+> Does the document being requested relate to processing of personal data: privacy notice, ROPA, DPA, internal data-protection policy, lawful-basis statement, DPIA, DSAR procedure, breach-notification template, cookie policy, or anything else the ICO would expect to see in a controller's accountability file?
+
+- `gdpr_document_requested`: bool
+- `gdpr_document_type`: free-text (only required if `gdpr_document_requested: true`)
+- `gdpr_data_in_scope`: bool (is personal data otherwise in scope, even if the document itself isn't a GDPR doc — e.g., a contractor SOW that includes shared-data processing terms?)
+
+**Predicate firing**: `gate-4-gdpr-document` fires on `gdpr_document_requested: true` — **unconditional refusal of `draft` mode** for ANY GDPR-related document, locked decision 2026-04-25. Routes to triage with `route_to: dpo (or lawyer + dpo if no DPO)`. Reversal requires a fresh `/slo-architect` pass with new ICO enforcement evidence.
+
+If `gdpr_data_in_scope: true` but `gdpr_document_requested: false` (e.g., a contractor SOW with data-handling clauses but the request is the SOW, not a DPA), the skill drafts the SOW but flags the data-handling clauses as "needs DPO review for adequacy" in the body.
+
+### F5. Regulated sector
+
+> Does the matter touch any regulator with statutory enforcement powers — see `references/biz/uk-regulator-enumeration.md`?
+
+- `regulator_in_scope`: bool
+- `regulator_id`: enum (closed list from `uk-regulator-enumeration.md`; only required if `regulator_in_scope: true`)
+- `regulator_relationship`: enum — `regulated-business` | `regulated-counterparty` | `regulator-as-counterparty` | `incidental`
+
+**Predicate firing**: `gate-1-regulated` fires on `regulator_in_scope: true` AND `regulator_relationship` ≠ `incidental`. The skill consults `references/biz/uk-regulator-enumeration.md` for routing — the default is `lawyer` but specific regulators (HMRC, ICO, Companies House, Pensions Regulator) override per the per-skill routing table.
+
+**The skill does NOT enumerate regulators from training memory**. If the founder names a regulator not in the enumeration file, refuse: "Regulator <X> is not in the enumeration. Either (a) confirm it's not the body you mean and pick from the file, or (b) flag the gap as a follow-up so the enumeration can be extended via `/slo-architect` review (do not bypass)."
+
+### F6. Doc-type and counterparty (artifact metadata)
+
+These fields are not used for gate evaluation but must be captured for the artifact frontmatter:
+
+- `doc_type`: enum — `nda` | `contractor-sow` | `ip-assignment` | `terms-and-conditions`
+- `counterparty_kebab_slug`: free-text (used in artifact filename)
+- `counterparty_legal_name`: free-text (used in artifact body; goes only to `docs/biz/legal/` confidential tier)
+
+**Refusal**: `doc_type` outside the enum → "B2C T&Cs out of scope" / "v1 doc-types are: nda | contractor-sow | ip-assignment | terms-and-conditions" (matches existing `slo-legal` SKILL.md refusal patterns).
+
+## Restate-and-confirm step
+
+After the conversation has gathered F1–F6, the skill emits a 3-5 sentence restatement:
+
+> Before I draft, let me restate what I understood:
+> - You're a UK [England & Wales] founder asking for a [contractor SOW] for [Acme Logistics Ltd].
+> - The deal value is [£3,200 ex-VAT total over a 4-month engagement] — under the £5,000 triage threshold.
+> - The counterparty does NOT have a lawyer in this matter, and they're signing your paper, not theirs.
+> - This is not a GDPR document, and no regulator is in scope.
+> - Gates evaluated: gate-1 PASS, gate-2 PASS, gate-3 PASS, gate-4 PASS — proceeding to draft.
+>
+> **Did I get that right?**
+
+On founder correction, the skill re-evaluates the four gates against the corrected input. On confirmation, the skill writes the intake values into the artifact frontmatter as `intake_summary:` and proceeds to draft.
+
+## Frontmatter contract (per artifact)
+
+The intake values land in the artifact frontmatter (extends `references/biz/artifact-schema.md`):
+
+```yaml
+intake_summary:
+  jurisdiction_self: uk-england-wales
+  jurisdiction_counterparty: uk-england-wales
+  governing_law_specified: false
+  counterparty_has_lawyer: no
+  signing_their_paper: no
+  deal_value_gbp_ex_vat: 3200
+  deal_value_basis: total-contract-value
+  deal_value_term_months: 4
+  deal_value_known_with_confidence: precise
+  gdpr_document_requested: false
+  gdpr_data_in_scope: false
+  regulator_in_scope: false
+  doc_type: contractor-sow
+  counterparty_kebab_slug: acme-logistics
+gates_evaluation:
+  gate-1-regulated: pass
+  gate-2-deal-value-over-5k: pass
+  gate-3-counterparty-has-lawyer-or-their-paper: pass
+  gate-4-gdpr-document: pass
+restated_and_confirmed: true
+restated_at: 2026-04-27T14:32:00Z
+```
+
+The `gates_evaluation:` block is the structured complement to `triage_gate_passed: bool` — a downstream test (per issue #19 M2) asserts every drafted artifact carries it AND the values match the SKILL.md gate evaluation logic.
+
+## Open extensions (runbook scope)
+
+The runbook from issue #19 should also produce four sister contracts (same conversational-elicitation discipline, different domain fields):
+
+- `accounting-intake-contract.md` — HMRC matter type, period, qualifying-activity claim type, FTE counts, founder-personal vs company-side.
+- `equity-intake-contract.md` — current cap table as structured rows, share-class breakdown, SEIS/EIS status, AA application date.
+- `fundraise-intake-contract.md` — round size GBP, planned signature date, AA application date, investor counsel y/n, lead investor identity, qualifying-trade VCM3000 audit date.
+- `hire-intake-contract.md` — role, full/part-time, expected duration, exclusivity, equipment/premises, substitution, CEST output capture.
+
+All five contracts share the F1 / F4 / F5 fields verbatim; the per-skill specifics extend. **None of the five is a form for the founder to fill.** Each is a structured destination shape for a conversational elicitation the skill drives.

--- a/references/biz/saas-kpi-targets-baseline.md
+++ b/references/biz/saas-kpi-targets-baseline.md
@@ -1,0 +1,250 @@
+---
+name: saas-kpi-targets-baseline
+created: 2026-04-27
+retrieved: 2026-04-27
+refresh_recommended_by: 2027-04-27
+status: starter — runbook from issue #20 to harden, source, and refresh annually
+audience: /slo-metrics (Runbook B2 M4) — primary consumer; /slo-fundraise + /slo-pricing + /slo-sales-funnel + /slo-product cite as needed
+purpose: |
+  Authoritative numeric baselines for SaaS KPI targets — CAC payback, gross margin, MoM
+  growth, NDR, burn multiple, runway, ARR. Replaces inlined heuristic numbers in skill
+  prose per the 2026-04-27 skill-pack review. Every claim cites a public source.
+
+  Every artifact written by /slo-metrics MUST include `baseline_ref:` frontmatter
+  pointing at this file with the retrieval-date stamp the artifact captured. Stale > 12
+  months → /slo-metrics emits a refresh warning analogous to the cost-baseline staleness
+  pattern in /slo-legal.
+---
+
+# SaaS KPI targets — sourced baseline
+
+This file replaces inlined heuristic numbers in [`skills/slo-metrics/SKILL.md`](../../skills/slo-metrics/SKILL.md), [`skills/slo-pricing/SKILL.md`](../../skills/slo-pricing/SKILL.md), [`skills/slo-sales-funnel/SKILL.md`](../../skills/slo-sales-funnel/SKILL.md), [`skills/slo-product/SKILL.md`](../../skills/slo-product/SKILL.md) per issue #20. Skill prose cites file:section, never inlines numbers.
+
+**Currency**: GBP unless otherwise stated. US-sourced benchmarks are reported as `<USD value> (≈ £<GBP value> at <fx-rate-date>)` where conversion is non-trivial; ratios and percentages are currency-agnostic.
+
+**Stage**: figures are seed-stage (post-pre-seed, pre-Series A) unless tagged otherwise. Series A and later need their own baseline file (out of scope for this starter).
+
+## Refresh discipline
+
+This file is `retrieved: 2026-04-27`. Each row has a per-source `last_checked:` field — refresh when stale > 12 months. A single stale row does NOT invalidate the file; the skill emits a per-row warning when consulting a stale value.
+
+The runbook from issue #20 should set up a `/loop @annually` agent that re-fetches each public source and opens a refresh PR. Until that lands, refresh is manual.
+
+## Schema
+
+Each KPI row carries:
+
+- `kpi_id`: stable kebab-slug (referenced by skill prose)
+- `display_name`: human-readable
+- `formula`: how to compute (so the skill emits the math, not just the target)
+- `b2b_target_seed`: seed-stage B2B target (range or single value)
+- `b2c_target_seed`: seed-stage B2C target (range or single value)
+- `watch_signal`: when to flag a problem
+- `source`: primary source URL + retrieval date
+- `last_checked`: date the source was last verified
+
+## Capital-efficiency KPIs
+
+### `kpi-burn-multiple`
+
+| field | value |
+|---|---|
+| display_name | Burn multiple |
+| formula | net cash burn (12-month trailing) ÷ net new ARR (12-month trailing) |
+| b2b_target_seed | ≤ 2 = good; 2–3 = watch; > 3 = unsustainable |
+| b2c_target_seed | Same bands as B2B (Bessemer's framework is industry-agnostic) |
+| watch_signal | > 3 for two consecutive quarters |
+| source | Bessemer Venture Partners — *State of the Cloud* annual reports + the Bessemer "Burn Multiple" framework. URL: https://www.bvp.com/atlas |
+| last_checked | 2026-04-27 |
+
+**Notes**: Bessemer's Burn Multiple framework was published 2020 and refined annually. The "≤ 2 / 2-3 / > 3" bands are stable across the framework's life. The framework is calibrated for SaaS; non-SaaS businesses (B2C marketplaces, hardware, services) need adjustment — flag in the artifact body.
+
+### `kpi-runway-months`
+
+| field | value |
+|---|---|
+| display_name | Runway (months) |
+| formula | cash on hand ÷ trailing 3-month average net burn |
+| b2b_target_seed | ≥ 18 months at any point post-funding |
+| b2c_target_seed | ≥ 18 months |
+| watch_signal | < 12 months → start fundraise prep; < 6 months → tier-2 cost cuts (see `/slo-founder-check` worst-case-runway worksheet) |
+| source | YC's standard guidance + Sequoia / Andreessen Horowitz public commentary. The 18-month figure is the consensus "minimum to comfortably fundraise into" — see e.g. https://blog.ycombinator.com/the-importance-of-runway/ (last refreshed 2024-09) |
+| last_checked | 2026-04-27 |
+
+**Notes**: The 18-month figure has been stable in YC / a16z / Sequoia commentary for over a decade. Founders' personal runway (per `/slo-founder-check`) is a separate tracker — do not conflate.
+
+## Growth KPIs
+
+### `kpi-mom-revenue-growth`
+
+| field | value |
+|---|---|
+| display_name | MoM revenue growth |
+| formula | (this month revenue − last month revenue) ÷ last month revenue |
+| b2b_target_seed | ≥ 10% MoM |
+| b2c_target_seed | ≥ 15% MoM |
+| watch_signal | B2B < 5% for 2+ months; B2C < 10% for 2+ months |
+| source | Paul Graham *Startup = Growth* essay (https://paulgraham.com/growth.html, 2012, last updated content stable) — defines 5–7% MoM as YC-cohort weekly growth → 22-30% MoM range. The 10% / 15% figures are seed-stage trade-up over post-MVP weekly cohorts; cited in OpenView "SaaS Benchmarks" annual reports (https://openviewpartners.com/saas-benchmarks/) |
+| last_checked | 2026-04-27 |
+
+**Notes**: PG's essay anchors weekly growth, not monthly; weekly 5-7% compounds to ~22-30% monthly. The 10% / 15% MoM bands here are post-traction seed-stage; pre-traction the targets are higher because the base is small.
+
+### `kpi-net-dollar-retention`
+
+| field | value |
+|---|---|
+| display_name | Net dollar retention (NDR) |
+| formula | (retained-and-expanded revenue from cohort) ÷ (original cohort revenue), measured 12 months later |
+| b2b_target_seed | ≥ 110% post-seed |
+| b2c_target_seed | NOT typically tracked at B2C consumer scale — use cohort retention curve (`kpi-cohort-retention-flatness`) instead |
+| watch_signal | < 100% (net contraction) for any 12-month cohort |
+| source | OpenView SaaS Benchmarks 2024 (https://openviewpartners.com/saas-benchmarks/) reports median NDR for early-stage B2B SaaS at 105%; top-quartile at 115%. The 110% target here is OpenView upper-half. ChartMogul *SaaS Retention Report* corroborates. |
+| last_checked | 2026-04-27 |
+
+### `kpi-cac-payback-months`
+
+| field | value |
+|---|---|
+| display_name | CAC payback period (months) |
+| formula | CAC ÷ (ARR per customer × gross margin) |
+| b2b_target_seed | ≤ 12 months |
+| b2c_target_seed | ≤ 6 months |
+| watch_signal | B2B > 18 months; B2C > 12 months |
+| source | OpenView SaaS Benchmarks 2024 reports B2B median CAC payback ~ 17 months; top-quartile ~ 8 months. The 12-month target here is mid-to-upper-quartile. Forentrepreneurs.com (David Skok) https://www.forentrepreneurs.com/saas-metrics-2/ provides the canonical formula. |
+| last_checked | 2026-04-27 |
+
+### `kpi-gross-margin`
+
+| field | value |
+|---|---|
+| display_name | Gross margin |
+| formula | (revenue − COGS) ÷ revenue |
+| b2b_target_seed | ≥ 75% (SaaS); 60-70% acceptable for managed-services SaaS |
+| b2c_target_seed | Varies wildly by category (digital subscription ≥ 80%; physical-goods D2C 30-50%); set per-business |
+| watch_signal | B2B < 65% sustained; B2C category-specific |
+| source | OpenView SaaS Benchmarks 2024 reports B2B SaaS median gross margin 73%, top-quartile 80%+. The 75% target is mid-quartile. For B2C, the variance is too large for a single number — `/slo-metrics consumer` should ask for the founder's category context. |
+| last_checked | 2026-04-27 |
+
+## B2C-specific KPIs
+
+### `kpi-cohort-retention-flatness`
+
+| field | value |
+|---|---|
+| display_name | Cohort retention curve flatness (D90 ÷ D7) |
+| formula | D90 retention rate ÷ D7 retention rate |
+| b2b_target_seed | Use W4 ÷ W1 instead (B2B cadence is weekly) |
+| b2c_target_seed | ≥ 0.6 (curve flattens — "smile"); 0.4–0.6 watch; < 0.4 (curve keeps falling — "slope") = product-market fit gap |
+| watch_signal | < 0.4 ratio |
+| source | Sequoia *Retention by the Numbers* (https://articles.sequoiacap.com/retention) + Andrew Chen *Retention curve* canonical post (https://andrewchen.com/retention-is-king/). The 0.6 threshold is Chen's "smile vs slope" framing. |
+| last_checked | 2026-04-27 |
+
+### `kpi-arpu`
+
+| field | value |
+|---|---|
+| display_name | Average revenue per paying user (ARPU) |
+| formula | total revenue ÷ paying customers, period-aligned |
+| b2b_target_seed | "Track trajectory, not target" — ARPU varies by segment 10x+ |
+| b2c_target_seed | "Track trajectory, not target" — same |
+| watch_signal | Declining > 10% / month for 2+ months → audit pricing tier mix (`/slo-pricing`) |
+| source | No single canonical source — ARPU is a tracker, not a benchmark. Skill should record period (monthly / annual), denominator definition (paying-only vs all signed-up), and anomalies. |
+| last_checked | 2026-04-27 |
+
+## NPS / satisfaction
+
+### `kpi-nps`
+
+| field | value |
+|---|---|
+| display_name | Net Promoter Score |
+| formula | % promoters (9-10) − % detractors (0-6) |
+| b2b_target_seed | ≥ 30 |
+| b2c_target_seed | ≥ 30 |
+| watch_signal | < 0 (more detractors than promoters) |
+| source | Bain & Co. canonical NPS framework (Reichheld 2003). Bain's annual NPS benchmarks by industry are public — https://www.netpromotersystem.com/about/. The "≥ 30 = good" floor is industry-agnostic; specific verticals have different medians (SaaS ~ 36, e-commerce ~ 45). |
+| last_checked | 2026-04-27 |
+
+## Outbound funnel conversion rates
+
+These are sourced from `references/biz/outbound-conversion-baselines.md` (issue #20 M1) — referenced here for completeness so `/slo-metrics` and `/slo-sales-funnel` can both cite a single authority chain.
+
+### `kpi-cold-to-meeting`
+
+| field | value |
+|---|---|
+| display_name | Cold outreach → qualified meeting |
+| b2b_target_seed | 1–3% on cold; 10–20% on warm referral |
+| source | Bridge Group SaaS Sales Development Report (https://blog.bridgegroupinc.com/sdr-metrics-and-compensation-report) reports median 1.7% cold-to-meeting; top quartile 4%+. Outreach.io public benchmarks corroborate. |
+| last_checked | 2026-04-27 |
+
+### `kpi-meeting-to-demo`
+
+| field | value |
+|---|---|
+| display_name | Qualified meeting → demo |
+| b2b_target_seed | 50% |
+| source | RAIN Group sales-conversion benchmarks (https://www.rainsalestraining.com/blog/sales-statistics) report median ~ 47% qualified-meeting-to-discovery-call. The 50% target here is rounded to mid-quartile. |
+| last_checked | 2026-04-27 |
+
+### `kpi-demo-to-verbal`
+
+| field | value |
+|---|---|
+| display_name | Demo → verbal commit |
+| b2b_target_seed | 30% |
+| source | Same as above; varies 20-40% by category. |
+| last_checked | 2026-04-27 |
+
+### `kpi-verbal-to-close`
+
+| field | value |
+|---|---|
+| display_name | Verbal commit → closed-won |
+| b2b_target_seed | 70-80% |
+| source | RAIN Group + HubSpot State of Inbound 2024 corroborate ~ 70-75% verbal-to-close in B2B SaaS. |
+| last_checked | 2026-04-27 |
+
+## Watch-signal aggregation
+
+When `/slo-metrics` or `/slo-fundraise prepare` produces an investor-update or funnel review, **the skill MUST surface every KPI watch-signal that fired** in the period. The watch-signal field is the structured forcing function — no hand-waved "things are mostly good".
+
+## Per-artifact `baseline_ref:` discipline
+
+Every artifact emitted by a skill that consults this file MUST carry:
+
+```yaml
+baseline_ref: references/biz/saas-kpi-targets-baseline.md@2026-04-27
+```
+
+The `@<retrieval-date>` is the date the SKILL.md prose CONSULTED this file (so a > 12-month gap between consultation and now triggers the staleness warning).
+
+Per issue #20 M4, a new `baseline_ref:` field is added to [`references/biz/artifact-schema.md`](artifact-schema.md) for generator outputs that cite numeric targets.
+
+## Open work for the runbook (issue #20)
+
+This starter file covers the highest-leverage rows. The runbook should:
+
+1. **Source-verify every row.** Each `source:` field is a starter citation; the runbook author should manually verify each URL, capture the page hash, and update `last_checked:`.
+2. **Extend coverage** to per-vertical benchmarks (PLG SaaS specifically; usage-based SaaS; vertical SaaS — e.g., compliance fintech vs HR SaaS — have different bands).
+3. **Add the annual refresh `/loop`** (per issue #20 M4 acceptance criteria).
+4. **Sister files**:
+   - `references/biz/outbound-conversion-baselines.md` (full funnel rates with sources)
+   - `references/biz/product-prioritization-frameworks.md` (RICE / Kano)
+   - `references/biz/value-equation-pricing.md` (the "25-33% of value" claim sourced)
+   - `references/biz/launch-success-thresholds.md` (or reframe as "set your own threshold")
+
+## Out of scope (this starter)
+
+- Series A and later targets (different bands, different file)
+- Non-UK currency adjustments beyond GBP / USD
+- Sector-specific verticals (fintech, healthtech, devtools, marketplace) — covered in the runbook follow-on
+- Forecasting / scenario modelling — `/slo-metrics` is a dashboard scaffold, not a forecaster
+
+## Cross-references
+
+- [`references/biz/artifact-schema.md`](artifact-schema.md) — `baseline_ref:` field added per issue #20 M4
+- [`skills/slo-metrics/SKILL.md`](../../skills/slo-metrics/SKILL.md) — primary consumer
+- [`skills/slo-pricing/SKILL.md`](../../skills/slo-pricing/SKILL.md), [`skills/slo-sales-funnel/SKILL.md`](../../skills/slo-sales-funnel/SKILL.md), [`skills/slo-product/SKILL.md`](../../skills/slo-product/SKILL.md) — secondary consumers
+- Issue #20 — runbook driving this file's hardening
+- Issue #21 D — `references/templates/heuristic-numbers-discipline.md` documents the "every numeric claim cites a baseline file" rule

--- a/references/biz/uk-regulator-enumeration.md
+++ b/references/biz/uk-regulator-enumeration.md
@@ -1,0 +1,143 @@
+---
+name: uk-regulator-enumeration
+created: 2026-04-27
+status: starter — runbook from issue #19 to harden + extend
+audience: every advisor skill in the biz pack (`/slo-legal`, `/slo-accounting`, `/slo-equity`, `/slo-fundraise`, `/slo-hire`)
+purpose: |
+  Closed enumeration of UK regulators with statutory enforcement powers. The
+  `gate-1-regulated` predicate in `references/biz/triage-gate.md` is evaluated by consulting
+  THIS file, not by enumerating from training memory.
+
+  Companion to `references/biz/jurisdiction-uk.md` (which is the prose-shaped overview);
+  this file is the closed canonical enum the predicate evaluation MUST match against.
+---
+
+# UK regulator enumeration — `gate-1-regulated` source-of-truth
+
+The advisor skills MUST consult this file when evaluating `gate-1-regulated`. Naming a regulator that is NOT on this list is a refusal pattern: either (a) the founder is not actually facing a regulated matter (probe further), or (b) the regulator is missing from this file and the founder should flag it as a content gap (do not bypass — extending the file is `/slo-architect` re-pass discipline).
+
+## Schema
+
+Each row is a `regulator_id` (kebab-slug, stable interface — referenced by intake forms in `references/biz/legal-intake-form.md` etc.) plus structured metadata.
+
+| Field | Type | Notes |
+|---|---|---|
+| `id` | string (kebab-slug) | Stable identifier for predicate evaluation |
+| `display_name` | string | Human-readable name |
+| `domain` | string | One-line description of regulatory scope |
+| `statutory_basis` | string | Primary legislation (Act + year) |
+| `default_route_to` | enum | `lawyer-specialist` / `lawyer` / `accountant` / `dpo` / `combined` |
+| `cited_by` | list | Which advisor skills typically cite this regulator |
+| `last_reviewed` | date (YYYY-MM-DD) | Annual cadence; stale > 12 months → refresh PR |
+
+## The enumeration (last-reviewed: 2026-04-27)
+
+### Tax + corporate
+
+| id | display_name | domain | statutory_basis | default_route_to | cited_by |
+|---|---|---|---|---|---|
+| `hmrc` | HM Revenue & Customs | Tax — corporation tax, VAT, PAYE/NI, R&D credits, SEIS/EIS, IR35 | Taxes Management Act 1970; Finance Acts; Income Tax Act 2007 (SEIS/EIS); ITEPA 2003 Chapter 10 (IR35) | `accountant` | `slo-accounting`, `slo-fundraise`, `slo-equity`, `slo-hire` |
+| `companies-house` | Companies House | Company filings, registration, beneficial ownership, persons of significant control | Companies Act 2006; Economic Crime and Corporate Transparency Act 2023 | `accountant` | `slo-equity`, `slo-accounting` |
+| `pensions-regulator` | The Pensions Regulator (TPR) | Workplace pensions auto-enrolment | Pensions Act 2008 | `accountant` | `slo-hire`, `slo-accounting` |
+
+### Data + privacy + communications
+
+| id | display_name | domain | statutory_basis | default_route_to | cited_by |
+|---|---|---|---|---|---|
+| `ico` | Information Commissioner's Office | UK GDPR; PECR; DPA 2018; FOI; Direct marketing; DUAA 2025 | Data Protection Act 2018; UK GDPR (retained); PECR 2003; DUAA 2025 | `dpo` (or `lawyer + dpo` if no DPO) | `slo-legal` (gate-4 supersedes), `slo-marketing`, `slo-sales-funnel`, `slo-accounting` (records of processing) |
+| `ofcom` | Office of Communications | Telecoms, broadcasting, postal services, online safety | Communications Act 2003; Online Safety Act 2023 | `lawyer-specialist` | `slo-legal`, `slo-marketing` |
+
+### Financial services + competition + consumer
+
+| id | display_name | domain | statutory_basis | default_route_to | cited_by |
+|---|---|---|---|---|---|
+| `fca` | Financial Conduct Authority | Financial services, regulated activities, AR/authorisation, consumer credit, financial promotion | Financial Services and Markets Act 2000 (FSMA) | `lawyer-specialist` | All four advisors |
+| `pra` | Prudential Regulation Authority | Banks, insurers, investment firms — prudential regulation | FSMA 2000 + Bank of England Act 1998 | `lawyer-specialist` | `slo-fundraise` (rare; mostly when scaling into FS) |
+| `cma` | Competition and Markets Authority | Mergers, anti-competitive conduct, consumer law (incl. DMCC 2024) | Competition Act 1998; Enterprise Act 2002; Digital Markets, Competition and Consumers Act 2024 | `lawyer-specialist` | `slo-fundraise` (round-related), `slo-legal` (B2B) |
+| `asa` | Advertising Standards Authority | Non-broadcast and broadcast advertising; CAP Code; influencer disclosure | Self-regulatory; backed by Ofcom for broadcast | `lawyer-specialist` | `slo-marketing`, `slo-launch` |
+| `tsi` | Trading Standards (via OPSS / local authorities) | Consumer protection, product safety, weights & measures, CRA 2015 enforcement | Consumer Rights Act 2015; Consumer Protection from Unfair Trading Regulations 2008 | `lawyer-specialist` | `slo-pricing` (B2C subscription), `slo-marketing` (B2C) |
+
+### Health + life sciences + medicines
+
+| id | display_name | domain | statutory_basis | default_route_to | cited_by |
+|---|---|---|---|---|---|
+| `mhra` | Medicines and Healthcare products Regulatory Agency | Medicines, medical devices, clinical trials | Medicines Act 1968; Human Medicines Regulations 2012; Medical Devices Regulations 2002 | `lawyer-specialist` + `accountant` (R&D context) | `slo-equity`, `slo-fundraise` |
+| `cqc` | Care Quality Commission | Health and social care providers (England) | Health and Social Care Act 2008 | `lawyer-specialist` | All four advisors |
+| `gmc` | General Medical Council | Medical practitioners | Medical Act 1983 | `lawyer-specialist` | Rare in seed-stage context; flag if relevant |
+| `nmc` | Nursing and Midwifery Council | Nursing and midwifery practitioners | Nursing and Midwifery Order 2001 | `lawyer-specialist` | Rare |
+| `hcpc` | Health and Care Professions Council | Allied health professionals (16 professions) | Health Professions Order 2001 | `lawyer-specialist` | Rare |
+
+### Workplace + employment
+
+| id | display_name | domain | statutory_basis | default_route_to | cited_by |
+|---|---|---|---|---|---|
+| `hse` | Health and Safety Executive | Workplace health & safety | Health and Safety at Work etc. Act 1974 | `lawyer-specialist` (employment) | `slo-hire` |
+| `ehrc` | Equality and Human Rights Commission | Equality law enforcement | Equality Act 2006 + Equality Act 2010 | `lawyer-specialist` (employment) | `slo-hire`, `slo-marketing` (B2C anti-discrimination) |
+
+### Utilities + sector regulators
+
+| id | display_name | domain | statutory_basis | default_route_to | cited_by |
+|---|---|---|---|---|---|
+| `ofgem` | Office of Gas and Electricity Markets | Energy markets | Gas Act 1986; Electricity Act 1989; Utilities Act 2000 | `lawyer-specialist` | Rare |
+| `ofwat` | Water Services Regulation Authority | Water and sewerage | Water Industry Act 1991 | `lawyer-specialist` | Rare |
+| `ofsted` | Office for Standards in Education, Children's Services and Skills | Education and children's services | Education Acts; Care Standards Act 2000 | `lawyer-specialist` | Rare |
+| `caa` | Civil Aviation Authority | Civil aviation, drones (UAS) | Civil Aviation Act 2012 + Air Navigation Order | `lawyer-specialist` | Rare; flag if drones / aviation in scope |
+
+### Sector-specific (environment + others)
+
+| id | display_name | domain | statutory_basis | default_route_to | cited_by |
+|---|---|---|---|---|---|
+| `environment-agency` | Environment Agency (England) | Environmental permits, waste, water resources | Environment Act 2021; Environmental Permitting Regulations 2016 | `lawyer-specialist` | Rare |
+| `charity-commission` | Charity Commission for England and Wales | Registered charities | Charities Act 2011 | `lawyer-specialist` (charity law) | If founder is operating CIC / charity vehicle alongside |
+| `oisc` | Office of the Immigration Services Commissioner | Immigration advisers | Immigration and Asylum Act 1999 Part V | `lawyer-specialist` | Rare; flag if visa-sponsorship business |
+| `solicitors-regulation-authority` | Solicitors Regulation Authority (SRA) | Solicitors and law firms | Legal Services Act 2007 | `lawyer-specialist` | If founder is a regulated legal-tech provider |
+
+## Per-skill routing override patterns
+
+The `default_route_to` value is the floor; advisor skills MAY override based on which regulator's domain is most relevant:
+
+- **`/slo-accounting`** routes HMRC / Companies House / Pensions Regulator firings to **accountant** (overrides the gate-1 lawyer default per the per-skill override pattern). Cross-discipline matters (e.g., FCA-regulated activity with accounting consequences) route to **lawyer-specialist + accountant**.
+- **`/slo-fundraise`** routes HMRC SEIS/EIS firings to **accountant** for the qualifying-trade determination; routes Companies House share-allotment firings to **lawyer + accountant**; routes FCA financial-promotion concerns to **lawyer-specialist**.
+- **`/slo-equity`** routes Companies House cap-table firings to **lawyer + accountant** (cap-table changes are corporate-secretarial *and* tax-relevant).
+- **`/slo-hire`** routes Pensions Regulator + HSE + EHRC firings — combined as appropriate.
+- **`/slo-legal`** routes ICO firings to `dpo (or lawyer + dpo if no DPO)` per gate-4 supersedence.
+
+## Predicate evaluation procedure
+
+When `slo-legal` (or any advisor skill) evaluates `gate-1-regulated`:
+
+1. Read `intake_summary.regulator_in_scope` from the structured intake form.
+2. If `false`, gate-1 passes.
+3. If `true`, read `intake_summary.regulator_id` and look it up in the table above.
+4. **If `regulator_id` is not in the table, refuse**. Do not match heuristically. Either (a) the founder confirms it's not the body they mean and picks from the closed enum, or (b) the gap is flagged as a follow-up content extension.
+5. If found, gate-1 fires unless `intake_summary.regulator_relationship == incidental`. Route to the regulator's `default_route_to`, applying the per-skill override pattern above.
+
+## Adding a new regulator
+
+This file is `status: stable-interface` — append-only without a `/slo-architect` re-pass; no removals or `id` renames.
+
+**Append procedure**:
+
+1. Add a row to the appropriate sub-table.
+2. Bump `last_reviewed:` to the date of the append.
+3. Add a structural-contract test in `crates/sldo-install/tests/` (per issue #19 M5 acceptance criteria) that asserts the new `id` is referenced by at least one advisor SKILL.md.
+4. `/slo-critique` security-persona review of the new row before merge.
+
+## Annual refresh
+
+The file's `last_reviewed:` triggers a refresh PR when stale > 12 months. The skill emits a warning analogous to the cost-baseline staleness pattern in `/slo-legal` SKILL.md if any advisor skill consults a > 12-month-stale enumeration.
+
+## Out of scope
+
+- Devolved-administration variations beyond E&W (Scottish-only / NI-only regulators flagged in the `domain:` column rather than as separate rows).
+- Self-regulatory bodies without statutory backing (these don't fire `gate-1-regulated`; they may be cited in body prose for completeness).
+- Non-UK regulators (v1 jurisdiction stance per `references/biz/jurisdiction-uk.md`).
+
+## Cross-references
+
+- `references/biz/triage-gate.md` — the predicate this file resolves.
+- `references/biz/jurisdiction-uk.md` — narrative version of UK regulator scope.
+- `references/biz/legal-intake-form.md` — F5 field uses `id` values from this file as the closed enum.
+- `references/biz/hmrc-vcm-index.md` — HMRC VCM-specific anchors for SEIS/EIS firings.
+- `references/biz/ico-duaa-index.md` — ICO DUAA 2025 anchors for ICO firings.
+- `references/biz/ir35-cest-factors.md` — HMRC IR35 specifics for `slo-hire`.

--- a/skills/README.md
+++ b/skills/README.md
@@ -21,25 +21,31 @@ From the repo root:
 
 ```bash
 cargo build --release --bin sldo-install
-./target/release/sldo-install          # global install: ~/.claude/skills/<name>/
-./target/release/sldo-install --local  # project-local: ./.claude/skills/<name>/
+./target/release/sldo-install                          # global Claude Code install: ~/.claude/skills/<name>/
+./target/release/sldo-install --host github-copilot   # global GitHub Copilot install: ~/.copilot/skills/<name>/
+./target/release/sldo-install --local                  # project-local Claude Code install: ./.claude/skills/<name>/
+./target/release/sldo-install --host github-copilot --local
+                                                       # project-local GitHub Copilot install: ./.copilot/skills/<name>/
 ```
 
-Running the installer twice is a no-op. Pass `--force` to replace an existing symlink that points somewhere else. Pass `--dry-run` to see what would change.
+Running the installer twice is a no-op. `claude-code` is the default host if you do not pass `--host`. Pass `--force` to replace an existing symlink that points somewhere else. Pass `--dry-run` to see what would change.
 
 ## Uninstall
 
 ```bash
 ./target/release/sldo-install uninstall
+./target/release/sldo-install --host github-copilot uninstall
 ```
 
-Only removes symlinks the installer created (recorded in `~/.sldo/install.toml`). Manual customizations are preserved.
+Only removes symlinks the installer created for the selected host (recorded in `~/.sldo/install.toml` for global installs, or the host-local manifest for `--local`). Manual customizations are preserved.
 
 ## Status and verification
 
 ```bash
-./target/release/sldo-install status   # list installed skills
-./target/release/sldo-install verify   # check symlinks still match manifest
+./target/release/sldo-install status                         # list Claude Code installs
+./target/release/sldo-install verify                         # verify Claude Code installs
+./target/release/sldo-install --host github-copilot status  # list GitHub Copilot installs
+./target/release/sldo-install --host github-copilot verify  # verify GitHub Copilot installs
 ```
 
 ## Adding a new skill

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,6 +1,8 @@
 # SunLitOrchestrate Skill Pack
 
-Source of truth for every `/slo-*` skill plus any third-party skills vendored into this pack. Each subdirectory here is one skill; each must contain a `SKILL.md` with YAML frontmatter (`name`, `description`) followed by the skill body.
+This directory is the raw source for every `/slo-*` skill plus any third-party skills vendored into the pack. Each subdirectory here is one skill; each must contain a `SKILL.md` with YAML frontmatter (`name`, `description`) followed by the skill body.
+
+The canonical living catalog is [../docs/skill-pack-catalog.md](../docs/skill-pack-catalog.md). Host-specific session overlays live in [../CLAUDE.md](../CLAUDE.md) and [../copilot-instructions.md](../copilot-instructions.md). The first-run guide lives in [../docs/getting-started.md](../docs/getting-started.md).
 
 ## Layout
 

--- a/skills/slo-research/SKILL.md
+++ b/skills/slo-research/SKILL.md
@@ -3,15 +3,21 @@ name: slo-research
 description: >
   Use this skill after /slo-ideate produces an idea doc, when the user says
   "research this", "check the market", "what's out there", "is this viable",
-  or when a design decision depends on data the codebase cannot answer. Wraps
-  the sldo-research Rust pipeline to produce a sourced dossier covering market,
-  competitors, technical prior art, and regulatory constraints. Do not use for
-  third-party library API reference — that is get-api-docs / chub.
+  or when a design decision depends on data the codebase cannot answer. Use
+  host-native research tools first to produce a sourced dossier covering
+  market, competitors, technical prior art, and regulatory constraints. An
+  optional Claude batch backend exists for users who explicitly want it. Do not
+  use for third-party library API reference — that is get-api-docs / chub.
 ---
 
-# /slo-research — run the research pipeline on an idea
+# /slo-research — research an idea with host-native tools first
 
-You are a senior analyst. You have one tool: the existing `sldo-research` Rust binary. Your job is to frame the research prompt tightly, dispatch the run, and gate the output against minimum quality bars. You do not do research in your head or from training data.
+You are a senior analyst. Your default path is host-native research tools:
+web search/fetch if the host provides them, repository reads, and explicit file
+writes into `docs/research/<slug>/`. Do not do research in your head or from
+training data. If the user explicitly wants automation through the optional
+Claude batch backend, you may use `sldo-research`, but that is a separate path
+and never the only way to run this skill.
 
 ## Inputs
 
@@ -28,28 +34,50 @@ Three files under `docs/research/<slug>/`:
 
 ## Pre-flight
 
-1. Check `which sldo-research`. If not on PATH, print:
-   > `sldo-research` CLI not found. Build it with `cargo install --path crates/sldo-research` from the repo root.
-   Then exit non-zero.
-2. Read the idea doc. If it does not have an "Open questions for /slo-research" section, refuse: tell the user to finish `/slo-ideate` first.
-3. If `docs/research/<slug>/dossier.md` already exists, surface it and ask whether to re-run (overwrites) or extend (appends a new section).
+1. Read the idea doc. If it does not have an "Open questions for /slo-research" section, refuse: tell the user to finish `/slo-ideate` first.
+2. If `docs/research/<slug>/dossier.md` already exists, surface it and ask whether to re-run (overwrites) or extend (appends a new section).
+3. Tell the user which path you are taking:
+   - `interactive host-native research` is the default.
+   - `optional Claude batch backend` is allowed only when the user explicitly asks for that path or when the session already depends on `sldo-research` for a deliberate automation reason.
 
-## Method
+## Method — interactive host-native research
 
-1. **Frame the brief.** Translate the idea doc's open questions into a prompt for `sldo-research`. Include:
+1. **Frame the brief.** Translate the idea doc's open questions into a research plan. Include:
    - the wedge (one sentence from the idea doc)
    - the target user (one sentence from the idea doc)
    - up to five specific, answerable research questions
    Do not include vague asks like "competitors" alone — specify "direct competitors", "adjacent tools", "prior art in <domain>".
-2. **Dispatch.** Shell out: `sldo-research <prompt-file> <repo-dir> -o docs/research/<slug>/raw.md` (or whatever flags the current version supports — check `sldo-research --help` if unsure).
-3. **Gate the output.** The dossier is not complete unless it has:
+2. **Research with host-native tools.** Use the host's own research capabilities first:
+   - web search and fetch for current sources
+   - repository reads when the idea depends on existing code or docs
+   - explicit notes while you gather evidence
+   Every factual claim must end up traceable to a source URL or to a clearly labeled repo-local artifact.
+3. **Write the three artifact files directly.**
+   - `docs/research/<slug>/dossier.md`
+   - `docs/research/<slug>/sources.md`
+   - `docs/research/<slug>/synthesis.md`
+4. **Gate the output.** The dossier is not complete unless it has:
    - ≥ 3 sourced competitor comparisons with names, pricing, and one concrete feature difference each
    - ≥ 1 technical prior-art reference (a library, paper, or open-source project)
    - at least one regulatory/legal flag OR an explicit "none apply and here is why"
    - every claim in `dossier.md` backed by a URL in `sources.md`
    If any of these is missing, set `incomplete: true` in the dossier frontmatter and surface the gaps — do not paper over them.
-4. **Synthesize.** Write `synthesis.md`. Every paragraph must end with "the design must handle <X> because <source>." If you cannot write that sentence, the finding is not actionable and belongs in open-questions instead.
-5. **Hand off.** Suggest the next step: `/slo-architect <slug>`.
+5. **Synthesize.** Write `synthesis.md`. Every paragraph must end with "the design must handle <X> because <source>." If you cannot write that sentence, the finding is not actionable and belongs in open-questions instead.
+6. **Hand off.** Suggest the next step: `/slo-architect <slug>`.
+
+## Optional path — optional Claude batch backend
+
+Use this only when the user explicitly wants the batch backend or when you are
+already in a Claude-specific automation flow and the distinction is visible to
+the user.
+
+1. Check `which sldo-research`. If not on PATH, print:
+   > `sldo-research` CLI not found. Build it with `cargo install --path crates/sldo-research` from the repo root.
+   Then exit non-zero.
+2. Run `sldo-research --help` once if you need to confirm the current CLI flags before dispatch.
+3. Build a prompt file from the idea doc's wedge, target user, and up to five specific research questions.
+4. Dispatch the batch backend with an explicit note that this is the optional Claude batch backend, not the default interactive path.
+5. Read the batch output critically. If it misses the required bars, keep `incomplete: true` visible and tell the user what is missing.
 
 ## Dossier shape
 
@@ -88,6 +116,7 @@ incomplete: false
 - Inventing competitors from training knowledge — refuse and say "the pipeline found no competitors; either the idea is novel or the query was wrong". Never invent.
 - Filling "incomplete" with a pass — if three competitors cannot be found, mark incomplete. Downstream skills use this flag.
 - Summarizing the idea doc in the synthesis — synthesis is about what you learned from outside, not a restatement of the pitch.
+- Telling GitHub Copilot users to install Claude just to use `/slo-research` interactively. The interactive path must remain usable without installing Claude.
 
 ## Note on chub / get-api-docs
 


### PR DESCRIPTION
## What changed
- rewrote the top-level onboarding docs around the current agent-host reality, including a refreshed `README`, a first-run guide, a capability matrix, and runbook/design/critique/completion notes for the new work
- expanded `sldo-install` host-awareness with manifest/path/install updates and added agent-host end-to-end coverage for install, status, verify, and compatibility behavior
- changed `/slo-research` guidance to prefer host-native interactive research by default, while keeping `sldo-research` as an optional Claude-specific batch backend
- added the GitHub Copilot overlay plus shared UK business references for legal intake, KPI baselines, and regulator enumeration

## Why
- onboarding had drifted away from the actual supported-host story, which made install paths, capability boundaries, and expected workflows harder to understand
- `/slo-research` was still steering interactive users toward a backend-first path even when the host could do the research natively
- the documentation and shared references needed a cleaner structure so future runbooks, critiques, and lessons stay discoverable

## Impact
- new users get a clearer setup path for Claude Code and GitHub Copilot, including where installs land and which flows are host-specific
- installer behavior is covered by explicit regression tests around host separation, manifest migration, and verification
- interactive research sessions now start from the host-native path instead of assuming the batch backend
- business-oriented skills can reuse more consistent shared reference material

## Validation
- `cargo test -p sldo-common -p sldo-install -p sldo-research`