### PR TITLE
docs: rewrite README around the three core contributions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,12 +9,15 @@ docs/legal
 # MSVC Windows builds of rustc generate these, which store debugging information
 *.pdb
 
-# RustRover
-#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
-#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
-#  and can be added to the global gitignore or merged into this file.  For a more nuclear
-#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
-#.idea/
+# Rust coverage instrumentation (cargo llvm-cov / tarpaulin)
+*.profraw
+
+# IDE / editor local state
+.vscode/
+.idea/
+*.swp
+*~
+
 .env
 .DS_Store
 
@@ -24,6 +27,13 @@ docs/legal
 
 # Research dossier output directory
 output/
+
+# Confidential biz-skill output (real PII, deal terms, real-person details).
+# Contract: CLAUDE.md "Two-tier output: docs/biz/ (gitignored) and
+# docs/biz-public/ (git-tracked)". Skills writing here include /slo-cofounder,
+# /slo-hire, /slo-founder-check, /slo-talk-to-users, plus confidential drafts
+# from /slo-equity, /slo-fundraise, /slo-legal, /slo-accounting.
+docs/biz/
 
 # User-local host-agent state in this repo (scheduled_tasks.lock, settings.local.json)
 .claude/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,3 +67,32 @@ The pack's value is in explicit guardrails. Do not skip:
 ## License
 
 By contributing, you agree your contribution is dual-licensed under Apache-2.0 OR MIT, matching the project (see [LICENSE](LICENSE)).
