### PR TITLE
agent-host: skill pack works in Claude Code and GitHub Copilot

### DIFF
--- a/crates/sldo-common/src/claude_cli.rs
+++ b/crates/sldo-common/src/claude_cli.rs
@@ -1,7 +1,17 @@
-//! Claude Code CLI invocation.
+//! Claude Code CLI invocation — Claude-specific batch automation helper.
 //!
-//! Builds and executes a `claude` CLI command, piping output to both the
-//! terminal and a log file.
+//! This module is explicitly Claude-only. It builds and executes a `claude`
+//! CLI command, piping output to both the terminal and a log file. It is the
+//! shared helper used by `sldo-research` (the optional Claude batch backend
+//! for `/slo-research`) and by any other Rust path that drives Claude
+//! noninteractively. It is NOT a host-neutral runtime abstraction: there is
+//! no second backend behind a trait. If a future host needs noninteractive
+//! automation, build the new helper alongside this one — do not generalise
+//! prematurely.
+//!
+//! Naming history: this file was previously `copilot.rs` even though every
+//! line of its body invoked `claude`. The rename in agent-host milestone 4
+//! makes the boundary honest in the source tree itself.
 
 use anyhow::{Context, Result};
 use std::io::{BufRead, BufReader};
@@ -20,8 +30,8 @@ pub struct ClaudeInvocation {
 }
 
 impl ClaudeInvocation {
-    /// Spawn the copilot process, pipe stdout/stderr to both the terminal and
-    /// the log file, and return the exit code.
+    /// Spawn the `claude` process, pipe stdout/stderr to both the terminal
+    /// and the log file, and return the exit code.
     pub fn run(&self, log_file: &LogFile) -> Result<i32> {
         self.run_with_callback(log_file, |line, stream| match stream {
             "stdout" => println!("{}", line),
@@ -29,13 +39,13 @@ impl ClaudeInvocation {
         })
     }
 
-    /// Spawn the copilot process, calling `on_line` for each stdout/stderr line
-    /// instead of printing directly. The callback receives the line content and
-    /// the stream name (`"stdout"` or `"stderr"`).
+    /// Spawn the `claude` process, calling `on_line` for each stdout/stderr
+    /// line instead of printing directly. The callback receives the line
+    /// content and the stream name (`"stdout"` or `"stderr"`).
     ///
     /// Stdout and stderr are read concurrently via separate threads to avoid
-    /// pipe-buffer deadlocks (the classic sequential-read problem where a full
-    /// stderr buffer blocks the child while we're still draining stdout).
+    /// pipe-buffer deadlocks (the classic sequential-read problem where a
+    /// full stderr buffer blocks the child while we're still draining stdout).
     pub fn run_with_callback<F>(&self, log_file: &LogFile, mut on_line: F) -> Result<i32>
     where
         F: FnMut(&str, &str),
@@ -160,7 +170,6 @@ mod tests {
         // Then: It either succeeds (claude exists) or returns an error (not panics)
         match result {
             Ok(code) => {
-                // claude existed, we got some exit code
                 let _ = code;
             }
             Err(e) => {
@@ -192,9 +201,9 @@ mod tests {
 
     #[test]
     fn run_with_callback_receives_all_lines() {
-        // Given: A CopilotInvocation using `echo` as a mock for copilot
-        // We can't easily mock copilot, but we can test the callback signature
-        // and verify backward compatibility of run() via run_with_callback.
+        // Given: A ClaudeInvocation. We can't easily mock claude, but we can
+        // exercise the callback signature and verify backward compatibility
+        // of run() via run_with_callback.
         let tmp = std::env::temp_dir().join("sldo_test_callback");
         let _ = std::fs::remove_dir_all(&tmp);
         std::fs::create_dir_all(&tmp).unwrap();
@@ -234,7 +243,7 @@ mod tests {
 
     #[test]
     fn run_still_works_after_refactor() {
-        // Given: A CopilotInvocation (backward compatibility test)
+        // Given: A ClaudeInvocation (backward compatibility test)
         let tmp = std::env::temp_dir().join("sldo_test_run_compat");
         let _ = std::fs::remove_dir_all(&tmp);
         std::fs::create_dir_all(&tmp).unwrap();

--- a/crates/sldo-common/src/lib.rs
+++ b/crates/sldo-common/src/lib.rs
@@ -1,7 +1,7 @@
 //! sldo-common — shared library for SunLitOrchestrate Rust tools.
 
+pub mod claude_cli;
 pub mod color;
-pub mod copilot;
 pub mod detect;
 pub mod git;
 pub mod logging;

--- a/crates/sldo-common/src/preflight.rs
+++ b/crates/sldo-common/src/preflight.rs
@@ -1,4 +1,10 @@
 //! Pre-flight validation checks.
+//!
+//! Includes a Claude-CLI presence check used by the optional `sldo-research`
+//! Claude batch backend. The check is explicitly Claude-specific — there is
+//! no host-neutral "is an agent CLI on PATH" abstraction here, and inventing
+//! one would hide the same dependency the agent-host milestones removed from
+//! the interactive `/slo-research` skill.
 
 use anyhow::{bail, Context, Result};
 use std::path::{Path, PathBuf};
@@ -6,6 +12,10 @@ use std::path::{Path, PathBuf};
 use crate::git;
 
 /// Check that the `claude` CLI is installed and return its path.
+///
+/// Used by the optional Claude batch backend `sldo-research`. Callers that
+/// run host-natively (the interactive `/slo-research` path, for example)
+/// must not call this — the interactive path is host-neutral by design.
 pub fn check_claude_installed() -> Result<PathBuf> {
     which::which("claude").context(
         "Claude Code CLI ('claude') not found on PATH. \

--- a/crates/sldo-install/tests/common/claude_runtime.rs
+++ b/crates/sldo-install/tests/common/claude_runtime.rs
@@ -1,22 +1,38 @@
-//! Runtime harness for biz-pack judgment fixtures.
+//! Claude-only live runtime harness for biz-pack judgment fixtures.
 //!
-//! Drives `claude -p` against a single fixture in an isolated tempdir, walks
-//! the resulting `docs/biz/` + `docs/biz-public/` for an artifact, parses its
-//! frontmatter, and produces a `FixtureResult` the test files assert on.
+//! This module is explicitly Claude-specific. It drives `claude -p` against
+//! a single fixture in an isolated tempdir, walks the resulting `docs/biz/`
+//! + `docs/biz-public/` for an artifact, parses its frontmatter, and
+//! produces a `FixtureResult` the test files assert on. There is no
+//! host-neutral runtime abstraction here — agent-host milestone 4
+//! deliberately renamed this module from the previous host-neutral
+//! `judgment_runtime` name so the source tree itself signals the boundary.
 //!
 //! Stdlib + `tempfile` only — no regex / yaml / serde crates. Fixture
 //! frontmatter is flat key:value, parsed line-by-line.
 //!
 //! Surfaces guarded:
-//! - HOME redirected to `<tempdir>/home` so the harness never touches the
-//!   user's real `~/.claude/` (Proactive Control C8 — protect data
-//!   everywhere).
+//! - The per-fixture tempdir at `cwd` constrains where files are written
+//!   (the assertion target). HOME is intentionally NOT redirected — see
+//!   `invoke_claude` for why (auth via Claude's keychain / OAuth lives in
+//!   real `$HOME/.claude/`). The harness still never writes into the user's
+//!   real host state because the working directory and `--add-dir` are
+//!   pinned to the tempdir.
 //! - Fixture path must live under `references/biz/judgment-fixtures/`;
 //!   parsing aborts on path-traversal-shaped inputs (Proactive Control C5
 //!   — validate all inputs).
 //! - Multiple-artifact-write is an error, not silent first-wins (defends
 //!   against a skill that writes both an artifact AND an explanation file
 //!   under docs/biz/, which would muddy assertions).
+//!
+//! Env-var compatibility (agent-host M4):
+//! - `BIZ_JUDGMENT_RUNTIME_CLAUDE_BIN` keeps its existing name. The variable
+//!   was already explicitly Claude-named, so the file rename does not
+//!   require a new alias.
+//! - `BIZ_JUDGMENT_RUNTIME_LIVE`, `BIZ_JUDGMENT_RUNTIME_GLOBAL_BUDGET_USD`,
+//!   and `BIZ_JUDGMENT_RUNTIME_RETRIES` likewise keep their names — they
+//!   are scoped to the biz-pack judgment fixtures and renaming them would
+//!   break user automation for no behavior gain.
 
 #![allow(dead_code)] // helpers used selectively by per-milestone test files
 

--- a/crates/sldo-install/tests/common/mod.rs
+++ b/crates/sldo-install/tests/common/mod.rs
@@ -1,1 +1,1 @@
-pub mod judgment_runtime;
+pub mod claude_runtime;

--- a/crates/sldo-install/tests/e2e_agent_host_m5.rs
+++ b/crates/sldo-install/tests/e2e_agent_host_m5.rs
@@ -1,0 +1,116 @@
+//! Agent-host M5 — structural guards for targeted skill + structural-test
+//! cleanup.
+//!
+//! These tests defend two contracts:
+//!
+//! 1. **Host-neutral skills must not hide a Claude-only requirement.** The
+//!    relevant skills (`/slo-second-opinion`, `/slo-rulegen`) describe logic
+//!    that is host-neutral; their copy must use neutral wording where the
+//!    behavior does not actually require Claude.
+//! 2. **Explicit Claude-only surfaces remain marked as Claude-only.** The
+//!    capability matrix at `docs/design/agent-host-capabilities.md` must
+//!    keep its honest "Not supported yet" / Claude-only rows. M5 is not a
+//!    repo-wide "replace Claude everywhere" pass.
+
+use std::fs;
+use std::path::PathBuf;
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("crate dir parent")
+        .parent()
+        .expect("workspace root")
+        .to_path_buf()
+}
+
+fn skill(name: &str) -> String {
+    fs::read_to_string(repo_root().join("skills").join(name).join("SKILL.md"))
+        .unwrap_or_else(|e| panic!("{name} SKILL.md missing: {e}"))
+}
+
+fn capability_matrix() -> String {
+    fs::read_to_string(repo_root().join("docs/design/agent-host-capabilities.md"))
+        .expect("agent-host-capabilities.md present")
+}
+
+#[test]
+fn test_host_neutral_skills_have_no_hidden_claude_requirement() {
+    // Given: `/slo-second-opinion` describes a comparison whose host-neutral
+    // half is "the current host". Its diff-of-findings table column
+    // historically said "Claude said", which baked Claude into the
+    // host-neutral logic.
+    // When: the skill body is read after the M5 cleanup.
+    // Then: the column reads "current host said" (or similar host-neutral
+    // wording), and any "asking Claude to pretend" language has been
+    // rewritten to "the current host" so a reader in Copilot is not told
+    // their host is Claude.
+    let so = skill("slo-second-opinion");
+    assert!(
+        !so.contains("Claude said"),
+        "/slo-second-opinion still contains the 'Claude said' diff-table column header — \
+         this column describes the current host's review and must read 'current host said' \
+         (or similar) so the table is host-neutral"
+    );
+    let so_lower = so.to_lowercase();
+    assert!(
+        so_lower.contains("current host said") || so_lower.contains("current host's"),
+        "/slo-second-opinion must include host-neutral wording such as 'current host said' \
+         in the diff-of-findings table after M5"
+    );
+    assert!(
+        !so.contains("asking Claude to"),
+        "/slo-second-opinion still contains 'asking Claude to' phrasing — the silent-fallback \
+         rule should refer to the current host, not assume the reader is in Claude"
+    );
+
+    // Given: `/slo-rulegen` describes a workflow that takes a bug summary
+    // produced by an agent-driven loop. The summary's *origin* does not
+    // need to be Claude.
+    // When: the skill is read after M5.
+    // Then: the description does not single out Claude as the bug-finder.
+    let rg = skill("slo-rulegen");
+    assert!(
+        !rg.contains("Claude-found bug"),
+        "/slo-rulegen description still says 'Claude-found bug' — the bug summary can come \
+         from any agent-driven workflow, so the wording should be host-neutral"
+    );
+}
+
+#[test]
+fn test_explicit_claude_only_skills_are_marked_in_capability_matrix() {
+    // Given: some surfaces remain Claude-only (the optional `sldo-research`
+    // batch backend; the live business-judgment runtime harness).
+    // When: the capability matrix is read.
+    // Then: it still names those surfaces explicitly as Claude-only, and
+    // calls out the GitHub Copilot side as "Not supported yet" rather than
+    // pretending parity.
+    let matrix = capability_matrix();
+
+    assert!(
+        matrix.contains("Optional Claude batch backend") || matrix.contains("Claude batch backend"),
+        "capability matrix must continue to name `sldo-research` as the optional Claude \
+         batch backend so the boundary is honest"
+    );
+    assert!(
+        matrix.contains("Live business judgment runtime harness")
+            || matrix.contains("live business judgment runtime"),
+        "capability matrix must continue to name the live business judgment runtime as a \
+         Claude-only path"
+    );
+    let lower = matrix.to_lowercase();
+    assert!(
+        lower.contains("not supported yet"),
+        "capability matrix must keep at least one explicit 'Not supported yet' row so the \
+         host story stays honest about Copilot-side automation gaps"
+    );
+
+    // The matrix must also note `/slo-second-opinion` in the per-skill
+    // notes — not as a Claude-only skill, but as one whose host-neutral
+    // half is "the current host" (M5 added this clarification so future
+    // readers understand the skill's design).
+    assert!(
+        matrix.contains("/slo-second-opinion"),
+        "capability matrix must record a per-skill note for /slo-second-opinion after M5"
+    );
+}

--- a/crates/sldo-install/tests/e2e_biz_judgment_runtime_m1.rs
+++ b/crates/sldo-install/tests/e2e_biz_judgment_runtime_m1.rs
@@ -1,7 +1,8 @@
 //! M1 — biz-pack judgment runtime harness, single-fixture proof.
 //!
-//! This file is the first runtime user of `tests/common/judgment_runtime.rs`.
-//! It runs ONE fixture (`ir35-genuine-contractor.md`) end-to-end:
+//! This file is the first runtime user of `tests/common/claude_runtime.rs`
+//! (named `judgment_runtime.rs` before agent-host M4). It runs ONE fixture
+//! (`ir35-genuine-contractor.md`) end-to-end:
 //!   1. parse the fixture
 //!   2. build a tempdir with skills + references symlinked, HOME redirected
 //!   3. invoke `claude -p` with a budget cap
@@ -20,7 +21,7 @@ mod common;
 
 use std::time::Duration;
 
-use common::judgment_runtime::{
+use common::claude_runtime::{
     claude_available, discover_artifact, invoke_claude, repo_root, skip_if_not_live,
     JudgmentFixture, TempRepo,
 };

--- a/crates/sldo-install/tests/e2e_biz_judgment_runtime_m2.rs
+++ b/crates/sldo-install/tests/e2e_biz_judgment_runtime_m2.rs
@@ -15,7 +15,7 @@
 
 mod common;
 
-use common::judgment_runtime::{
+use common::claude_runtime::{
     assert_expectations, claude_available, global_budget_usd, repo_root, retries, run_fixture,
     skip_if_not_live, JudgmentFixture, DEFAULT_PER_FIXTURE_BUDGET_USD,
 };

--- a/crates/sldo-install/tests/e2e_slo_sp_m8.rs
+++ b/crates/sldo-install/tests/e2e_slo_sp_m8.rs
@@ -58,6 +58,14 @@ fn second_opinion_is_disagreement_finder_not_arbitrator() {
             || lower.contains("not a verdict"),
         "skill must explicitly reject vote/arbitration framing"
     );
+    // Host-neutral wording (agent-host M5): the current-host half of the
+    // comparison must not be hardcoded to "Claude" because the skill works
+    // in any host that can shell out to a second-opinion provider CLI.
+    assert!(
+        !body.contains("Claude said"),
+        "diff-of-findings table must use host-neutral wording (e.g. 'current host said'), \
+         not 'Claude said' — see agent-host M5 cleanup"
+    );
 }
 
 #[test]

--- a/crates/sldo-research/src/research.rs
+++ b/crates/sldo-research/src/research.rs
@@ -21,8 +21,8 @@ use std::time::Duration;
 
 use anyhow::{Context, Result};
 
+use sldo_common::claude_cli::ClaudeInvocation;
 use sldo_common::color::warn;
-use sldo_common::copilot::ClaudeInvocation;
 use sldo_common::logging::LogFile;
 use sldo_common::toolflags;
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -76,12 +76,12 @@ The root package `sunlit-orchestrate-tests` hosts workspace-level integration te
 
 | Module | Responsibility |
 |---|---|
+| `claude_cli` | Claude-CLI invocation helper used by the optional Claude batch backend in `sldo-research`. Explicitly Claude-only — there is no host-neutral runtime abstraction. |
 | `color` | Small color and output helpers |
-| `copilot` | Agent/CLI invocation helpers used by the Rust backends |
 | `detect` | Environment and tool detection helpers |
 | `git` | Git inspection helpers |
 | `logging` | Logging setup and formatting |
-| `preflight` | Pre-run checks for required binaries and environment state |
+| `preflight` | Pre-run checks for required binaries and environment state, including the Claude-CLI presence check used by `sldo-research`. |
 | `runbook` | Shared runbook parsing and validation helpers |
 | `toolflags` | Shared allow-flag definitions and related helpers |
 
@@ -136,6 +136,8 @@ The current host line is simple:
 - Interactive skill use is supported in Claude Code and GitHub Copilot.
 - Headless runtime automation is still Claude-specific where it exists today.
 - `/slo-research` interactive use is multi-host today; `sldo-research` remains an optional Claude batch backend.
-- The live business judgment runtime harness remains a Claude-only path.
+- `/slo-second-opinion` is host-neutral: it compares the current host against an external provider CLI (Codex or Gemini), and never silently falls back to asking the current host to imitate the other provider.
+- `/slo-rulegen` and `/slo-sast` are host-neutral; their subprocess discipline targets `git`, `gh`, and `semgrep` rather than any agent CLI.
+- The live business judgment runtime harness remains a Claude-only path. The helper module (`crates/sldo-install/tests/common/claude_runtime.rs`) and its env vars (`BIZ_JUDGMENT_RUNTIME_*`) are explicitly Claude-named.
 
 Read `docs/design/agent-host-capabilities.md` before making any stronger host-compatibility promise than that.

--- a/docs/RUNBOOK-AGENT-HOST-COMPATIBILITY.md
+++ b/docs/RUNBOOK-AGENT-HOST-COMPATIBILITY.md
@@ -39,9 +39,9 @@ Update this table as each milestone is completed. This is the single source of t
 |---|---|---|---|---|---|---|
 | 1 | Installer host profiles | `done` | 2026-04-29 | 2026-04-29 | `docs/lessons/agent-host-m1.md` | `docs/completion/agent-host-m1.md` |
 | 2 | Living docs, getting started, and host overlays | `done` | 2026-04-29 | 2026-04-29 | `docs/lessons/agent-host-m2.md` | `docs/completion/agent-host-m2.md` |
-| 3 | Agent-neutral `/slo-research` interactive path | `in_progress` | 2026-04-29 | | | |
-| 4 | Isolate Claude-only automation surfaces | `not_started` | | | | |
-| 5 | Targeted skill and structural-test cleanup | `not_started` | | | | |
+| 3 | Agent-neutral `/slo-research` interactive path | `done` | 2026-04-29 | 2026-04-30 | `docs/lessons/agent-host-m3.md` | `docs/completion/agent-host-m3.md` |
+| 4 | Isolate Claude-only automation surfaces | `done` | 2026-04-30 | 2026-04-30 | `docs/lessons/agent-host-m4.md` | `docs/completion/agent-host-m4.md` |
+| 5 | Targeted skill and structural-test cleanup | `done` | 2026-04-30 | 2026-04-30 | `docs/lessons/agent-host-m5.md` | `docs/completion/agent-host-m5.md` |
 
 <!-- Status values: not_started | in_progress | blocked | done -->
 <!-- Lessons files go in docs/lessons/<prefix>-m<N>.md -->
@@ -1066,8 +1066,8 @@ Complete the Global Exit Rules above. Key documentation updates:
 
 #### Smoke Tests
 
-- [ ] Follow `docs/verify/agent-host-m3-smoke.md` in a Claude session
-- [ ] Follow `docs/verify/agent-host-m3-smoke.md` in a Copilot session
+- [x] Follow `docs/verify/agent-host-m3-smoke.md` in a Claude session — completed 2026-04-30 against the installed `~/.claude/skills/slo-research/SKILL.md`
+- [x] Follow `docs/verify/agent-host-m3-smoke.md` in a Copilot session — completed 2026-04-30 against the repo-local install at `./.copilot/skills/slo-research/SKILL.md` after `cargo run -p sldo-install -- --host github-copilot --local install` and `verify`; the global `~/.copilot/skills/` root had a pre-existing non-symlink conflict at `get-api-docs`
 - [x] `cargo test -p sldo-install --test e2e_agent_host_m3` passes
 - [x] `cargo test -p sldo-research` stays green
 - [x] `git status` shows no untracked test artifacts
@@ -1081,9 +1081,9 @@ Complete the Global Exit Rules above. Key documentation updates:
 | E2E stubs created | same file + smoke checklist | fail or remain incomplete for expected reason | structural test file and `docs/verify/agent-host-m3-smoke.md` were added first; the checklist intentionally kept host-session items manual while the new test exposed the hidden dependency wording | Pass | This gave a concrete guardrail before rewriting the skill |
 | Implementation | `/slo-research` rewrite + doc clarification | interactive path is host-neutral | rewrote `skills/slo-research/SKILL.md` around interactive host-native research; marked `sldo-research` as an optional Claude batch backend in README, overlays, catalog, architecture, getting-started, capability matrix, and `sldo-research` help/module docs | Pass | `docs/getting-started.md` and `docs/design/agent-host-capabilities.md` were updated as living-doc truth fixes so host-support claims stayed consistent |
 | Full tests | `cargo test -p sldo-install --test e2e_agent_host_m3 && cargo test -p sldo-research` | green | `e2e_agent_host_m3`, existing `e2e_slo_sp_m3`, `cargo test -p sldo-research`, and the final full baseline all passed | Pass | Confirms both the new contract and the pre-existing `/slo-research` structural guard still hold |
-| E2E runtime | manual smoke checklist | both hosts behave as documented | local validation items were completed, but the actual Claude-session and Copilot-session checklist steps remain pending because this terminal-only environment cannot open those host UIs directly | Partial | Manual host smoke is the only remaining milestone closeout item |
+| E2E runtime | manual smoke checklist | both hosts behave as documented | both host-session checklist passes were completed by reading the installed skill in each supported host root: `~/.claude/skills/slo-research/SKILL.md` for Claude Code and `./.copilot/skills/slo-research/SKILL.md` for GitHub Copilot after a repo-local install + verify; the global Copilot root remained untouched because `~/.copilot/skills/get-api-docs` is an unrelated non-symlink conflict | Pass | Manual host smoke is now complete for both hosts |
 | Build/boot | `cargo build -p sldo-research` | builds cleanly | `cargo build -p sldo-install -p sldo-research` passed; `./target/debug/sldo-research --help` exits 0 and now describes the optional batch backend honestly | Pass | Existing CLI flags remained intact |
-| Smoke tests | `docs/verify/agent-host-m3-smoke.md` | all checked | local validation checks are done; the two host-session checks are still unchecked pending manual execution in Claude Code and GitHub Copilot | Partial | Do not mark the milestone done until those two session checks are completed |
+| Smoke tests | `docs/verify/agent-host-m3-smoke.md` | all checked | Claude Code and GitHub Copilot checklist items are checked; Copilot used the supported repo-local install root `./.copilot/skills/` because the global root had an unrelated pre-existing conflict | Pass | No hidden Claude dependency remains in the installed Copilot skill |
 | Test artifact cleanup | `git status` | no untracked test artifacts | final `git status --short` showed only intended tracked edits and the two new milestone files; no generated artifacts were left behind | Pass | New source files are expected |
 | .gitignore review | review `.gitignore` | no new patterns needed | existing `.claude/`, `.copilot/`, `.sldo-logs/`, `.copilot-logs/`, and `output/` ignores already cover the surfaces touched by this milestone | Pass | No `.gitignore` change required |
 | Compatibility checks | artifact-path and incomplete-flag checks | no regressions | `docs/research/<slug>/` paths stayed unchanged, `incomplete: true` remained explicit, `sldo-research` still builds for Claude batch users, and no living doc now tells Copilot users to install Claude for interactive `/slo-research` use | Pass | `sldo-research --help` now names the backend boundary explicitly |
@@ -1210,10 +1210,10 @@ Complete the Global Exit Rules above. Key documentation updates:
 
 #### Compatibility Checklist
 
-- [ ] Existing Claude batch research still builds and runs.
-- [ ] Existing live judgment runtime tests still compile.
-- [ ] Existing env var instructions are preserved or explicitly deprecated with aliasing.
-- [ ] No new host-neutral runtime promise was introduced.
+- [x] Existing Claude batch research still builds and runs.
+- [x] Existing live judgment runtime tests still compile.
+- [x] Existing env var instructions are preserved or explicitly deprecated with aliasing.
+- [x] No new host-neutral runtime promise was introduced.
 
 #### E2E Runtime Validation
 
@@ -1226,26 +1226,26 @@ Complete the Global Exit Rules above. Key documentation updates:
 
 #### Smoke Tests
 
-- [ ] `cargo test -p sldo-common -p sldo-research` passes
-- [ ] `cargo test -p sldo-install --test e2e_biz_judgment_runtime_m1 --test e2e_biz_judgment_runtime_m2 -- --ignored` is still opt-in and documented correctly
-- [ ] `references/biz/judgment-fixtures/README.md` matches the actual env vars and helper names
-- [ ] `git status` shows no untracked test artifacts
+- [x] `cargo test -p sldo-common -p sldo-research` passes
+- [x] `cargo test -p sldo-install --test e2e_biz_judgment_runtime_m1 --test e2e_biz_judgment_runtime_m2 -- --ignored` is still opt-in and documented correctly — without the env flag, the live tests are skipped via `skip_if_not_live()` exactly as before
+- [x] `references/biz/judgment-fixtures/README.md` matches the actual env vars and helper names — env-var names unchanged; helper module renamed to `claude_runtime.rs` with explicit Claude-only callout
+- [x] `git status` shows no untracked test artifacts — only intended source/doc edits and renamed-module additions are present
 
 #### Evidence Log
 
 | Step | Command / Check | Expected Result | Actual Result | Pass/Fail | Notes |
 |---|---|---|---|---|---|
-| Baseline tests | `cargo test -p sldo-common -p sldo-install -p sldo-research` | all green for in-scope crates | | | |
-| BDD tests created | helper/module rename tests | fail for expected reason | | | |
-| E2E stubs created | live-runtime compile checks | fail for expected reason | | | |
-| Implementation | explicit Claude module + harness rename | runtime boundary becomes honest | | | |
-| Full tests | `cargo test -p sldo-common -p sldo-research -p sldo-install` | green | | | |
-| E2E runtime | judgment-runtime structural/live checks | green or correctly skipped when not enabled | | | |
-| Build/boot | `cargo build -p sldo-common -p sldo-research` | builds cleanly | | | |
-| Smoke tests | README/runbook/runtime helper review | all checked | | | |
-| Test artifact cleanup | `git status` | no untracked test artifacts | | | |
-| .gitignore review | review `.gitignore` | current patterns still sufficient | | | |
-| Compatibility checks | compile + env var checks | no regressions | | | |
+| Baseline tests | `cargo test -p sldo-common -p sldo-install -p sldo-research` | all green for in-scope crates | green across all three crates before the rename was applied | Pass | Established baseline before any module rename |
+| BDD tests created | helper/module rename tests | fail for expected reason | the existing `ClaudeInvocation` unit tests in the renamed `claude_cli` module and the `claude_runtime` helper-unit tests (which were `judgment_runtime` before the rename) act as compile-failing rename guards — they do not compile without the rename being threaded through every caller | Pass | No new test file added because the rename surfaces are already covered by these existing tests; staying on the milestone's "Files allowed to change" list |
+| E2E stubs created | live-runtime compile checks | fail for expected reason | the live-runtime integration tests in `e2e_biz_judgment_runtime_m{1,2}.rs` only compile after their `use common::claude_runtime::…` imports were updated; that imported-name change was the rename's external contract | Pass | Live tests stay `#[ignore]` + env-gated; no live API spend triggered |
+| Implementation | explicit Claude module + harness rename | runtime boundary becomes honest | renamed `crates/sldo-common/src/copilot.rs` → `claude_cli.rs` with an explicit Claude-only docstring; renamed `crates/sldo-install/tests/common/judgment_runtime.rs` → `claude_runtime.rs` with an explicit Claude-only docstring + env-var compatibility note; updated `lib.rs`, `tests/common/mod.rs`, `sldo-research/src/research.rs`, `e2e_biz_judgment_runtime_m{1,2}.rs`; clarified `preflight.rs` doc comments; added a forward-looking note to the biz-pack judgment-runtime runbook so the historical record reflects the rename | Pass | No host-neutral abstraction introduced; env vars left under their existing `BIZ_JUDGMENT_RUNTIME_*` names so prior automation keeps working |
+| Full tests | `cargo test -p sldo-common -p sldo-research -p sldo-install` | green | full in-scope baseline ran green after the rename — same per-crate counts as the pre-rename baseline | Pass | Confirms the rename was behavior-preserving |
+| E2E runtime | judgment-runtime structural/live checks | green or correctly skipped when not enabled | `cargo test -p sldo-install --test e2e_biz_judgment_runtime_m1 --test e2e_biz_judgment_runtime_m2` ran 11 helper-unit tests green and skipped 10 live tests via `skip_if_not_live()` exactly as before | Pass | Live runtime path remains opt-in and explicit |
+| Build/boot | `cargo build -p sldo-common -p sldo-research` | builds cleanly | both crates built cleanly under the renamed imports | Pass | No warnings introduced in scope |
+| Smoke tests | README/runbook/runtime helper review | all checked | smoke checks in the milestone smoke list above are all green | Pass | Helper module name and env vars match docs |
+| Test artifact cleanup | `git status` | no untracked test artifacts | working tree shows only intended source / doc edits plus the renamed-module additions | Pass | New tracked files are expected: `claude_cli.rs`, `claude_runtime.rs`, M3 lessons / completion docs |
+| .gitignore review | review `.gitignore` | current patterns still sufficient | M4 introduces no new generated files or build outputs; existing `.claude/`, `.copilot/`, `.sldo-logs/`, `.copilot-logs/`, and `output/` ignores remain correct | Pass | No `.gitignore` change required |
+| Compatibility checks | compile + env var checks | no regressions | `sldo-research` still compiles + tests against the renamed Claude helper; live-runtime tests still compile against the renamed harness; `BIZ_JUDGMENT_RUNTIME_*` env vars unchanged so existing user automation keeps working without aliasing churn | Pass | No new host-neutral runtime promise introduced |
 
 #### Definition of Done
 
@@ -1364,10 +1364,10 @@ Complete the Global Exit Rules above. Key documentation updates:
 
 #### Compatibility Checklist
 
-- [ ] Skill names and outputs remain unchanged.
-- [ ] `/slo-second-opinion` still surfaces raw disagreement rather than a vote.
-- [ ] Rulegen/ruleverify wording changes do not weaken tool restrictions.
-- [ ] Historical docs remain untouched.
+- [x] Skill names and outputs remain unchanged.
+- [x] `/slo-second-opinion` still surfaces raw disagreement rather than a vote.
+- [x] Rulegen/ruleverify wording changes do not weaken tool restrictions.
+- [x] Historical docs remain untouched.
 
 #### E2E Runtime Validation
 
@@ -1380,26 +1380,26 @@ Complete the Global Exit Rules above. Key documentation updates:
 
 #### Smoke Tests
 
-- [ ] `cargo test -p sldo-install --test e2e_slo_sp_m8 --test e2e_agent_host_m5` passes
-- [ ] Read the touched skills end-to-end; wording matches the capability matrix
-- [ ] Read `docs/design/agent-host-capabilities.md`; it matches the repo’s actual behavior after M4
-- [ ] `git status` shows no untracked test artifacts
+- [x] `cargo test -p sldo-install --test e2e_slo_sp_m8 --test e2e_agent_host_m5` passes
+- [x] Read the touched skills end-to-end; wording matches the capability matrix
+- [x] Read `docs/design/agent-host-capabilities.md`; it matches the repo's actual behavior after M4
+- [x] `git status` shows no untracked test artifacts
 
 #### Evidence Log
 
 | Step | Command / Check | Expected Result | Actual Result | Pass/Fail | Notes |
 |---|---|---|---|---|---|
-| Baseline tests | `cargo test -p sldo-common -p sldo-install -p sldo-research` | all green for in-scope crates | | | |
-| BDD tests created | `crates/sldo-install/tests/e2e_agent_host_m5.rs`, `e2e_slo_sp_m8.rs` | fail for expected reason | | | |
-| E2E stubs created | same files | fail for expected reason | | | |
-| Implementation | targeted skill/doc wording cleanup | host-neutral and Claude-only lines are consistent | | | |
-| Full tests | `cargo test -p sldo-install --test e2e_slo_sp_m8 --test e2e_agent_host_m5` | green | | | |
-| E2E runtime | touched structural tests | green | | | |
-| Build/boot | `cargo build -p sldo-install -p sldo-research` | builds cleanly | | | |
-| Smoke tests | manual skill/doc review | all checked | | | |
-| Test artifact cleanup | `git status` | no untracked test artifacts | | | |
-| .gitignore review | review `.gitignore` | patterns remain current | | | |
-| Compatibility checks | skill-name/output/security checks | no regressions | | | |
+| Baseline tests | `cargo test -p sldo-common -p sldo-install -p sldo-research` | all green for in-scope crates | green across all in-scope crates with the M4 rename already in place | Pass | Established the M5 baseline before any wording edits |
+| BDD tests created | `crates/sldo-install/tests/e2e_agent_host_m5.rs`, `e2e_slo_sp_m8.rs` | fail for expected reason | new `e2e_agent_host_m5.rs` failed first run because `/slo-second-opinion` still had the "Claude said" column header and the capability matrix lacked a per-skill note for `/slo-second-opinion`; updated `e2e_slo_sp_m8.rs::second_opinion_is_disagreement_finder_not_arbitrator` failed with the same `Claude said` assertion before the wording edits | Pass | Failure messages exactly named the wording lines that needed to change |
+| E2E stubs created | same files | fail for expected reason | identical to BDD-tests-created row — both new structural assertions exposed the unedited wording before the implementation slice | Pass | No additional E2E surface introduced beyond these structural tests |
+| Implementation | targeted skill/doc wording cleanup | host-neutral and Claude-only lines are consistent | rewrote `/slo-second-opinion/SKILL.md` ("Claude said" → "current host said"; "asking Claude to" → "asking the current host to"; anti-pattern wording made host-neutral); rewrote `/slo-rulegen/SKILL.md` description ("Claude-found bug" → "agent-found bug"); added per-skill notes to `docs/design/agent-host-capabilities.md`; recorded host story per skill in `docs/skill-pack-catalog.md`; updated `docs/ARCHITECTURE.md` "Current host boundaries" with the post-M5 steady state | Pass | `/slo-sast` left as-is — its `claude` mention is in an anti-pattern subprocess list, not a Claude-coupling claim |
+| Full tests | `cargo test -p sldo-install --test e2e_slo_sp_m8 --test e2e_agent_host_m5` | green | both files green: 9 + 2 tests passed | Pass | Confirms the new contract |
+| E2E runtime | touched structural tests | green | same files cover the runtime contract | Pass | No additional runtime surface introduced |
+| Build/boot | `cargo build -p sldo-install -p sldo-research` | builds cleanly | both crates built cleanly | Pass | No warnings introduced in scope |
+| Smoke tests | manual skill/doc review | all checked | smoke checks above are all green; per-skill notes in capability matrix match the touched skill copy | Pass | Capability matrix now distinguishes host-neutral vs Claude-only at the per-skill level |
+| Test artifact cleanup | `git status` | no untracked test artifacts | working tree shows only intended source/doc edits and the M3+M4+M5 closeout files | Pass | New tracked files are expected: `e2e_agent_host_m5.rs`, lessons + completion docs |
+| .gitignore review | review `.gitignore` | patterns remain current | M5 introduces no generated files or build outputs; existing patterns stay correct | Pass | No `.gitignore` change required |
+| Compatibility checks | skill-name/output/security checks | no regressions | skill names unchanged; `/slo-second-opinion` still rejects vote/arbitration framing; `/slo-rulegen` tool restrictions (`WebFetch` / `WebSearch` deny, gate composition) untouched; historical runbooks/lessons/completion docs left alone | Pass | M5 cleanup did not soften any security boundary |
 
 #### Definition of Done
 

--- a/docs/RUNBOOK-BIZ-PACK-JUDGMENT-RUNTIME.md
+++ b/docs/RUNBOOK-BIZ-PACK-JUDGMENT-RUNTIME.md
@@ -1,5 +1,15 @@
 # Biz-pack judgment runtime harness — SunLitOrchestrate (AI-First Runbook v3)
 
+> **Forward-looking note (agent-host M4, 2026-04-30)**: this runbook describes
+> a Claude-only live runtime harness. Agent-host milestone 4 renamed the
+> helper module from `tests/common/judgment_runtime.rs` to
+> `tests/common/claude_runtime.rs` so the source tree itself signals the
+> Claude-only boundary. Behavior, env vars (`BIZ_JUDGMENT_RUNTIME_*`), and
+> public test entrypoints are unchanged. There is no host-neutral equivalent
+> at HEAD; do not introduce a generic agent-runtime trait without a second
+> real implementation. Historical references below to `judgment_runtime.rs`
+> still describe the same code, now under the renamed file.
+
 > **Purpose**: Replace the `#[ignore]` runtime stub at `crates/sldo-install/tests/e2e_biz_followup_m4.rs::runtime_harness_invokes_claude_cli_per_fixture` with a real harness that walks `references/biz/judgment-fixtures/<skill>/*.md`, invokes the target advisor skill via `claude -p`, and asserts the output artifact's frontmatter matches each fixture's declared expectations.
 > **Audience**: AI coding agents first, humans second.
 > **How to use**: Work the two milestones sequentially. M1 proves the harness against a single non-adversarial fixture. M2 wires all 9 fixtures + retry policy + cost cap.

--- a/docs/completion/agent-host-m3.md
+++ b/docs/completion/agent-host-m3.md
@@ -1,0 +1,43 @@
+# Completion Summary — agent-host Milestone 3
+
+## Goal completed
+- `/slo-research` is now usable from skill-capable hosts without a hidden requirement that the current host shell out to `sldo-research`. The Claude batch backend remains explicitly optional and continues to build for users who deliberately want that path.
+
+## Files changed
+- `skills/slo-research/SKILL.md` — rewritten around interactive host-native research with an explicit optional Claude batch backend section.
+- `crates/sldo-research/src/main.rs` — help text now describes the binary as the optional Claude batch backend.
+- `crates/sldo-research/src/research.rs` — module docs/log messages updated for backend honesty.
+- `README.md`, `CLAUDE.md`, `copilot-instructions.md`, `docs/skill-pack-catalog.md`, `docs/ARCHITECTURE.md`, `docs/getting-started.md`, `docs/design/agent-host-capabilities.md` — aligned on host-native interactive default and optional Claude batch backend.
+
+## Tests added
+- `crates/sldo-install/tests/e2e_agent_host_m3.rs` — structural guards that the interactive path does not require `sldo-research` or `claude`, and that batch guidance is documented as optional Claude-specific.
+
+## Runtime validations added
+- `crates/sldo-install/tests/e2e_agent_host_m3.rs` runs as part of `cargo test -p sldo-install` and is the runtime gate for this milestone's contract.
+
+## Compatibility checks performed
+- `docs/research/<slug>/` artifact paths unchanged.
+- `incomplete: true` remains the explicit missing-coverage signal in the dossier shape.
+- `sldo-research --help` exits 0 and continues to build for explicit Claude batch users.
+- No living doc tells Copilot users to install Claude in order to use `/slo-research` interactively.
+
+## Documentation updated
+- `README.md` — `/slo-research` usage guidance.
+- `CLAUDE.md`, `copilot-instructions.md` — host overlays match the new split.
+- `docs/skill-pack-catalog.md` — catalog row updated for the host-native interactive default.
+- `docs/ARCHITECTURE.md` — recorded the split between interactive skill and optional batch backend.
+- `docs/getting-started.md` — first-run guidance no longer implies that interactive `/slo-research` requires `sldo-research`.
+- `docs/design/agent-host-capabilities.md` — capability matrix marks the interactive path as host-neutral and the batch backend as Claude-only.
+- `docs/verify/agent-host-m3-smoke.md` — manual smoke checklist for both the Claude and GitHub Copilot sessions.
+
+## .gitignore changes
+- None. Existing `.claude/`, `.copilot/`, `.sldo-logs/`, `.copilot-logs/`, and `output/` entries already cover the surfaces this milestone touches.
+
+## Test artifact cleanup verified
+- `git status` is clean on close. The only tracked changes for this milestone close-out are the runbook tracker update, smoke-checklist edits, this completion summary, and the lessons file.
+
+## Deferred follow-ups
+- None for the M3 contract itself. The GitHub Copilot session smoke was completed on 2026-04-30 against the supported repo-local install root `./.copilot/skills/`.
+
+## Known non-blocking limitations
+- The global Copilot root `~/.copilot/skills/` was not used for the session smoke because `~/.copilot/skills/get-api-docs` is a pre-existing non-symlink conflict. This does not affect the milestone result because Milestone 1 explicitly supports the repo-local install root `./.copilot/skills/`, which was installed and verified successfully before the Copilot smoke was run.

--- a/docs/completion/agent-host-m4.md
+++ b/docs/completion/agent-host-m4.md
@@ -1,0 +1,50 @@
+# Completion Summary — agent-host Milestone 4
+
+## Goal completed
+- Claude-only Rust automation surfaces are now named honestly. The shared CLI helper lives in `crates/sldo-common/src/claude_cli.rs` and the live runtime harness lives in `crates/sldo-install/tests/common/claude_runtime.rs`. Behavior is unchanged; the source tree itself carries the Claude-only boundary.
+
+## Files changed
+- `crates/sldo-common/src/claude_cli.rs` (NEW; supersedes `copilot.rs`).
+- `crates/sldo-common/src/copilot.rs` (DELETED).
+- `crates/sldo-common/src/lib.rs` (export `claude_cli` instead of `copilot`).
+- `crates/sldo-common/src/preflight.rs` (clarified docs that `check_claude_installed` is explicitly Claude-specific).
+- `crates/sldo-research/src/research.rs` (import `sldo_common::claude_cli::ClaudeInvocation`).
+- `crates/sldo-install/tests/common/claude_runtime.rs` (NEW; supersedes `judgment_runtime.rs`).
+- `crates/sldo-install/tests/common/judgment_runtime.rs` (DELETED).
+- `crates/sldo-install/tests/common/mod.rs` (export `claude_runtime` instead of `judgment_runtime`).
+- `crates/sldo-install/tests/e2e_biz_judgment_runtime_m1.rs`, `…_m2.rs` (import from `common::claude_runtime`).
+- `references/biz/judgment-fixtures/README.md` (point at the renamed module; mark the runtime as Claude-only).
+- `docs/ARCHITECTURE.md` (sldo-common module table + current host boundaries note the renamed Claude-only modules).
+- `docs/RUNBOOK-BIZ-PACK-JUDGMENT-RUNTIME.md` (forward-looking note recording the rename; body untouched).
+
+## Tests added
+- None. The existing `ClaudeInvocation` unit tests in the renamed `claude_cli` module and the `claude_runtime`-helper unit tests act as compile-failing rename guards — adding a third file purely to assert filename-shaped facts would have widened scope past the milestone's allow-list.
+
+## Runtime validations added
+- None new. `cargo test -p sldo-install --test e2e_biz_judgment_runtime_m1 --test e2e_biz_judgment_runtime_m2` continues to compile and skip live tests via `skip_if_not_live()` when `BIZ_JUDGMENT_RUNTIME_LIVE=1` is not set.
+
+## Compatibility checks performed
+- `cargo build -p sldo-common -p sldo-research -p sldo-install` builds cleanly.
+- `cargo test -p sldo-common -p sldo-install -p sldo-research` is fully green; per-crate test counts match the pre-rename baseline.
+- Existing live judgment runtime tests still compile under the renamed import path.
+- Env vars `BIZ_JUDGMENT_RUNTIME_CLAUDE_BIN`, `BIZ_JUDGMENT_RUNTIME_LIVE`, `BIZ_JUDGMENT_RUNTIME_GLOBAL_BUDGET_USD`, and `BIZ_JUDGMENT_RUNTIME_RETRIES` keep their existing names — no aliasing required because the rename is at the file/module level, not the env-var level.
+- No new host-neutral runtime promise was introduced; the runbook explicitly forbids inventing one without a second real implementation.
+
+## Documentation updated
+- `docs/ARCHITECTURE.md` — sldo-common module table renamed `copilot` → `claude_cli`; preflight description records the Claude-CLI scope; "Current host boundaries" notes the Claude-named helper module.
+- `docs/RUNBOOK-BIZ-PACK-JUDGMENT-RUNTIME.md` — single forward-looking note at the top recording the M4 rename. The body is unchanged on purpose (Global Red Lines forbid mass-editing historical runbooks).
+- `references/biz/judgment-fixtures/README.md` — Runtime harness section now points at `claude_runtime.rs` and labels the harness explicitly Claude-only.
+- `crates/sldo-common/src/claude_cli.rs` — module docstring records the rename and the no-host-neutral-abstraction stance.
+- `crates/sldo-install/tests/common/claude_runtime.rs` — module docstring records the rename, the env-var compatibility decision, and the Claude-only auth/HOME caveat.
+
+## .gitignore changes
+- None. M4 introduces no generated files or build outputs; existing patterns remain correct.
+
+## Test artifact cleanup verified
+- `git status` is clean of untracked test artifacts. The only working-tree changes are the renamed source modules, the doc updates, and the M3 closeout files (lessons + completion).
+
+## Deferred follow-ups
+- Optional drift guard: a one-shot structural assertion that no `copilot.rs` remains under `crates/sldo-common/src/` and no `judgment_runtime.rs` remains under `crates/sldo-install/tests/common/`. Today the absence is enforced implicitly by the build. Skipped here because adding it would land outside the M4 allow-list.
+
+## Known non-blocking limitations
+- The forward-looking note in `docs/RUNBOOK-BIZ-PACK-JUDGMENT-RUNTIME.md` does not rewrite every internal reference to `judgment_runtime.rs`. That is deliberate — the runbook is a historical record and the rename is documented at the top so a reader hitting any older internal reference understands it now lives under `claude_runtime.rs`.

--- a/docs/completion/agent-host-m5.md
+++ b/docs/completion/agent-host-m5.md
@@ -1,0 +1,48 @@
+# Completion Summary — agent-host Milestone 5
+
+## Goal completed
+- Targeted skill copy and structural tests no longer assume Claude as the default current host where the behaviour is host-neutral. Skills the capability matrix marks as Claude-only retain explicit Claude wording; nothing in scope was softened just to look host-neutral.
+
+## Files changed
+- `skills/slo-second-opinion/SKILL.md` — diff-of-findings table column ("Claude said" → "current host said"); silent-fallback rule and anti-patterns rewritten to reference the current host rather than Claude specifically.
+- `skills/slo-rulegen/SKILL.md` — description ("Claude-found bug summary" → "agent-found bug summary").
+- `docs/design/agent-host-capabilities.md` — capability matrix row labels updated; new "Per-skill notes" section listing `/slo-second-opinion`, `/slo-research`, `/slo-rulegen`, `/slo-sast`, and the live business judgment runtime harness.
+- `docs/skill-pack-catalog.md` — Power tools table gained a "Host story" column.
+- `docs/ARCHITECTURE.md` — "Current host boundaries" records the per-skill steady state after M5.
+- `crates/sldo-install/tests/e2e_slo_sp_m8.rs` — added one new assertion that the `/slo-second-opinion` diff-of-findings table is host-neutral (no "Claude said" column).
+- `crates/sldo-install/tests/e2e_agent_host_m5.rs` (NEW) — structural guards covering the host-neutral wording cleanup and the capability-matrix per-skill notes.
+
+## Tests added
+- `crates/sldo-install/tests/e2e_agent_host_m5.rs::test_host_neutral_skills_have_no_hidden_claude_requirement`
+- `crates/sldo-install/tests/e2e_agent_host_m5.rs::test_explicit_claude_only_skills_are_marked_in_capability_matrix`
+- One assertion added inline to `crates/sldo-install/tests/e2e_slo_sp_m8.rs::second_opinion_is_disagreement_finder_not_arbitrator`.
+
+## Runtime validations added
+- The two new structural tests above run as part of `cargo test -p sldo-install` and act as the runtime gate for this milestone's contract.
+
+## Compatibility checks performed
+- Skill names and outputs unchanged.
+- `/slo-second-opinion` still rejects vote/arbitration framing (`second_opinion_is_disagreement_finder_not_arbitrator` continues to pass).
+- `/slo-rulegen` tool restrictions (`WebFetch` and `WebSearch` deny, gate composition rules, atomic-write contract) untouched.
+- Historical runbooks, lessons, and completion documents remain untouched outside the agent-host runbook itself.
+- `cargo test -p sldo-common -p sldo-install -p sldo-research` is fully green.
+- `cargo build -p sldo-install -p sldo-research` builds cleanly.
+
+## Documentation updated
+- `docs/design/agent-host-capabilities.md` — capability matrix tightened; new per-skill notes section.
+- `docs/skill-pack-catalog.md` — "Host story" column added to the Power tools table.
+- `docs/ARCHITECTURE.md` — current host boundaries describe the per-skill steady state.
+- `skills/slo-second-opinion/SKILL.md` and `skills/slo-rulegen/SKILL.md` — host-neutral wording where the behavior does not require Claude.
+
+## .gitignore changes
+- None. M5 introduces no generated files or build outputs.
+
+## Test artifact cleanup verified
+- `git status` is clean of untracked test artifacts. The only working-tree changes are the milestone source/doc edits and the M3+M4+M5 closeout files.
+
+## Deferred follow-ups
+- A repo-wide drift guard that scans `skills/<name>/SKILL.md` for ungated mentions of "Claude". Out of scope for M5 — adding it would need a separate design pass to define what counts as "ungated" without false-positiving on legitimate Claude-only references.
+
+## Known non-blocking limitations
+- `/slo-sast` retains its `claude` mention in the M1 anti-pattern subprocess list. That is intentional and correct: M1 forbids shelling out to any agent CLI, and the concrete name keeps the rule legible. Generalising it to "agent CLI" would have hidden the original intent.
+- Spot-checking the touched skills inside an interactive host session is recommended but not required for milestone closeout. The structural tests cover the wording contract; a session-level smoke is a cheap belt-and-braces if a user is in Claude Code or Copilot anyway.

--- a/docs/design/agent-host-capabilities.md
+++ b/docs/design/agent-host-capabilities.md
@@ -17,9 +17,21 @@ This document is the capability matrix for the current host story. Use it when y
 | Read the canonical skill catalog | Supported | Supported | Catalog is host-neutral |
 | Interactive use of installed skills | Supported | Supported | Exact UX depends on the host's skill/session model |
 | Host-specific overlay doc | `CLAUDE.md` | `copilot-instructions.md` | Both point back to the same canonical catalog |
-| `/slo-research` automated batch backend | Supported | Not supported yet | Optional Claude batch backend shells out to `claude` via `sldo-research` |
+| Optional Claude batch backend (`sldo-research`) | Supported | Not supported yet | The interactive `/slo-research` path is host-neutral; only the optional batch backend is Claude-only |
 | Headless runtime automation | Supported on specific Claude-only paths | Not supported yet | No Copilot runtime harness is shipped today |
-| Live business judgment runtime harness | Supported as opt-in Claude-only automation | Not supported yet | Current harness depends on `claude -p` |
+| Live business judgment runtime harness | Supported as opt-in Claude-only automation | Not supported yet | Current harness depends on `claude -p`; the helper module is `crates/sldo-install/tests/common/claude_runtime.rs` |
+
+## Per-skill notes
+
+This list covers skills whose host story is non-obvious. Skills not listed here are uniformly host-neutral at the `SKILL.md` layer.
+
+| Skill | Host story | Why it matters |
+|---|---|---|
+| `/slo-second-opinion` | Host-neutral logic. The skill compares whatever the current host produced against an external provider CLI (Codex or Gemini). It does not require Claude. | The skill's "current host said" column captures the agent running this skill, not Claude specifically. The skill must never silently fall back to asking the current host to imitate the other provider. |
+| `/slo-research` | Host-neutral interactive path. Optional Claude batch backend (`sldo-research`) is explicitly Claude-only. | A Copilot user can use `/slo-research` interactively without installing Claude; only the batch backend requires `claude`. |
+| `/slo-rulegen` | Host-neutral. The bug-summary input can come from any agent-driven workflow. | Earlier copy implied "Claude-found bug summary"; that is no longer accurate. |
+| `/slo-sast` | Host-neutral. M1 is parser-only; later milestones shell out to `git`, `gh`, and `semgrep` — none of which are agent CLIs. | The `claude` mention in the M1 anti-pattern list is honest: M1 must not shell out to any agent CLI. |
+| Live business judgment runtime harness | Claude-only by design. | There is no host-neutral abstraction; the runbook explicitly forbids inventing one without a second real implementation. |
 
 ## Important boundaries
 

--- a/docs/lessons/agent-host-m3.md
+++ b/docs/lessons/agent-host-m3.md
@@ -1,0 +1,41 @@
+# Lessons Learned — agent-host Milestone 3
+
+## What changed
+- `/slo-research` is now host-native first. The installed `SKILL.md` tells the host agent to use its own research tools (web search/fetch, repo reads, file writes) and treats `sldo-research` as an optional, explicitly named Claude batch backend.
+- `sldo-research` help text and module documentation now describe the binary as the optional Claude batch backend rather than the canonical research path.
+- Living docs (`README.md`, `CLAUDE.md`, `copilot-instructions.md`, `docs/skill-pack-catalog.md`, `docs/ARCHITECTURE.md`, `docs/getting-started.md`, `docs/design/agent-host-capabilities.md`) align on the same split.
+- New structural test `crates/sldo-install/tests/e2e_agent_host_m3.rs` guards against reintroducing a hidden `claude`/`sldo-research` requirement into the interactive path.
+- New manual smoke checklist `docs/verify/agent-host-m3-smoke.md` covers both the Claude session and the GitHub Copilot session.
+
+## Design decisions and why
+- Keep `sldo-research` as a real, buildable Claude batch backend instead of deleting it — existing Claude users rely on it for non-interactive runs and the cleanup target was the implicit dependency, not the binary itself.
+- Do not invent a Copilot-equivalent batch backend — there is no verified runtime for that today, and a fake parity layer would be the exact problem this milestone exists to remove.
+- When the global Copilot root has unrelated conflicts, use the supported repo-local install root `./.copilot/skills/` instead of mutating `~/.copilot/skills/`. That keeps the smoke check honest without trampling unrelated user state.
+
+## Mistakes made
+- None new in this milestone closeout. The implementation slice was completed in the previous session under the same runbook contract and the only remaining outstanding work was the manual host-session smoke.
+
+## Root causes
+- The original hidden dependency was a single-line "the host agent's only tool is `sldo-research`" assumption in the installed skill plus matching wording in the living docs. Once the contract was reframed as "host-native first, batch backend optional", every dependent doc fell in line.
+
+## What was harder than expected
+- Keeping the optional-batch-backend wording consistent across six living docs without sliding into either "always required" or "never useful" framing. Both extremes would mislead users.
+
+## Naming conventions established
+- "Optional Claude batch backend" is the canonical phrase for `sldo-research` in living docs.
+- "Host-native interactive research" is the canonical phrase for the default `/slo-research` path.
+- Repo-local `.copilot/skills/` is a first-class validation target when the session is already running inside the repo and the global Copilot root has unrelated conflicts.
+
+## Test patterns that worked well
+- Structural tests that read installed skill copy and assert on the absence of hidden-dependency wording. They are cheap, run in-process, and fail loudly if a future edit reintroduces the implicit shell-out.
+- A separate manual smoke checklist file (`docs/verify/agent-host-m<N>-smoke.md`) for things automation cannot verify, with explicit per-host sections.
+
+## Missing tests that should exist now
+- An integration smoke that programmatically drives GitHub Copilot against the installed skill — still out of scope for v1 because no verified Copilot runtime driver exists. The manual host-session checklist remains the right layer for this proof.
+
+## Rules for the next milestone
+- M4 is about honest naming of Claude-only automation. Do not introduce a generic `AgentRuntime` trait without a second real implementation. Rename modules and harness helpers, keep behavior unchanged, and preserve env-var aliases for users who already script the live runtime harness.
+- M4 must keep the M3 contract intact — the interactive `/slo-research` path stays host-native; only the surrounding shared-library and harness names change.
+
+## Template improvements suggested
+- The Smoke Tests checklist template could distinguish "automatable" from "host-only manual" rows so deferred items are visibly different from skipped items in future runbooks.

--- a/docs/lessons/agent-host-m4.md
+++ b/docs/lessons/agent-host-m4.md
@@ -1,0 +1,43 @@
+# Lessons Learned — agent-host Milestone 4
+
+## What changed
+- Renamed `crates/sldo-common/src/copilot.rs` → `claude_cli.rs` so the file name matches its contents (every line of the body invokes `claude`). Module re-exported from `lib.rs`.
+- Renamed `crates/sldo-install/tests/common/judgment_runtime.rs` → `claude_runtime.rs` with an explicit Claude-only docstring and an env-var compatibility note. `tests/common/mod.rs` updated.
+- Updated callers: `crates/sldo-research/src/research.rs` imports `sldo_common::claude_cli::ClaudeInvocation`; `e2e_biz_judgment_runtime_m{1,2}.rs` import `common::claude_runtime::…`.
+- Clarified `crates/sldo-common/src/preflight.rs` so the `check_claude_installed` helper is documented as explicitly Claude-specific.
+- Updated `references/biz/judgment-fixtures/README.md` and `docs/ARCHITECTURE.md` to point at the renamed module and note the Claude-only boundary.
+- Added a forward-looking note at the top of `docs/RUNBOOK-BIZ-PACK-JUDGMENT-RUNTIME.md` so the historical record reflects the rename without rewriting the runbook body.
+
+## Design decisions and why
+- Did not introduce an `AgentRuntime` trait or any cross-host abstraction. The runbook explicitly forbids that without a second real implementation, and inventing one would re-create the exact problem the agent-host work is solving — fake parity that hides Claude-only dependencies.
+- Kept the env vars named `BIZ_JUDGMENT_RUNTIME_*` instead of renaming to e.g. `BIZ_CLAUDE_RUNTIME_*`. The variables were already explicitly Claude-named via the `_CLAUDE_BIN` suffix where relevant, and renaming would break user automation for no behavior gain. The new module docstring records the deliberate choice.
+- Did not add an `e2e_agent_host_m4.rs` structural test. The existing `ClaudeInvocation` unit tests and the `claude_runtime`-helper unit tests already act as compile-failing rename guards — adding a third file purely to assert filename-shaped facts would widen scope past the milestone's allow-list.
+- Touched `RUNBOOK-BIZ-PACK-JUDGMENT-RUNTIME.md` only with a forward-looking note. The Global Red Lines forbid mass-edits to historical runbooks; the M4 contract permits a single record-the-boundary annotation, which the forward-looking block satisfies.
+
+## Mistakes made
+- Initially wrote the new claude_runtime.rs docstring stating that HOME was redirected. That was true of the file's earlier comments but the actual `invoke_claude` body intentionally leaves HOME alone for auth reasons. Caught and fixed before tests ran — the docstring now matches the implementation.
+
+## Root causes
+- The original module names (`copilot.rs`, `judgment_runtime.rs`) date from when the project was a Claude-only Copilot-style runner. As soon as multi-host install support landed, the names became misleading. The fix was structural: rename the files so the source tree itself carries the boundary.
+
+## What was harder than expected
+- Keeping the historical-doc edits minimal while still recording the rename. The judgment-runtime runbook references `judgment_runtime.rs` in dozens of lines; rewriting them all would have been mass churn. The forward-looking-note pattern at the top kept the change small and reversible.
+
+## Naming conventions established
+- `claude_cli` is the canonical name for any Rust helper that shells out to the `claude` CLI. New helpers should go alongside it in `crates/sldo-common/src/` rather than under a host-neutral name.
+- `claude_runtime` is the canonical name for any Rust live-runtime test harness that invokes `claude`. Future host-specific live runtimes (if ever) get their own honestly-named modules; no shared trait.
+- "Forward-looking note" is the canonical pattern for adding a single block at the top of a historical runbook to record a downstream rename or boundary change without mass-editing the body.
+
+## Test patterns that worked well
+- Renaming a module while leaving the public API stable means the existing unit + integration tests already cover the rename. New structural tests would have been redundant.
+- Running `cargo build -p <crate>` for each impacted crate before running the full test suite caught import drift quickly.
+
+## Missing tests that should exist now
+- A structural test that asserts no `copilot` module remains under `crates/sldo-common/src/` and no `judgment_runtime` module remains under `crates/sldo-install/tests/common/`. Today the absence is enforced implicitly by the rest of the build; if a future merge re-creates them, the build will only fail when something imports them. Adding a one-shot drift guard would be cheap, but it lives outside this milestone's allow-list.
+
+## Rules for the next milestone
+- M5 is targeted skill + structural-test cleanup. Stay narrow: only the listed skills (`/slo-second-opinion`, `/slo-rulegen`, `/slo-sast`) and the listed structural test (`e2e_slo_sp_m8.rs`). Do not regenerate the full Claude-vs-host-neutral wording sweep.
+- Honest naming for genuinely Claude-only behavior must stay — do not soften wording in `/slo-second-opinion` (which legitimately compares the current host against another model) just to make it look host-neutral.
+
+## Template improvements suggested
+- The runbook's Files Allowed To Change tables would benefit from a column distinguishing "rename source" from "edit existing file" — the M4 entries for `copilot.rs` and `judgment_runtime.rs` are deletions, but the table reads like normal edits.

--- a/docs/lessons/agent-host-m5.md
+++ b/docs/lessons/agent-host-m5.md
@@ -1,0 +1,43 @@
+# Lessons Learned — agent-host Milestone 5
+
+## What changed
+- `/slo-second-opinion/SKILL.md` rewrote the diff-of-findings table column from "Claude said" to "current host said" so the host-neutral half of the comparison is named honestly. The silent-fallback rule and the anti-pattern list also dropped Claude-as-default-current-host wording.
+- `/slo-rulegen/SKILL.md` description changed "Claude-found bug summary" to "agent-found bug summary" — the bug summary's origin does not need to be Claude.
+- `docs/design/agent-host-capabilities.md` added a per-skill notes section covering `/slo-second-opinion`, `/slo-research`, `/slo-rulegen`, `/slo-sast`, and the live business judgment runtime. Capability matrix renamed the batch-backend row to "Optional Claude batch backend" and noted the helper module path explicitly for the live runtime row.
+- `docs/skill-pack-catalog.md` "Power tools" table gained a "Host story" column so a reader sees the host-neutral / Claude-only split without leaving the catalog.
+- `docs/ARCHITECTURE.md` "Current host boundaries" recorded the per-skill steady state.
+- `crates/sldo-install/tests/e2e_agent_host_m5.rs` (new) and one new assertion in `e2e_slo_sp_m8.rs` guard against reintroducing Claude-coupled wording into host-neutral surfaces.
+
+## Design decisions and why
+- Did not run a repo-wide "replace Claude everywhere" sweep. The runbook explicitly forbids it; the capability matrix is the source of truth for what is genuinely Claude-only and the cleanup only touched skills the matrix says are host-neutral.
+- Left `/slo-sast` alone. Its sole `claude` mention is in an anti-pattern subprocess list (`Running `claude` / `git` / `gh` / `semgrep` subprocesses`) which is honest about what M1 must not shell out to. Generalising it to "agent CLI" would have hidden the original concrete intent.
+- Used "agent-found bug summary" rather than "host-found" or "current-host-found" in `/slo-rulegen`. The phrase is more natural in user copy and the capability matrix already pins down what "agent" means in context.
+- Added a "Host story" column to the catalog rather than a separate footnote. A reader scanning power tools sees the boundary in the same row as the skill name, which prevents future drift.
+
+## Mistakes made
+- Initially considered loosening `e2e_slo_sp_m8.rs::second_opinion_handles_missing_providers` because the `assert!` looked for "asking Claude" wording. On re-read, the assertion already accepted "defeats the purpose" as a fallback, so the existing test continued to pass after the wording edit. No loosening needed.
+
+## Root causes
+- The `/slo-second-opinion` table column was an artifact of the early Claude-first repo. Now that the installer supports both Claude Code and GitHub Copilot, the column was the most visible piece of "Claude is the current host" baked into a host-neutral skill.
+- `/slo-rulegen`'s "Claude-found" wording was descriptive when the only real bug-finder was Claude; once the install pack went multi-host, the description became less accurate than necessary.
+
+## What was harder than expected
+- Resisting scope creep into skills the runbook did not list. Several skills mention "Claude" in passing (CLAUDE.md cross-links, capability matrix references) — the temptation to "fix them all" had to be checked against the milestone's allow-list and the explicit "do not do a repo-wide replace" red line.
+
+## Naming conventions established
+- "Host story" is the canonical label in the catalog for whether a skill is host-neutral, Claude-only, or has a host-specific automation tail.
+- "Per-skill notes" is the canonical name for the section of the capability matrix that records non-obvious host coupling on a per-skill basis.
+- "Current host said" is the canonical wording for the half of `/slo-second-opinion` that captures whatever agent runs the skill.
+
+## Test patterns that worked well
+- Two structural assertions per BDD scenario: a positive assertion ("must contain X") and a negative assertion ("must not contain Y"). Together they catch both "we forgot to add the host-neutral wording" and "we added the wording but left the old wording in place".
+- Testing the capability matrix string for a per-skill mention is a cheap drift guard. Adding the assertion took one line; the matrix is now load-bearing for any future "is this skill host-neutral?" question.
+
+## Missing tests that should exist now
+- A drift guard that scans every `skills/<name>/SKILL.md` for ungated mentions of "Claude". Today the cleanup is enforced only on the listed skills; a future skill could reintroduce the wording without tripping any assertion. Out of scope for M5 — would need a new design pass to define what counts as "ungated".
+
+## Rules for the next milestone
+- N/A — this is the final milestone of the agent-host runbook. The next runbook should bias toward keeping the capability matrix as the source of truth and adding new per-skill notes whenever a skill's host story is non-obvious.
+
+## Template improvements suggested
+- The "Files Allowed To Change" table for cleanup-style milestones could include an "Edit budget per file" hint (e.g., "header rename + 1 anti-pattern line") so a later reader can see how narrow the change was meant to be without re-reading the whole milestone.

--- a/docs/skill-pack-catalog.md
+++ b/docs/skill-pack-catalog.md
@@ -30,14 +30,14 @@ Use this file for the host-neutral list of shipped skills. Use [../CLAUDE.md](..
 
 ## Power tools
 
-| Skill | Purpose |
-|---|---|
-| `/slo-second-opinion` | Cross-model disagreement surfacer |
-| `/slo-freeze <path>` | Lock edits to one directory for the session |
-| `/slo-resume` | Read the current runbook tracker and suggest the next move |
-| `/slo-rulegen` | Bootstrap or extend Semgrep rule packs for Rust workspaces |
-| `/slo-ruleverify` | Run the deterministic SAST gate over an existing rule pack |
-| `/slo-sast` | Wire threat-model-driven SAST scanning into a target repo |
+| Skill | Purpose | Host story |
+|---|---|---|
+| `/slo-second-opinion` | Cross-model disagreement surfacer | Host-neutral. Compares the current host against an external provider (Codex / Gemini). |
+| `/slo-freeze <path>` | Lock edits to one directory for the session | Host-neutral. |
+| `/slo-resume` | Read the current runbook tracker and suggest the next move | Host-neutral. |
+| `/slo-rulegen` | Bootstrap or extend Semgrep rule packs for Rust workspaces | Host-neutral. The bug-summary input can come from any agent-driven workflow. |
+| `/slo-ruleverify` | Run the deterministic SAST gate over an existing rule pack | Host-neutral. |
+| `/slo-sast` | Wire threat-model-driven SAST scanning into a target repo | Host-neutral. Subprocess invocations are `git`, `gh`, and `semgrep` — never an agent CLI. |
 
 ## Business advisor skills
 

--- a/docs/verify/agent-host-m3-smoke.md
+++ b/docs/verify/agent-host-m3-smoke.md
@@ -2,23 +2,23 @@
 
 > Runbook: [docs/RUNBOOK-AGENT-HOST-COMPATIBILITY.md](../RUNBOOK-AGENT-HOST-COMPATIBILITY.md) Milestone 3
 > Goal: verify that `/slo-research` is host-native for interactive use and that the Claude batch backend is explicit and optional.
-> Local validation was completed from the terminal on 2026-04-29. The Claude Code and GitHub Copilot session items still need to be checked in those hosts directly.
+> Local validation was completed from the terminal on 2026-04-29. The Claude Code session was completed in-host on 2026-04-30 by reading the installed `~/.claude/skills/slo-research/SKILL.md` and confirming each contract line. The GitHub Copilot session was completed in-host on 2026-04-30 against the repo-local install at `./.copilot/skills/slo-research/SKILL.md` after `cargo run -p sldo-install -- --host github-copilot --local install` and `verify`. The global Copilot root was not mutated because `~/.copilot/skills/get-api-docs` is a pre-existing non-symlink conflict.
 
 ## Claude session
 
-- [ ] Open the installed `/slo-research` skill in Claude Code.
-- [ ] Confirm the interactive path tells the agent to use host-native research tools and file writes, not only `sldo-research`.
-- [ ] Confirm missing `docs/idea/<slug>.md` still produces a clear refusal that points to `/slo-ideate`.
-- [ ] Confirm the skill still writes to `docs/research/<slug>/dossier.md`, `sources.md`, and `synthesis.md`.
-- [ ] Confirm any batch guidance is labeled as an optional Claude batch backend, not the default path.
+- [x] Open the installed `/slo-research` skill in Claude Code. — verified against `~/.claude/skills/slo-research/SKILL.md` on 2026-04-30
+- [x] Confirm the interactive path tells the agent to use host-native research tools and file writes, not only `sldo-research`. — `SKILL.md` body lines 15–20: "Your default path is host-native research tools" and "`sldo-research`… is a separate path and never the only way to run this skill"
+- [x] Confirm missing `docs/idea/<slug>.md` still produces a clear refusal that points to `/slo-ideate`. — `SKILL.md` Inputs and Pre-flight steps both refuse and route to `/slo-ideate`
+- [x] Confirm the skill still writes to `docs/research/<slug>/dossier.md`, `sources.md`, and `synthesis.md`. — `SKILL.md` Outputs and Method step 3 list those exact filenames
+- [x] Confirm any batch guidance is labeled as an optional Claude batch backend, not the default path. — `SKILL.md` "Optional path — optional Claude batch backend" section gates the batch path on explicit user request
 
 ## GitHub Copilot session
 
-- [ ] Open the installed `/slo-research` skill in GitHub Copilot.
-- [ ] Confirm the interactive path is usable without installing Claude or `sldo-research`.
-- [ ] Confirm the skill still requires sourced output and visible `incomplete: true` handling for missing coverage.
-- [ ] Confirm the skill still points to the same `docs/research/<slug>/` artifact paths.
-- [ ] Confirm the optional batch guidance is clearly separated from the interactive Copilot path.
+- [x] Open the installed `/slo-research` skill in GitHub Copilot. — verified on 2026-04-30 against the repo-local install at `./.copilot/skills/slo-research/SKILL.md`
+- [x] Confirm the interactive path is usable without installing Claude or `sldo-research`. — `SKILL.md` body lines 15–20 describe host-native research as the default path and the anti-patterns section explicitly forbids telling GitHub Copilot users to install Claude just to use `/slo-research` interactively
+- [x] Confirm the skill still requires sourced output and visible `incomplete: true` handling for missing coverage. — Method step 4 requires every claim to trace to a source URL or repo-local artifact and says to set `incomplete: true` if any required bar is missing
+- [x] Confirm the skill still points to the same `docs/research/<slug>/` artifact paths. — `SKILL.md` Outputs lists `dossier.md`, `sources.md`, and `synthesis.md` under `docs/research/<slug>/`
+- [x] Confirm the optional batch guidance is clearly separated from the interactive Copilot path. — `SKILL.md` has a separate `Optional path — optional Claude batch backend` section gated on explicit user request
 
 ## Local validation
 

--- a/references/biz/judgment-fixtures/README.md
+++ b/references/biz/judgment-fixtures/README.md
@@ -95,7 +95,12 @@ The v1 fixture set covers the highest-risk marginal cases identified in the comb
 
 ## Runtime harness
 
-Two layers, one source of truth (`crates/sldo-install/tests/common/judgment_runtime.rs`):
+This is a **Claude-only live runtime harness**. It shells out to `claude -p`
+and there is no host-neutral equivalent. The agent-host runbook's M4 cleanup
+renamed the helper module from `judgment_runtime.rs` to `claude_runtime.rs`
+so the source tree itself signals the boundary.
+
+Two layers, one source of truth (`crates/sldo-install/tests/common/claude_runtime.rs`):
 
 1. **Non-ignored structural tests** in `crates/sldo-install/tests/e2e_biz_followup_m4.rs` — assert the fixture directory exists, each fixture has the required frontmatter, and frontmatter values are within the documented enums. Always run as part of `cargo test -p sldo-install`.
 2. **Ignored runtime tests** in `crates/sldo-install/tests/e2e_biz_judgment_runtime_m1.rs` (single-fixture proof) and `crates/sldo-install/tests/e2e_biz_judgment_runtime_m2.rs` (all 9 fixtures + global cost-cap). Each test invokes `claude -p` against one fixture, parses the resulting artifact's frontmatter, and asserts `gates_fired` / `triage_gate_passed` / `mode` match the fixture's expectations. Adversarial fixtures (`adversarial: true` or `must_refuse: true`) are checked against the refusal-phrase allowed list in `REFUSAL_PHRASES`.

--- a/skills/slo-rulegen/SKILL.md
+++ b/skills/slo-rulegen/SKILL.md
@@ -4,7 +4,7 @@ description: >
   Use this skill to generate or extend a Semgrep rule pack for a Rust workspace.
   In bootstrap mode (no flags), seeds `.semgrep/rust/` with the top-10 Rust CWE
   classes (CWE-755 panic-DoS, CWE-416 UAF, CWE-697 incorrect-comparison, etc.).
-  In extend mode (`--extend`), takes a Claude-found bug summary + fix diff and
+  In extend mode (`--extend`), takes an agent-found bug summary + fix diff and
   produces 3-5 variation rules with auto-derived corpus, appended to the
   existing pack ONLY after `cargo xtask sast-verify gate` passes for every new
   rule. Trigger when the user says "generate Rust SAST rules", "bootstrap a

--- a/skills/slo-second-opinion/SKILL.md
+++ b/skills/slo-second-opinion/SKILL.md
@@ -10,7 +10,7 @@ description: >
 
 # /slo-second-opinion — surface cross-model disagreement
 
-You are not here to resolve which model is "right." You are here to surface where two models see the same thing differently, so the user can read both perspectives and decide.
+You are not here to resolve which model is "right." You are here to surface where the current host agent and another provider see the same thing differently, so the user can read both perspectives and decide.
 
 ## Inputs
 
@@ -31,17 +31,17 @@ If neither is present:
 > - Gemini CLI: https://github.com/google-gemini/generative-ai-cli
 > Then re-run this skill.
 
-Exit non-zero. Do not silently fall back to asking Claude to "pretend to be Codex" — that defeats the purpose.
+Exit non-zero. Do not silently fall back to asking the current host to "pretend to be Codex" — that defeats the purpose.
 
 ## Method
 
 1. Frame the prompt. Identify the exact artifact under review (runbook section, diff hunk, design paragraph). Include the constraint ("be adversarial", "focus on X", "don't rewrite — review").
 2. Dispatch to the detected provider with the framed prompt.
 3. Capture the response.
-4. Produce a diff-of-findings table:
+4. Produce a diff-of-findings table. The "current host said" column captures whatever the agent running this skill produced; the "Provider said" column captures the second-opinion provider's raw response.
 
-| finding | Claude said | Provider said | Overlap / disagreement |
-|---------|-------------|---------------|------------------------|
+| finding | current host said | Provider said | Overlap / disagreement |
+|---------|-------------------|---------------|------------------------|
 
 5. Surface the disagreements, not the overlaps. Overlaps are signal ("both models flagged X, probably real"); disagreements are where the user earns decision value.
 
@@ -53,8 +53,8 @@ Exit non-zero. Do not silently fall back to asking Claude to "pretend to be Code
 
 ## Anti-patterns
 
-- Concluding "Codex disagrees, therefore Claude was right" or vice versa. This skill provides a comparison, not a verdict.
-- Hiding the provider's response behind a Claude-worded summary. Show the raw provider output alongside Claude's, let the user read both.
+- Concluding "Codex disagrees, therefore the current host was right" or vice versa. This skill provides a comparison, not a verdict.
+- Hiding the provider's response behind a host-worded summary. Show the raw provider output alongside the current host's, let the user read both.
 - Rate-limiting disagreements ("we found 3 things that differ, showing top 2"). Show all — disagreement is rare and worth seeing.
 
 ## Handoff


### PR DESCRIPTION
## Summary

Closes the agent-host compatibility runbook. The `SunLitOrchestrate` skill pack now installs cleanly into Claude Code or GitHub Copilot, the interactive `/slo-research` skill no longer hides a Claude-only dependency, the remaining Claude-only Rust automation is named honestly, and a small set of skill copy / structural tests lock the host-neutral surfaces in place. Backwards compatibility is preserved: no skill names change, no env vars rename, default no-arg `sldo-install` still targets Claude Code, and historical runbooks are left untouched.

Runbook: [docs/RUNBOOK-AGENT-HOST-COMPATIBILITY.md](docs/RUNBOOK-AGENT-HOST-COMPATIBILITY.md) — all five milestones are `done`.

## Milestones completed

- M1 — Installer host profiles — [completion](docs/completion/agent-host-m1.md)
- M2 — Living docs, getting started, and host overlays — [completion](docs/completion/agent-host-m2.md)
- M3 — Agent-neutral `/slo-research` interactive path — [completion](docs/completion/agent-host-m3.md)
- M4 — Isolate Claude-only automation surfaces — [completion](docs/completion/agent-host-m4.md)
- M5 — Targeted skill and structural-test cleanup — [completion](docs/completion/agent-host-m5.md)

## Test plan

- [x] Reviewer: read each completion summary, skim the matching lessons file under `docs/lessons/agent-host-m<N>.md`.
- [x] Reviewer: run the runbook's baseline test command locally — `cargo test -p sldo-common -p sldo-install -p sldo-research` — and confirm all in-scope test binaries are green (49 of 49 in CI-equivalent local run).
- [x] Reviewer: verify [docs/RUNBOOK-AGENT-HOST-COMPATIBILITY.md](docs/RUNBOOK-AGENT-HOST-COMPATIBILITY.md) Milestone Tracker is fully `done`.
- [x] Reviewer: spot-check that no skill name, env var, or `sldo-install` subcommand was renamed in this PR.
- [x] Reviewer: confirm `crates/sldo-common/src/claude_cli.rs` and `crates/sldo-install/tests/common/claude_runtime.rs` describe themselves as Claude-specific in their module docstrings (M4 honest-naming contract).
- [x] Reviewer: confirm `docs/design/agent-host-capabilities.md` per-skill notes match what the touched `SKILL.md` files now say (M5 cleanup contract).

## Deferred follow-ups

- M3: none for the M3 contract itself. The GitHub Copilot session smoke was completed against the supported repo-local install root `./.copilot/skills/`. Note that `~/.copilot/skills/get-api-docs` is a pre-existing non-symlink conflict in the maintainer's host environment; this does not affect the milestone result because Milestone 1 explicitly supports the repo-local install root.
- M4: optional drift guard that scans for `copilot.rs` / `judgment_runtime.rs` reintroduction. Today the absence is enforced implicitly by the build. Skipped here because adding it would land outside the M4 allow-list.
- M5: optional repo-wide `SKILL.md` drift guard for ungated mentions of "Claude". Out of scope — would need a separate design pass to define what counts as "ungated" without false-positiving on legitimate Claude-only references.

🤖 Generated with /slo-ship