+
+## Sign-off — Developer Certificate of Origin
+
+Every commit must carry a `Signed-off-by:` trailer asserting the [Developer Certificate of Origin 1.1](https://developercertificate.org/). This is a lightweight attestation that you have the right to contribute the work under the project's licence; it is not a Contributor Licence Agreement and does not transfer copyright.
+
+Add the trailer automatically with `git commit -s` (or `git commit --signoff`). The trailer looks like:
+
+```
+Signed-off-by: Your Name <your.email@example.com>
+```
+
+The name must be your real name (no anonymous / pseudonymous contributions) and the email must match the email on the commit. If you have multiple commits in a PR, each commit needs its own sign-off — `git rebase --signoff main` adds the trailer to existing commits in your branch.
+
+Why DCO and not a CLA: the DCO keeps the contribution barrier low (no agreement to e-sign, no separate database to maintain) while still establishing a clear chain of provenance. It does not grant the project relicensing rights — your contributions remain Apache-2.0 OR MIT in perpetuity, matching the project licence.
+
+## New source files — copyright and SPDX header
+
+For **new** source files you create, add this header at the top:
+
+```rust
+// Copyright 2026 Sherif Mansour and SunLitOrchestrate contributors.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+```
+
+(Adjust comment syntax for the language.) Existing files do not need to be retroactively headered — the project-level [NOTICE](NOTICE) and [LICENSE](LICENSE) cover the repo as a whole. The per-file header is belt-and-braces for new code, not a requirement to bulk-edit existing code.
+
+## Trade-marks
+
+The Apache-2.0 / MIT dual licence grants no rights in the project name or logo. See [TRADEMARKS.md](TRADEMARKS.md) for what permission you do and do not need before using the name in a fork, derivative, or downstream product.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,16 @@
+SunLitOrchestrate
+Copyright 2026 Sherif Mansour
+
+Licensed under either of:
+
+  * Apache License, Version 2.0
+    (https://www.apache.org/licenses/LICENSE-2.0)
+
+  * MIT License
+    (https://opensource.org/licenses/MIT)
+
+at your option. See LICENSE for both full texts.
+
+Trade-mark notice: see TRADEMARKS.md. Neither the Apache 2.0 licence (see
+section 6 of that licence) nor the MIT licence grants any rights in the
+project's name or logo.

--- a/README.md
+++ b/README.md
@@ -221,14 +221,20 @@ This project adopts the [Contributor Covenant 2.1](https://www.contributor-coven
 
 ## License
 
+Copyright 2026 Sherif Mansour. An open-source project by Sherif Mansour.
+
 Dual-licensed under either of:
 
 - [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [MIT license](https://opensource.org/licenses/MIT)
 
-at your option (see [LICENSE](LICENSE) for both texts). Pick whichever fits your project; you do not need to comply with both.
+at your option (see [LICENSE](LICENSE) for both texts, and [NOTICE](NOTICE) for the project-level copyright notice). Pick whichever fits your project; you do not need to comply with both.
 
-Unless you explicitly state otherwise, any contribution intentionally submitted for inclusion in the work by you, as defined in the Apache-2.0 license, shall be dual-licensed as above, without any additional terms or conditions.
+Unless you explicitly state otherwise, any contribution intentionally submitted for inclusion in the work by you, as defined in the Apache-2.0 license, shall be dual-licensed as above, without any additional terms or conditions. Contributions require a Developer Certificate of Origin sign-off — see [CONTRIBUTING.md](CONTRIBUTING.md#sign-off--developer-certificate-of-origin).
+
+## Trade-marks
+
+**SunLitOrchestrate** and the associated logo are unregistered trade-marks of Sherif Mansour. The Apache-2.0 / MIT licences grant rights in the code, not in the name or logo — see [TRADEMARKS.md](TRADEMARKS.md) for what permission you do and do not need.
 
 ## Acknowledgements
 

--- a/README.md
+++ b/README.md
@@ -1,22 +1,108 @@
 # SunLitOrchestrate
 
-> An AI-first workflow that turns "build this" into scoped, reviewable, testable work. SunLitOrchestrate adds durable guardrails around LLM execution: idea → research → architecture → plan → critique → execute → verify → ship → reflect.
+> A contract-driven workflow for AI-assisted software delivery. SunLitOrchestrate turns "build this" into scoped, reviewable, testable work, with security considerations and durable guardrails wired in at every stage: idea → research → architecture → plan → critique → execute → verify → ship → reflect.
 
-## Why SunLitOrchestrate
+Three contributions make this pack distinct: **(1) a runbook artifact that bakes best practices into every milestone**, **(2) security wired into every step rather than bolted on at the end**, and **(3) an opt-in TLA+ formal-specification stage for designs that need it**. See [What makes SunLitOrchestrate different](#what-makes-sunlitorchestrate-different) for what each one actually buys you.
 
-SunLitOrchestrate is for teams who like fast LLM output but dislike silent scope drift, missing rationale, and lessons that die in chat history.
+**License:** [Apache-2.0 OR MIT](LICENSE) (dual; pick either) — explicitly NOT AGPL. **Status:** active development. The skill pack and Rust CLIs are stable.
 
-- **Stop silent scope widening**: every feature lives in a `docs/RUNBOOK-<feature>.md` with allowed files, forbidden shortcuts, BDD scenarios, abuse cases, and regression tests.
-- **Preserve the why**: research dossiers, threat models, runbooks, lessons, and completion summaries survive across sessions and reviewers.
-- **Add formal rigor where it matters**: `/slo-tla` gives the workflow an explicit TLA+ step for designs with real concurrency, ordering, or protocol risk, so the system can be challenged as a spec before it is implemented as code.
-- **Keep follow-ups alive**: `/slo-retro` captures what was learned, and `/slo-resume` is the "what next?" entrypoint when work gets interrupted.
-- **Default to reviewability**: the pack prefers explicit contracts, adversarial critique, and verification over "the model will probably remember".
+## The problem
+
+LLM-assisted development is fast at producing code and slow at producing the things that make code useful afterwards: a clear scope, a recorded rationale, an honest threat model, an executable verification plan, and lessons that survive the next conversation. The default failure modes are easy to recognise:
+
+- **Silent scope drift** — the model "helpfully" rewrites adjacent files; the diff balloons; review becomes a coin flip.
+- **Lost rationale** — the *why* lives in a chat transcript that no one reads three weeks later.
+- **Verification theatre** — "the tests pass" without a written contract for what the tests are supposed to prove.
+- **Security as an afterthought** — threat modelling, SAST, and abuse cases happen (if at all) after the code is already merged.
+- **Lessons that die in chat** — the same mistake gets re-made next sprint because nothing was captured outside the session.
+
+The bet behind SunLitOrchestrate is that these failures are not LLM limitations — they are *workflow* limitations. The model can produce strong work when the surrounding workflow forces it to commit to scope, rationale, and verification before code is written.
+
+## What SunLitOrchestrate is
+
+A **skill pack** — a set of `/slo-*` slash commands installed into a host AI coding agent (Claude Code by default, GitHub Copilot also supported) — plus a small Rust toolchain that installs the pack, provides an optional batch backend for `/slo-research`, and runs a Semgrep rule gate (`cargo xtask sast-verify`) wired to the SAST skills.
+
+The pack is organised around three workflows that compose:
+
+1. **Core sprint flow** — `/slo-ideate → /slo-research → /slo-architect → /slo-plan → /slo-critique → /slo-execute → /slo-verify → /slo-retro → /slo-ship`. Each stage produces a versioned artifact under `docs/` that the next stage (and the next reviewer) can rely on. Optional `/slo-tla` adds a TLA+ model-check step for designs with real concurrency, ordering, or protocol risk.
+2. **Security + SAST** — `/slo-rulegen`, `/slo-ruleverify`, `/slo-sast`. A 10/10 CWE Semgrep rule pack is included, gated by CI.
+3. **UK biz pack (v1)** — 15 founder, GTM, pricing, legal, accounting, equity, and hiring artifact skills, with mandatory hard-block gates (regulated work, large counterparties, GDPR, IR35) and confidential-vs-public output tiers.
+
+The raw `SKILL.md` contract is agent-neutral, so the pack is portable between hosts. Canonical list: [docs/skill-pack-catalog.md](docs/skill-pack-catalog.md).
+
+## What makes SunLitOrchestrate different
+
+Three contributions distinguish this pack from other AI-coding workflows. Everything else in the project exists to support them.
+
+### 1. The runbook artifact — a template that bakes in best practices
+
+Every feature is bound to a `docs/RUNBOOK-<feature>.md` produced by `/slo-plan` against the canonical [v4 runbook template](docs/slo/templates/runbook-template_v_4_template.md). The template *is* the contribution — it forces every milestone, before any code is written, to declare:
+
+- **Scope** — exactly which files are allowed and which shortcuts are forbidden, so out-of-scope edits become contract violations rather than judgment calls the model gets to make on its own.
+- **Behaviour** — BDD scenarios for the golden path, *plus* explicit abuse cases for the failure modes an attacker or careless caller would hit.
+- **Verification** — the regression tests that close the loop, the interface contracts the milestone must respect, and the gates `/slo-verify` will run.
+- **Reliability** — Carmack-style controls layered on top of v3: debugger-first inspection, mandatory static analysis, assertion-driven invariants, bounded resource design, "make invalid states unrepresentable".
+- **Carry-forward** — lessons and threat-model deltas pulled from prior retros, so each runbook *learns* from the last one rather than starting blank.
+
+The runbook outlives the LLM session that produced it. It is what the next reviewer reads, what the next runbook inherits from, and what the project's institutional memory is recorded in. Best practices stop being something you have to remember to apply — they are baked into the artifact you cannot avoid producing.
+
+### 2. Security on every step, not a separate phase
+
+Most AI-coding workflows treat security as a closing checklist or a separate audit pass. SunLitOrchestrate wires it into the sprint flow from the very first stage, and threads it forward through every subsequent one:
+
+- **`/slo-ideate`** — before any architecture exists, ideation asks: *"what is the worst day this system causes?"* The output must name three concrete failure outcomes — a breach (which data leaves the trust boundary, to whom), a compliance fine (which regulation, what scale), or a prolonged outage (who notices, how long until the user defects). Vague answers like "security matters" or "downtime is bad" are explicitly rejected. Those named risks are what `/slo-architect` builds the threat model from — security is on the table before code exists as a concept.
+- **`/slo-architect`** — produces a STRIDE threat model and an abuse-case set on *every* pass, not optionally and not later. The threat-model rows become the seed for the abuse cases the next stage carries forward, and the architecture doc records the security best practices the build is committed to (proactive-controls vocabulary, named secure libraries, data-classification posture).
+- **`/slo-plan`** — the v4 runbook template has three mandatory security rows in the Contract Block of every milestone: **data classification** (`Public | Internal | Confidential | Restricted`), **proactive controls in play** (OWASP C1–C10 and named libraries from the SunLitSecureLibraries / Hulumi vocabularies), and **abuse acceptance scenarios** (concrete attacker-role + step + outcome, each citing a threat-model row). Silent omission is forbidden — the only acceptable empty answer is `N/A — no new surface introduced` with a reason. BDD Acceptance Scenarios additionally require abuse-case rows whenever a new surface is introduced. The plan template *bakes in* secure coding and testing — you cannot ship a runbook that doesn't account for them.
+- **`/slo-execute`** — writes BDD tests first, *including the abuse-case rows*. Security tests are part of the red-green TDD cycle from the start, not bolted on after the feature works. The skill is also bound to the runbook's allow-list, so it cannot silently widen scope into adjacent files — closing one of the most common attack surfaces against the workflow itself. Each security consideration declared in the plan becomes a concrete test the milestone has to pass.
+- **`/slo-verify`** — runs a PII-pattern scan over public output paths (Pass 4), so confidential drafts cannot accidentally leak through the public tier; runtime QA closes the loop on the abuse-case scenarios.
+- **`/slo-rulegen` + `/slo-ruleverify` + `/slo-sast`** — maintain and CI-gate a 10/10 CWE-class Semgrep rule pack against the codebase, so the static-analysis layer is also kept honest as the project evolves.
+- **The UK biz pack** — adds hard-block gates (regulated work, counterparties >£5,000, GDPR-scoped documents, IR35-triggering hires) that refuse to draft until the right human is in the loop.
+
+The consequence: there is no "security review" stage at the end, because there is no stage *without* security in it. From the first ideation question — *"what's the worst that can happen?"* — through threat model, plan template, BDD test scaffolding, runtime verification, and CI rule gate, security is something the workflow *forces* you to commit to and execute on, not something you might remember to do.
+
+### 3. TLA+ formal specification for designs that earn it
+
+Almost no AI-coding workflow offers a formal-methods step at all. SunLitOrchestrate adds `/slo-tla` as an explicit stage between architecture and plan, for designs where concurrency, ordering, or protocol risk is real. The skill drives a TLC model-check of the design *as a specification* before any code is written — so the class of bug that would only surface under contention, partial failure, or unusual interleavings in production gets caught while the design is still text.
+
+The decision of whether a runbook needs TLA+ is set during `/slo-architect` via the `tla_required: true | false` field, so it is visible, recorded, and reviewable rather than implicit. When the flag is true, the runbook cannot proceed past plan without a passing model-check; when false, the reasoning for skipping it is recorded in the architecture doc. Either way, the choice is on the record.
+
+The result: well-designed solutions are the default, not an artifact of "the engineer happened to think about it carefully this time".
+
+## How it works
+
+A normal sprint runs the sprint-flow skills in order. Each stage produces a checked-in artifact under `docs/` that the next stage (and the next reviewer) can rely on — the workflow is the chain of artifacts, not a chain of prompts.
+
+```text
+/slo-ideate          # interrogate the problem; Q7 forces "what's the worst day this system causes?"
+/slo-research        # produce a sourced dossier with named adversaries, named regulations, named UX failures
+/slo-architect       # commit to a stack, build a STRIDE threat model, record security best practices
+/slo-tla             # optional: model-check the design when concurrency / ordering / protocol risk is real
+/slo-plan            # write the v4 runbook one milestone at a time (data classification + proactive controls + abuse cases mandatory)
+/slo-critique        # four-persona adversarial review (CEO, eng, security, design) before any code is written
+/slo-execute M1      # drive one milestone within the allow-list — BDD tests first, including abuse-case rows
+/slo-verify M1       # runtime QA + Playwright (if UI) + PII scan over public outputs
+/slo-retro M1        # lessons + completion summary + tracker update
+# ... repeat /slo-execute / /slo-verify / /slo-retro per milestone ...
+/slo-ship            # open a runbook-aware PR linking to the artifacts above
+```
+
+Two re-entry paths matter:
+
+- **`/slo-resume`** — the pack's read-only orientation path. If you step away mid-runbook, it reads the tracker and suggests the next action without starting work for you.
+- **Security-only adoption** — `/slo-rulegen` and `/slo-ruleverify` can run standalone against any Rust codebase to maintain the CWE Semgrep rule pack, without running the rest of the sprint flow. See [Quick start → Security-only quick path](#security-only-quick-path).
+
+The artifacts produced by each stage live under `docs/slo/` (idea, research dossier, architecture, threat model, runbook, retro, completion summary). They are the project's institutional memory and the input to the *next* runbook's carry-forward.
+
+## When NOT to use it
+
+- **Throwaway scripts and one-shot prototypes.** The runbook discipline doesn't pay back if the artifact won't be read twice.
+- **Teams that want a low-friction "vibe-code with the LLM" loop.** SunLitOrchestrate is intentionally heavier on contracts than on autonomy. If you don't want the contracts, the rest of the pack will feel like ceremony.
+- **Non-UK jurisdictions for the biz pack.** v1 is UK-only by design; non-UK is a fresh `/slo-architect` pass, not a flag.
+- **Headless / CI-only automation as the primary path.** Most skills are interactive today. See [docs/slo/design/agent-host-capabilities.md](docs/slo/design/agent-host-capabilities.md) for the exact boundary.
+
+## Where to go next
 
 If this is your first time here, start with [docs/getting-started.md](docs/getting-started.md). Unfamiliar acronyms (TLA+, BDD, CWE, SEIS, IR35, CAC, NDR, …) are defined in [docs/GLOSSARY.md](docs/GLOSSARY.md).
-
-**License:** [Apache-2.0 OR MIT](LICENSE) (dual; pick either) — explicitly NOT AGPL.
-
-**Status:** active development. The skill pack and Rust CLIs are stable.
 
 ## What ships here
 
@@ -80,23 +166,7 @@ What success looks like:
 
 `/slo-research` now uses host-native research first in both Claude Code and GitHub Copilot. `sldo-research` remains an optional Claude batch backend when you explicitly want that automation path.
 
-### Typical flow
-
-```text
-/slo-ideate          # interrogate the problem before code exists
-/slo-research        # produce a sourced dossier
-/slo-architect       # commit to a stack + threat model
-/slo-tla             # optional: model-check the design when concurrency or ordering risk is real
-/slo-plan            # write the v3 runbook one milestone at a time
-/slo-critique        # run the adversarial review pass
-/slo-execute M1      # drive one milestone within the allow-list
-/slo-verify M1       # runtime QA + Playwright if UI
-/slo-retro M1        # lessons + completion + tracker update
-# ... repeat /slo-execute / /slo-verify / /slo-retro per milestone ...
-/slo-ship            # open a runbook-aware PR
-```
-
-If you step away mid-runbook, use `/slo-resume`. It is the pack's read-only orientation path: it reads the tracker and suggests the next action.
+For the canonical sprint sequence (ideate → ship), see [How it works](#how-it-works) above.
 
 ### Security-only quick path
 
@@ -245,3 +315,5 @@ Unless you explicitly state otherwise, any contribution intentionally submitted 
 - John Carmack's [*Best programming setup and IDE*](https://youtu.be/tzr7hRXcwkw?si=SeeakVCVpqWatOUl) clip from the Lex Fridman Podcast for influencing the v4 runbook template's Carmack-style reliability controls — debugger-first inspection, mandatory static analysis, assertion-driven invariants, bounded resource design, and "make invalid states unrepresentable".
 - The [oneNDA](https://www.onenda.org/) consortium for the canonical UK NDA template the biz-pack `/slo-legal draft nda` flow points users to. Licensed under [CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0/); the canonical `.docx` is fetched manually by the user from onenda.org and is never copied, modified, rendered, or redistributed by this repo. The skill produces only a separate Markdown cover artifact for company-specific fields — assembly happens on the user's machine, against the user's locally-downloaded canonical `.docx`.
 - The [SeedLegals](https://seedlegals.com/) public pricing page as the v1 cost baseline anchor for biz-pack ROI claims, alongside JPP Law's fixed-fee public pricing.
+- Garry Tan's [gstack](https://github.com/garrytan/gstack) for the skill-pack-as-workflow pattern that shaped the overall structure of SunLitOrchestrate's `/slo-*` skills — the idea that a stage-aware collection of opinionated skills can carry a project from ideation to ship more reliably than ad-hoc prompting.
+- OpenAI's [Symphony](https://github.com/openai/symphony) for influencing how SunLitOrchestrate thinks about multi-agent orchestration and the seams between specialist roles in a development workflow.

--- a/TRADEMARKS.md
+++ b/TRADEMARKS.md
@@ -1,0 +1,31 @@
+# Trade-marks
+
+**SunLitOrchestrate** and the associated logo are unregistered trade-marks of **Sherif Mansour**.
+
+The dual licence on this repository ([Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0) OR [MIT](https://opensource.org/licenses/MIT)) grants you rights in the **code**. It does **not** grant you rights in the **name** or **logo**:
+
+- **Apache License, Version 2.0** explicitly excludes trade-mark grants — see [section 6](https://www.apache.org/licenses/LICENSE-2.0#trademarks) of that licence: *"This License does not grant permission to use the trade names, trademarks, service marks, or product names of the Licensor."*
+- **MIT** is silent on trade-marks. Silence does not transfer rights — under UK and US trade-mark law, rights are reserved to the owner by default.
+
+## What you may do without permission
+
+- Use, modify, distribute, and sublicense the code under the terms of either Apache-2.0 or MIT (your choice).
+- Refer to the project by name in factual, descriptive, non-endorsing ways — e.g. *"compatible with SunLitOrchestrate"*, *"a fork of SunLitOrchestrate"*, *"based on SunLitOrchestrate"* — provided the use does not imply sponsorship, affiliation, or endorsement.
+- Use the name in academic citation, journalism, technical documentation, or commentary.
+
+## What requires written permission
+
+- Using **SunLitOrchestrate** as the name (or part of the name) of a fork, derivative, product, service, or company.
+- Using the **logo** in any context other than unmodified inclusion in the source tree.
+- Any use that could reasonably create confusion as to the origin or sponsorship of a fork or derivative.
+- Domain registrations containing **sunlitorchestrate** or confusingly similar variants.
+
+If you fork the project and modify it materially, please rename the fork. The Apache 2.0 / MIT licences guarantee your right to fork; the trade-mark reservation guarantees that the name continues to identify the upstream project.
+
+## Requesting permission
+
+Open a GitHub issue tagged `trademark` at https://github.com/kerberosmansour/SunLitOrchestrate or contact Sherif Mansour directly via the contact details in the GitHub profile.
+
+## Future assignment
+
+Sherif Mansour intends to assign these trade-marks (and the associated copyrights) to a UK limited company on its incorporation. This notice will be updated at that time. Existing licences granted under Apache-2.0 / MIT remain in force regardless of any future assignment — those licences are irrevocable as to the code already published.


### PR DESCRIPTION
## Summary

- **README rewrite (8a984dc).** Restructures the opening so a reader hits **problem → artifact → three differentiating contributions → canonical sprint flow** before any install instructions. The three contributions get a dedicated `## What makes SunLitOrchestrate different` section with one numbered subsection each: (1) the v4 runbook artifact as a template that bakes in best practices, (2) security woven into every stage of the sprint flow (`/slo-ideate` Q7 → `/slo-architect` STRIDE → `/slo-plan` mandatory Contract Block security rows → `/slo-execute` BDD-tests-first-including-abuse-cases → `/slo-verify` PII scan → `/slo-rulegen` CI gate → biz-pack hard blocks), and (3) the optional TLA+ formal-specification stage. Also promotes the typical-flow walkthrough from a buried Quick-start subsection to a top-level `## How it works` section, with each inline comment enriched to teach what the stage actually produces. Adds Acknowledgements entries for Garry Tan's [gstack](https://github.com/garrytan/gstack) and OpenAI's [Symphony](https://github.com/openai/symphony).
- **Governance polish (9c5519d).** Adds Developer Certificate of Origin sign-off requirement to CONTRIBUTING.md, a project-level copyright note in README.md, and a new TRADEMARKS.md for unregistered trade-mark posture on the SunLitOrchestrate name + logo.
- **Repo hygiene (2a86b4f).** Adds `docs/biz/` (the contracted-but-missing rule per CLAUDE.md "two-tier output" invariant — `/slo-cofounder`, `/slo-hire`, `/slo-founder-check`, `/slo-talk-to-users`, and confidential drafts from biz advisors all write here), plus defensive entries for `*.profraw` (Rust coverage), `.vscode/`, `.idea/`, `*.swp`, `*~`. Adds NOTICE for project-level copyright.

All three commits are docs/governance-only — no code or skill changes.

## Test plan

- [x] Render the README on GitHub and confirm the three contributions land within the first screen and the new `## How it works` section appears before `## When NOT to use it`.
- [x] Verify the in-page anchor `#what-makes-sunlitorchestrate-different` (used in the teaser line) resolves on GitHub's heading-slug rules.
- [x] Verify the in-page anchor `#how-it-works` (used in the Quick start back-reference) resolves.
- [x] Spot-check the new acknowledgement links: [gstack](https://github.com/garrytan/gstack) and [Symphony](https://github.com/openai/symphony).
- [ ] Confirm `git check-ignore docs/biz/foo.md` returns a hit and `docs/biz-public/foo.md` does not.
- [x] Confirm CONTRIBUTING.md DCO section renders cleanly and TRADEMARKS.md is reachable from README's Trade-marks section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)