### PR TITLE
[codex] add Codex host support

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,4 @@
-# Auto detect text files and perform LF normalization
-* text=auto
+# Auto-detect text files, store them normalized, and check them out as LF.
+# Several SLO contract tests intentionally assert exact Markdown frontmatter
+# delimiters; keeping text worktrees LF-only makes those checks portable.
+* text=auto eol=lf

--- a/.github/workflows/sldo-install.yml
+++ b/.github/workflows/sldo-install.yml
@@ -1,0 +1,40 @@
+# Cross-platform installer smoke.
+#
+# The installer is the portability boundary for the skill pack. This workflow
+# keeps the managed-link behavior honest on Linux, macOS, and Windows.
+
+name: sldo-install cross-platform
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: cargo test -p sldo-install (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
+
+      - name: Test installer
+        run: cargo test -p sldo-install

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,52 @@
+# SunLitOrchestrate - Codex overlay
+
+This file is the Codex overlay for the canonical living catalog at [docs/skill-pack-catalog.md](docs/skill-pack-catalog.md). Use it when you are working in Codex and need the Codex-specific install path, reading order, and limitations.
+
+If you are new to the repo, start with [docs/getting-started.md](docs/getting-started.md). For the other host overlays, read [CLAUDE.md](CLAUDE.md) or [copilot-instructions.md](copilot-instructions.md).
+
+## Read this first
+
+1. [docs/getting-started.md](docs/getting-started.md) - first-run path
+2. [docs/skill-pack-catalog.md](docs/skill-pack-catalog.md) - canonical living catalog
+3. [docs/slo/design/agent-host-capabilities.md](docs/slo/design/agent-host-capabilities.md) - what works today and what is still host-specific
+
+## Install into Codex
+
+From the repo root:
+
+```bash
+cargo build -p sldo-install --release
+./target/release/sldo-install --host codex
+./target/release/sldo-install --host codex status
+./target/release/sldo-install --host codex verify
+```
+
+Project-local install:
+
+```bash
+./target/release/sldo-install --host codex --local
+```
+
+Global installs land in `~/.codex/skills/`. Local installs land in `./.codex/skills/`.
+
+## What works today
+
+- The installed skill contract is the same Markdown `SKILL.md` format used by the other hosts.
+- `sldo-install` can install, list, verify, and uninstall Codex-targeted skills.
+- The canonical skill list stays in [docs/skill-pack-catalog.md](docs/skill-pack-catalog.md), so this file only explains Codex-specific details.
+- After installing or updating skills, reload or restart the Codex session if the current session does not pick up the new skill list.
+
+## Current limitations
+
+- Headless runtime automation in Codex is **not supported yet**. Do not assume there is a Codex CLI runtime equivalent to the Claude-only test harnesses.
+- `/slo-research` supports host-native interactive research. The separate `sldo-research` path remains an optional Claude batch backend when a user explicitly wants batch automation.
+- The live business judgment runtime harness remains Claude-only today because it shells out to `claude -p`.
+- Specialist agents under [agents/](agents/) are Claude-Code-only. Codex users continue to use `/slo-critique` and `/slo-verify` directly; that is the canonical portable path and produces the same artifact formats.
+- `.claude-plugin/plugin.json` is Claude Code only. Codex users install via `sldo-install --host codex`.
+
+## First session checklist
+
+1. Confirm the install target is Codex by running `./target/release/sldo-install --host codex status`.
+2. Read [docs/getting-started.md](docs/getting-started.md) for the first-run path.
+3. Use [docs/skill-pack-catalog.md](docs/skill-pack-catalog.md) to pick the skill you want.
+4. Check [docs/slo/design/agent-host-capabilities.md](docs/slo/design/agent-host-capabilities.md) before assuming a runtime or automation surface exists.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # SunLitOrchestrate — Claude Code overlay
 
-This file is the Claude Code overlay for the canonical living catalog at [docs/skill-pack-catalog.md](docs/skill-pack-catalog.md). Use it when you are working in Claude Code and need Claude-specific session notes. For the host-neutral list of shipped skills, read the catalog first. For GitHub Copilot-specific notes, read [copilot-instructions.md](copilot-instructions.md).
+This file is the Claude Code overlay for the canonical living catalog at [docs/skill-pack-catalog.md](docs/skill-pack-catalog.md). Use it when you are working in Claude Code and need Claude-specific session notes. For the host-neutral list of shipped skills, read the catalog first. For GitHub Copilot-specific notes, read [copilot-instructions.md](copilot-instructions.md). For Codex-specific notes, read [AGENTS.md](AGENTS.md).
 
 ## Skill pack — first-party `/slo-*` skills
 
@@ -75,8 +75,8 @@ Synthetic, non-normative gallery at [examples/](examples/). Read these to see wh
 
 ## Distribution channels
 
-- `sldo-install` (canonical) — installs into `~/.claude/skills/` (or `--local`).
-- `.claude-plugin/plugin.json` (optional, additive) — Claude Code organizational installs may prefer a one-zip distribution. Tagged releases produce a downloadable zip via the SHA-pinned [release-zip workflow](.github/workflows/release-zip.yml).
+- `sldo-install` (canonical, multi-host) - installs into the selected host root.
+- `.claude-plugin/plugin.json` (optional, additive) - Claude Code organizational installs may prefer a one-zip distribution. Tagged releases produce a downloadable zip via the SHA-pinned [release-zip workflow](.github/workflows/release-zip.yml).
 
 ## Canonical planning artifact
 
@@ -103,6 +103,6 @@ cargo build -p sldo-install --release
 
 Manifest: `~/.sldo/install.toml`.
 
-If you are using GitHub Copilot instead of Claude Code, use [copilot-instructions.md](copilot-instructions.md) for the matching host overlay.
+If you are using GitHub Copilot instead of Claude Code, use [copilot-instructions.md](copilot-instructions.md) for the matching host overlay. If you are using Codex, use [AGENTS.md](AGENTS.md).
 
 If you are completely new to the repo, start with [docs/getting-started.md](docs/getting-started.md) before using this overlay.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Three contributions make this pack distinct: **(1) a runbook artifact that bakes
 
 ## Table of contents
 
+- [At a glance](#at-a-glance)
 - [The problem](#the-problem)
 - [What SunLitOrchestrate is](#what-sunlitorchestrate-is)
 - [What makes SunLitOrchestrate different](#what-makes-sunlitorchestrate-different)
@@ -19,6 +20,26 @@ Three contributions make this pack distinct: **(1) a runbook artifact that bakes
 - [Documentation](#documentation)
 - [Contributing](#contributing)
 - [Acknowledgements](#acknowledgements)
+
+## At a glance
+
+SunLitOrchestrate is a portable `/slo-*` skill pack for disciplined AI-assisted delivery. It gives a host agent a sequence of reviewable contracts instead of one loose prompt.
+
+| If you have... | Start with... | You get... |
+|---|---|---|
+| A new product or feature idea | `/slo-ideate` | Problem framing, risks, and a path into research/design |
+| A scoped GitHub issue | `/slo-ticket-pick #<issue>` | A compact ticket contract, evidence log, and PR handoff |
+| A full feature that needs planning | `/slo-plan` after ideate/research/architecture | A v4 runbook with milestones, BDD, abuse cases, and gates |
+| A security-only need | `/slo-rulegen` or `/slo-sast` | Semgrep rules and a deterministic verification gate |
+| A UK founder/business artifact | The relevant `/slo-*` biz skill | Drafts or decision artifacts with hard-block gates |
+
+Supported interactive hosts:
+
+| Host | Install target | Overlay |
+|---|---|---|
+| Claude Code | `~/.claude/skills/` | [CLAUDE.md](CLAUDE.md) |
+| GitHub Copilot | `~/.copilot/skills/` | [copilot-instructions.md](copilot-instructions.md) |
+| Codex | `~/.codex/skills/` | [AGENTS.md](AGENTS.md) |
 
 ## The problem
 
@@ -34,7 +55,7 @@ The bet behind SunLitOrchestrate is that these failures are not LLM limitations 
 
 ## What SunLitOrchestrate is
 
-A **skill pack** — a set of `/slo-*` slash commands installed into a host AI coding agent (Claude Code by default, GitHub Copilot also supported) — plus a small Rust toolchain that installs the pack, provides an optional batch backend for `/slo-research`, and runs a Semgrep rule gate (`cargo xtask sast-verify`) wired to the SAST skills.
+A **skill pack** - a set of `/slo-*` slash commands installed into a host AI coding agent (Claude Code by default; GitHub Copilot and Codex also supported) - plus a small Rust toolchain that installs the pack, provides an optional batch backend for `/slo-research`, and runs a Semgrep rule gate (`cargo xtask sast-verify`) wired to the SAST skills.
 
 The pack is organised around four workflows that compose:
 
@@ -153,7 +174,7 @@ If this is your first time here, start with [docs/getting-started.md](docs/getti
 | Security + SAST | Threat-model-by-default design and Semgrep rule-pack generation | `/slo-sast`, `/slo-rulegen`, `/slo-ruleverify` |
 | UK biz pack (v1) | Founder, GTM, pricing, legal, accounting, equity, and hiring artifacts for UK-only workflows | `/slo-legal`, `/slo-accounting`, `/slo-equity`, `/slo-fundraise`, `/slo-talk-to-users`, `/slo-gtm`, `/slo-product`, `/slo-marketing`, `/slo-launch`, `/slo-sales-funnel`, `/slo-pricing`, `/slo-metrics`, `/slo-cofounder`, `/slo-hire`, `/slo-founder-check` |
 
-The raw `SKILL.md` contract is agent-neutral. The canonical skill list lives in [docs/skill-pack-catalog.md](docs/skill-pack-catalog.md). Host-specific overlays live in [CLAUDE.md](CLAUDE.md) and [copilot-instructions.md](copilot-instructions.md).
+The raw `SKILL.md` contract is agent-neutral. The canonical skill list lives in [docs/skill-pack-catalog.md](docs/skill-pack-catalog.md). Host-specific overlays live in [CLAUDE.md](CLAUDE.md), [copilot-instructions.md](copilot-instructions.md), and [AGENTS.md](AGENTS.md).
 
 The workflow is intentionally more technical-contract-driven than a typical prompt stack. The v4 runbook contract at [docs/slo/templates/runbook-template_v_4_template.md](docs/slo/templates/runbook-template_v_4_template.md) gives every milestone explicit scope, interfaces, abuse cases, compatibility expectations, verification gates, plus Carmack-style reliability controls (debugger-first inspection, mandatory static analysis, assertion-driven invariants, bounded resource design, "make invalid states unrepresentable"). For designs with real protocol complexity, `/slo-tla` adds a formal-spec step so the design can be checked with TLA+ before implementation. The earlier [v3 template](docs/slo/templates/runbook-template_v_3_template.md) remains in place as a historical artifact for runbooks already authored against it.
 
@@ -173,7 +194,7 @@ If you want the step-by-step first-run path, read [docs/getting-started.md](docs
 ### Prerequisites
 
 - **Rust toolchain** (stable). `rustup install stable` if you don't have one.
-- **A supported host agent**: Claude Code or GitHub Copilot. Claude Code remains the default target if you do not pass `--host`.
+- **A supported host agent**: Claude Code, GitHub Copilot, or Codex. Claude Code remains the default target if you do not pass `--host`.
 - **Semgrep** (`brew install semgrep` or `pip install semgrep`). Required only for the SAST rule-pack path.
 
 ### Install the skill pack
@@ -194,19 +215,25 @@ cargo build -p sldo-install --release
 ./target/release/sldo-install --host github-copilot status
 ./target/release/sldo-install --host github-copilot verify
 
+# Codex
+./target/release/sldo-install --host codex
+./target/release/sldo-install --host codex status
+./target/release/sldo-install --host codex verify
+
 # Project-local installs
 ./target/release/sldo-install --local
 ./target/release/sldo-install --host github-copilot --local
+./target/release/sldo-install --host codex --local
 ```
 
 What success looks like:
 
 - `sldo-install` prints the selected target root.
 - `status` lists the installed skills for the host you chose.
-- Global installs land in `~/.claude/skills/` or `~/.copilot/skills/`.
-- Local installs land in `./.claude/skills/` or `./.copilot/skills/` if you add `--local`.
+- Global installs land in `~/.claude/skills/`, `~/.copilot/skills/`, or `~/.codex/skills/`.
+- Local installs land in `./.claude/skills/`, `./.copilot/skills/`, or `./.codex/skills/` if you add `--local`.
 
-`/slo-research` now uses host-native research first in both Claude Code and GitHub Copilot. `sldo-research` remains an optional Claude batch backend when you explicitly want that automation path.
+`/slo-research` now uses host-native research first in Claude Code, GitHub Copilot, and Codex. `sldo-research` remains an optional Claude batch backend when you explicitly want that automation path.
 
 For the canonical sprint sequence (ideate → ship), see [How it works](#how-it-works) above.
 
@@ -214,7 +241,7 @@ For the canonical sprint sequence (ideate → ship), see [How it works](#how-it-
 
 Claude Code organizational installs may prefer a one-zip distribution over cloning the repo. A `.claude-plugin/plugin.json` is published; tagged releases also produce a downloadable zip via the SHA-pinned [release-zip workflow](.github/workflows/release-zip.yml).
 
-**The Rust installer remains canonical.** `sldo-install` is the supported install path for both Claude Code and GitHub Copilot; the plugin distribution is additive and Claude-only. GitHub Copilot users continue to use `sldo-install --host github-copilot`. Choosing the plugin path on Claude Code does not bypass `sldo-install`'s manifest at `~/.sldo/install.toml` — both paths point at the same `skills/` tree.
+**The Rust installer remains canonical.** `sldo-install` is the supported install path for Claude Code, GitHub Copilot, and Codex; the plugin distribution is additive and Claude-only. GitHub Copilot users continue to use `sldo-install --host github-copilot`; Codex users use `sldo-install --host codex`. Choosing the plugin path on Claude Code does not bypass `sldo-install`'s manifest at `~/.sldo/install.toml` - both paths point at the same `skills/` tree.
 
 ### Examples
 
@@ -241,7 +268,7 @@ CI wiring is documented in [`references/sast/CI-WIRING.md`](references/sast/CI-W
 
 ## Host reality
 
-- Claude Code and GitHub Copilot can both install and use the `SKILL.md` pack interactively.
+- Claude Code, GitHub Copilot, and Codex can install and use the `SKILL.md` pack interactively.
 - Claude Code remains the default host if you omit `--host`.
 - Headless runtime automation is still host-specific today.
 - `sldo-research` as a batch backend and the live business judgment runtime harness are still Claude-only today.
@@ -265,9 +292,10 @@ The README is the orientation page. For the full host-neutral skill list, output
 
 - [docs/skill-pack-catalog.md](docs/skill-pack-catalog.md) — canonical living catalog of shipped skills
 - [docs/getting-started.md](docs/getting-started.md) — first-run path with exact commands and expected results
-- [docs/slo/design/agent-host-capabilities.md](docs/slo/design/agent-host-capabilities.md) — what works in Claude Code, GitHub Copilot, or both
+- [docs/slo/design/agent-host-capabilities.md](docs/slo/design/agent-host-capabilities.md) — what works in Claude Code, GitHub Copilot, Codex, or host-specific automation
 - [CLAUDE.md](CLAUDE.md) — Claude Code overlay
 - [copilot-instructions.md](copilot-instructions.md) — GitHub Copilot overlay
+- [AGENTS.md](AGENTS.md) — Codex overlay
 - [docs/PARADIGM-OVER-ENGINEERING-FOR-SIMPLICITY.md](docs/PARADIGM-OVER-ENGINEERING-FOR-SIMPLICITY.md) — design philosophy: more internal discipline, less user-visible ceremony
 - [skills/get-api-docs/UPSTREAM.md](skills/get-api-docs/UPSTREAM.md) — attribution for the vendored `/get-api-docs` helper
 
@@ -286,6 +314,7 @@ The README is the orientation page. For the full host-neutral skill list, output
 ├── docs/                         # Runbooks, design docs, lessons, completions
 ├── CLAUDE.md                     # Claude Code overlay for the canonical skill catalog
 ├── copilot-instructions.md       # GitHub Copilot overlay for the same skill pack
+├── AGENTS.md                     # Codex overlay for the same skill pack
 └── SECURITY.md                   # Project-wide security defaults
 ```
 
@@ -313,6 +342,7 @@ Start here:
 - [SECURITY.md](SECURITY.md) — project-wide security defaults
 - [CLAUDE.md](CLAUDE.md) — Claude Code overlay
 - [copilot-instructions.md](copilot-instructions.md) — GitHub Copilot overlay
+- [AGENTS.md](AGENTS.md) — Codex overlay
 
 Skill-pack design:
 
@@ -333,8 +363,8 @@ Per-runbook detail:
 Contributions are welcome. The recommended workflow:
 
 1. **Fork + clone.** `git clone <your-fork>` and `cd SunLitOrchestrate`.
-2. **Open an issue first** for non-trivial work — the v3 runbook discipline only pays off when the work is scoped before code is written.
-3. **Use the skills on yourself.** `/slo-ideate` → `/slo-research` → `/slo-architect` → `/slo-plan` produces a runbook the maintainers can review without any code yet. This is the lowest-friction path to merging.
+2. **Open an issue first** for non-trivial work. Use the ticket-sized SLO flow for small changes and the full v4 runbook flow for larger ones.
+3. **Use the skills on yourself.** `/slo-ideate` -> `/slo-research` -> `/slo-architect` -> `/slo-plan` produces a runbook the maintainers can review without any code yet. For a small issue, use `/slo-ticket-pick` -> `/slo-ticket-plan`.
 4. **Pass the baseline.** `cargo test -p sldo-common -p sldo-install -p sldo-research` must be green.
 5. **Open a PR.** The PR description should link to the runbook + the closed milestone's completion summary.
 

--- a/README.md
+++ b/README.md
@@ -232,6 +232,8 @@ What success looks like:
 - `status` lists the installed skills for the host you chose.
 - Global installs land in `~/.claude/skills/`, `~/.copilot/skills/`, or `~/.codex/skills/`.
 - Local installs land in `./.claude/skills/`, `./.copilot/skills/`, or `./.codex/skills/` if you add `--local`.
+- On Windows PowerShell, use `.\target\release\sldo-install.exe` with the same flags. Native Windows shells can rely on `%USERPROFILE%` when `HOME` is not set.
+- Linux and macOS installs use directory symlinks. Windows tries directory symlinks first, then falls back to directory junctions if symlink privileges are unavailable.
 
 `/slo-research` now uses host-native research first in Claude Code, GitHub Copilot, and Codex. `sldo-research` remains an optional Claude batch backend when you explicitly want that automation path.
 
@@ -307,7 +309,7 @@ The README is the orientation page. For the full host-neutral skill list, output
 ├── crates/
 │   ├── sldo-common/              # Shared library (used by the remaining Rust tooling)
 │   ├── sldo-research/            # Optional Claude batch backend for /slo-research
-│   └── sldo-install/             # Skill installer (symlinks skills/* into the selected host root)
+│   └── sldo-install/             # Skill installer (managed-links skills/* into the selected host root)
 ├── xtasks/sast-verify/           # cargo xtask sast-verify (Semgrep rule gate; driven by /slo-rulegen + /slo-ruleverify)
 ├── .semgrep/rust/                # 10/10 CWE rule pack (M1 + M1.5 + M1.6)
 ├── references/                   # Shared scaffolding read by skills (biz/, sast/)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -16,7 +16,7 @@
 ~~~text
 Top risks were not explicitly captured by /slo-ideate for this runbook (the M1 edits to /slo-ideate post-date its original authoring). Inferred defaults used here; re-run /slo-ideate or update the idea doc to populate Top risks properly.
 
-- Breach: attacker-controlled content in a SKILL.md (installed locally) causes an agent in a future session to exfiltrate source or credentials from the user's machine via subprocess invocation. Surface: skills/*, sldo-install symlinks.
+- Breach: attacker-controlled content in a SKILL.md (installed locally) causes an agent in a future session to exfiltrate source or credentials from the user's machine via subprocess invocation. Surface: skills/*, sldo-install managed links.
 - Compliance fine: N/A — SLO is an OSS skill pack with no data processing; the compliance surface is downstream (users' projects).
 - Prolonged outage: sldo-research, sldo-plan, sldo-run shell out to the `claude` CLI; rate-limit or API outage stops the pipeline for affected users. Mitigation is user-side (retry, back off).
 ~~~
@@ -43,7 +43,7 @@ Top risks were not explicitly captured by /slo-ideate for this runbook (the M1 e
 - SKILL.md / prompt files: `sldo-research` accepts a `<prompt-file>` argument and passes its contents to `claude` via stdin. The prompt file is trusted input — the user chose it. **Do not pass untrusted prompt files** (e.g., user-uploaded content on a server); this is documented in the research skill's README.
 - Subprocess invocation: `Command::new("claude" | "git" | "cargo")` with explicit argument lists (no shell). Arguments derived from user input are passed as separate args, never interpolated into a shell string. `Stdio::piped()` with drain-in-separate-threads to avoid pipe-buffer deadlocks.
 - Outbound URLs: `sldo-tla-sha` fetches HTTPS URLs from `skills/slo-tla/tools.toml`. Host allow-list (`github.com`, `objects.githubusercontent.com`, `raw.githubusercontent.com`, etc. — see `src/allowed_hosts.rs`) enforced pre-redirect and post-redirect. Hard byte cap (`DEFAULT_MAX_BYTES = 500 MiB`) on streamed response to prevent OOM on a malicious CDN response.
-- File paths from user input: all paths used by `sldo-install` are computed from `~/.claude/` + skill name; user never provides arbitrary paths.
+- File paths from user input: install roots used by `sldo-install` are computed from the selected host config directory (`.claude`, `.copilot`, or `.codex`) + skill name; user never provides arbitrary target paths.
 - SQL / LDAP / shell interpolation: N/A — no database, no LDAP, no shell interpolation.
 - HTML output: N/A — no rendered HTML surface (parked Tauri app excluded).
 
@@ -63,7 +63,7 @@ N/A for current surfaces. If future work reintroduces an HTTP API (which would r
 - Rust: `cargo audit` + `cargo deny check` are the Phase 3 (`/slo-security-test`) contract for future CI; not currently wired. Recommended additions to CI: run on every PR, fail on High/Critical.
 - No git dependencies in any workspace `Cargo.toml`; all deps from crates.io.
 - Licenses: `MIT`, `Apache-2.0`, `BSD-3-Clause` across the dep graph (not currently enforced by `cargo deny`; manual audit only).
-- Skill pack installation: `sldo-install` uses symlinks with no elevated privileges; uninstall preserves user-modified symlinks (warns rather than overwrites).
+- Skill pack installation: `sldo-install` uses managed directory links. Linux and macOS use symlinks; Windows tries symlinks and falls back to directory junctions when symlink privileges are unavailable. Uninstall preserves user-modified links (warns rather than overwrites).
 
 ## Defense-in-depth
 

--- a/copilot-instructions.md
+++ b/copilot-instructions.md
@@ -2,7 +2,7 @@
 
 This file is the GitHub Copilot overlay for the canonical living catalog at [docs/skill-pack-catalog.md](docs/skill-pack-catalog.md). Use it when you are working in GitHub Copilot and want the Copilot-specific install path, reading order, and limitations.
 
-If you are new to the repo, start with [docs/getting-started.md](docs/getting-started.md). If you want the Claude-specific version of this file, read [CLAUDE.md](CLAUDE.md).
+If you are new to the repo, start with [docs/getting-started.md](docs/getting-started.md). If you want the Claude-specific version of this file, read [CLAUDE.md](CLAUDE.md). If you want the Codex-specific version, read [AGENTS.md](AGENTS.md).
 
 ## Read this first
 
@@ -40,7 +40,7 @@ Global installs land in `~/.copilot/skills/`. Local installs land in `./.copilot
 - Headless runtime automation in GitHub Copilot is **not supported yet**. Do not assume there is a Copilot CLI runtime equivalent to the Claude-only test harnesses.
 - `/slo-research` now supports host-native interactive research without installing Claude. The separate `sldo-research` path remains an optional Claude batch backend when a user explicitly wants batch automation.
 - The live business judgment runtime harness remains Claude-only today because it shells out to `claude -p`.
-- **Specialist agents under [agents/](agents/) are Claude-Code-only** (sap-imp M5; per the [host-capability matrix](docs/slo/design/host-capability-matrix.md)). Copilot users continue to use `/slo-critique` and `/slo-verify` directly — this is the canonical portable path and produces the same `docs/slo/critique/<slug>.md` artifact format. No second-class treatment: every agent file declares a `copilot-fallback:` field naming `/slo-critique` or `/slo-verify` as the path.
+- **Specialist agents under [agents/](agents/) are Claude-Code-only** (sap-imp M5; per the [host-capability matrix](docs/slo/design/host-capability-matrix.md)). Copilot and Codex users continue to use `/slo-critique` and `/slo-verify` directly; this is the canonical portable path and produces the same `docs/slo/critique/<slug>.md` artifact format. No second-class treatment: every agent file declares a `copilot-fallback:` field naming `/slo-critique` or `/slo-verify` as the path.
 - **`.claude-plugin/plugin.json`** (sap-imp M4) is Claude Code only. Copilot users install via `sldo-install --host github-copilot` (canonical, multi-host).
 
 ## First session checklist

--- a/crates/sldo-install/src/host.rs
+++ b/crates/sldo-install/src/host.rs
@@ -4,6 +4,7 @@ use clap::ValueEnum;
 pub enum Host {
     ClaudeCode,
     GithubCopilot,
+    Codex,
 }
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
@@ -25,11 +26,18 @@ const GITHUB_COPILOT: HostDescriptor = HostDescriptor {
     config_dir: ".copilot",
 };
 
+const CODEX: HostDescriptor = HostDescriptor {
+    id: "codex",
+    display_name: "Codex",
+    config_dir: ".codex",
+};
+
 impl Host {
     pub fn descriptor(self) -> &'static HostDescriptor {
         match self {
             Self::ClaudeCode => &CLAUDE_CODE,
             Self::GithubCopilot => &GITHUB_COPILOT,
+            Self::Codex => &CODEX,
         }
     }
 
@@ -54,5 +62,12 @@ mod tests {
         let descriptor = Host::GithubCopilot.descriptor();
         assert_eq!(descriptor.id, "github-copilot");
         assert_eq!(descriptor.config_dir, ".copilot");
+    }
+
+    #[test]
+    fn codex_descriptor_matches_expected_paths() {
+        let descriptor = Host::Codex.descriptor();
+        assert_eq!(descriptor.id, "codex");
+        assert_eq!(descriptor.config_dir, ".codex");
     }
 }

--- a/crates/sldo-install/src/install.rs
+++ b/crates/sldo-install/src/install.rs
@@ -2,12 +2,12 @@
 //!
 //! Idempotency contract: calling `install` repeatedly with the same inputs
 //! yields the same filesystem state. Calling `uninstall` reverses every
-//! symlink and removes the manifest.
+//! managed link and removes the manifest.
 //!
-//! Symlink safety: we never overwrite a non-symlink target. Overwriting an
-//! existing symlink requires `--force`. Uninstall only removes symlinks that
-//! point at the source recorded in the manifest — if a user has replaced a
-//! symlink manually, we leave it alone and warn.
+//! Managed-link safety: we never overwrite a non-link target. Overwriting an
+//! existing managed link requires `--force`. Uninstall only removes managed
+//! links that point at the source recorded in the manifest — if a user has
+//! replaced a link manually, we leave it alone and warn.
 
 use anyhow::{bail, Context, Result};
 use colored::Colorize;
@@ -30,9 +30,9 @@ pub struct Options {
 #[derive(Debug, Default)]
 struct Plan {
     to_create: Vec<PlanItem>,
-    to_update: Vec<PlanItem>, // existing symlink pointing elsewhere, needs --force
+    to_update: Vec<PlanItem>, // existing managed link pointing elsewhere, needs --force
     up_to_date: Vec<PlanItem>,
-    conflicts: Vec<PlanItem>, // non-symlink target, cannot overwrite
+    conflicts: Vec<PlanItem>, // non-link target, cannot overwrite
 }
 
 #[derive(Debug, Clone)]
@@ -103,29 +103,11 @@ fn plan(opts: &Options) -> Result<(Plan, PathBuf, PathBuf)> {
             target: target.clone(),
         };
 
-        if target.exists() || target.is_symlink() {
-            // is_symlink works even when the symlink is dangling.
-            if target.is_symlink() {
-                match fs::read_link(&target) {
-                    Ok(link) => {
-                        // Resolve relative symlinks against their parent to compare.
-                        let resolved = if link.is_absolute() {
-                            link
-                        } else {
-                            target
-                                .parent()
-                                .map(|p| p.join(&link))
-                                .unwrap_or(link.clone())
-                        };
-                        let resolved_canon = fs::canonicalize(&resolved).unwrap_or(resolved);
-                        if resolved_canon == source_abs {
-                            plan.up_to_date.push(item);
-                        } else {
-                            plan.to_update.push(item);
-                        }
-                    }
-                    Err(_) => plan.to_update.push(item),
-                }
+        if target.exists() || is_managed_link_path(&target) {
+            if managed_link_points_to(&target, &source_abs) {
+                plan.up_to_date.push(item);
+            } else if is_managed_link_path(&target) {
+                plan.to_update.push(item);
             } else {
                 // Real file or directory where we'd install — conflict.
                 plan.conflicts.push(item);
@@ -142,12 +124,12 @@ pub fn install(opts: &Options) -> Result<()> {
     let (plan, root, manifest_path) = plan(opts)?;
 
     if !plan.conflicts.is_empty() {
-        eprintln!("{}", "conflicts (existing non-symlink paths):".red().bold());
+        eprintln!("{}", "conflicts (existing non-link paths):".red().bold());
         for item in &plan.conflicts {
             eprintln!("  {} -> {}", item.target.display(), item.source.display());
         }
         bail!(
-            "{} skill(s) have non-symlink paths at their install targets. \
+            "{} skill(s) have non-link paths at their install targets. \
              Remove or relocate them and re-run.",
             plan.conflicts.len()
         );
@@ -156,7 +138,7 @@ pub fn install(opts: &Options) -> Result<()> {
     if !plan.to_update.is_empty() && !opts.force {
         eprintln!(
             "{}",
-            "the following symlinks point elsewhere and would be replaced by --force:"
+            "the following managed links point elsewhere and would be replaced by --force:"
                 .yellow()
                 .bold()
         );
@@ -164,7 +146,7 @@ pub fn install(opts: &Options) -> Result<()> {
             eprintln!("  {}", item.target.display());
         }
         bail!(
-            "{} symlink(s) already exist. Pass --force to overwrite.",
+            "{} managed link(s) already exist. Pass --force to overwrite.",
             plan.to_update.len()
         );
     }
@@ -180,15 +162,18 @@ pub fn install(opts: &Options) -> Result<()> {
     let mut manifest = Manifest::load(&manifest_path)?;
 
     for item in plan.to_create.iter().chain(plan.to_update.iter()) {
-        // Remove pre-existing symlink (only symlinks reach this branch).
-        if item.target.is_symlink() {
-            fs::remove_file(&item.target).with_context(|| {
-                format!("Failed to remove old symlink: {}", item.target.display())
+        // Remove pre-existing managed link (only managed links reach this branch).
+        if is_managed_link_path(&item.target) {
+            remove_managed_link_path(&item.target).with_context(|| {
+                format!(
+                    "Failed to remove old managed link: {}",
+                    item.target.display()
+                )
             })?;
         }
-        create_symlink(&item.source, &item.target).with_context(|| {
+        create_managed_link(&item.source, &item.target).with_context(|| {
             format!(
-                "Failed to symlink {} -> {}",
+                "Failed to link {} -> {}",
                 item.target.display(),
                 item.source.display()
             )
@@ -266,7 +251,7 @@ pub fn uninstall(opts: &Options) -> Result<()> {
             bad += 1;
             continue;
         }
-        match remove_managed_symlink(&entry) {
+        match remove_managed_link(&entry) {
             Ok(true) => {
                 println!("  {} {}", "-".yellow().bold(), entry.name);
                 manifest.remove(&entry.name, opts.host);
@@ -345,35 +330,29 @@ pub fn verify(opts: &Options) -> Result<()> {
             bad += 1;
             continue;
         }
-        if !entry.target.is_symlink() {
-            eprintln!("  {} {}: target is not a symlink", "x".red(), entry.name);
+        if !is_managed_link_path(&entry.target) {
+            eprintln!(
+                "  {} {}: target is not a managed link",
+                "x".red(),
+                entry.name
+            );
             bad += 1;
             continue;
         }
-        let link = match fs::read_link(&entry.target) {
+        let actual = match managed_link_target(&entry.target) {
             Ok(p) => p,
             Err(e) => {
-                eprintln!("  {} {}: read_link failed: {}", "x".red(), entry.name, e);
+                eprintln!("  {} {}: link target failed: {}", "x".red(), entry.name, e);
                 bad += 1;
                 continue;
             }
         };
-        let resolved = if link.is_absolute() {
-            link
-        } else {
-            entry
-                .target
-                .parent()
-                .map(|p| p.join(&link))
-                .unwrap_or(link.clone())
-        };
-        let canon = fs::canonicalize(&resolved).unwrap_or(resolved);
-        if canon != entry.source {
+        if actual != entry.source {
             eprintln!(
                 "  {} {}: points to {} (expected {})",
                 "x".red(),
                 entry.name,
-                canon.display(),
+                actual.display(),
                 entry.source.display()
             );
             bad += 1;
@@ -388,42 +367,119 @@ pub fn verify(opts: &Options) -> Result<()> {
 }
 
 #[cfg(unix)]
-fn create_symlink(source: &Path, target: &Path) -> std::io::Result<()> {
-    std::os::unix::fs::symlink(source, target)
+fn create_managed_link(source: &Path, target: &Path) -> Result<()> {
+    std::os::unix::fs::symlink(source, target)?;
+    Ok(())
 }
 
 #[cfg(windows)]
-fn create_symlink(source: &Path, target: &Path) -> std::io::Result<()> {
-    std::os::windows::fs::symlink_dir(source, target)
+fn create_managed_link(source: &Path, target: &Path) -> Result<()> {
+    match std::os::windows::fs::symlink_dir(source, target) {
+        Ok(()) => Ok(()),
+        Err(symlink_error) => create_windows_junction(source, target).with_context(|| {
+            format!("Windows directory symlink failed ({symlink_error}); junction fallback failed")
+        }),
+    }
 }
 
-/// Remove a symlink only if it still points at the source recorded in the
+#[cfg(windows)]
+fn create_windows_junction(source: &Path, target: &Path) -> Result<()> {
+    use std::process::Command;
+
+    let output = Command::new("cmd")
+        .args(["/C", "mklink", "/J"])
+        .arg(target)
+        .arg(source)
+        .output()
+        .context("failed to invoke Windows mklink junction fallback")?;
+
+    if output.status.success() {
+        return Ok(());
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    bail!(
+        "mklink /J failed with status {}. stdout: {} stderr: {}",
+        output.status,
+        stdout.trim(),
+        stderr.trim()
+    )
+}
+
+/// Remove a managed link only if it still points at the source recorded in the
 /// manifest. Returns Ok(true) if removed, Ok(false) if preserved (modified by
 /// the user), Err on I/O failure.
-fn remove_managed_symlink(entry: &Entry) -> Result<bool> {
-    if !entry.target.is_symlink() {
+fn remove_managed_link(entry: &Entry) -> Result<bool> {
+    if !is_managed_link_path(&entry.target) {
         // Either user replaced it with a real file, or it was already removed.
         if !entry.target.exists() {
             return Ok(true); // already gone — count as removed
         }
         return Ok(false);
     }
-    let link = fs::read_link(&entry.target)?;
+    let actual = managed_link_target(&entry.target)?;
+    if actual != entry.source {
+        return Ok(false);
+    }
+    remove_managed_link_path(&entry.target)?;
+    Ok(true)
+}
+
+fn managed_link_points_to(target: &Path, source: &Path) -> bool {
+    managed_link_target(target)
+        .map(|actual| actual == source)
+        .unwrap_or(false)
+}
+
+fn managed_link_target(target: &Path) -> Result<PathBuf> {
+    if !is_managed_link_path(target) {
+        bail!("target is not a managed link");
+    }
+
+    if let Ok(canon) = fs::canonicalize(target) {
+        return Ok(canon);
+    }
+
+    let link = fs::read_link(target)?;
     let resolved = if link.is_absolute() {
         link
     } else {
-        entry
-            .target
+        target
             .parent()
             .map(|p| p.join(&link))
             .unwrap_or(link.clone())
     };
-    let canon = fs::canonicalize(&resolved).unwrap_or(resolved);
-    if canon != entry.source {
-        return Ok(false);
-    }
-    fs::remove_file(&entry.target)?;
-    Ok(true)
+    Ok(fs::canonicalize(&resolved).unwrap_or(resolved))
+}
+
+fn is_managed_link_path(path: &Path) -> bool {
+    path.is_symlink() || is_windows_reparse_point(path)
+}
+
+#[cfg(windows)]
+fn is_windows_reparse_point(path: &Path) -> bool {
+    use std::os::windows::fs::MetadataExt;
+
+    const FILE_ATTRIBUTE_REPARSE_POINT: u32 = 0x400;
+    fs::symlink_metadata(path)
+        .map(|metadata| metadata.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT != 0)
+        .unwrap_or(false)
+}
+
+#[cfg(not(windows))]
+fn is_windows_reparse_point(_path: &Path) -> bool {
+    false
+}
+
+#[cfg(unix)]
+fn remove_managed_link_path(target: &Path) -> std::io::Result<()> {
+    fs::remove_file(target)
+}
+
+#[cfg(windows)]
+fn remove_managed_link_path(target: &Path) -> std::io::Result<()> {
+    fs::remove_dir(target).or_else(|_| fs::remove_file(target))
 }
 
 fn validate_entry_target_in_host_root(entry: &Entry, root: &Path) -> Result<()> {
@@ -459,7 +515,7 @@ fn print_plan(plan: &Plan, root: &Path) {
         }
     }
     if !plan.conflicts.is_empty() {
-        println!("conflicts (non-symlink paths):");
+        println!("conflicts (non-link paths):");
         for i in &plan.conflicts {
             println!("  ! {}", i.target.display());
         }

--- a/crates/sldo-install/src/main.rs
+++ b/crates/sldo-install/src/main.rs
@@ -1,8 +1,8 @@
 //! `sldo-install` — install, update, and uninstall the SunLitOrchestrate skill pack.
 //!
-//! Symlinks the skill directories under `skills/` in this repo into the
-//! selected host agent's skills directory (default: `~/.claude/skills/`), or
-//! into a project-local host directory such as `./.claude/skills/`,
+//! Links the skill directories under `skills/` in this repo into the selected
+//! host agent's skills directory (default: `~/.claude/skills/`), or into a
+//! project-local host directory such as `./.claude/skills/`,
 //! `./.copilot/skills/`, or `./.codex/skills/` when `--local` is passed.
 //!
 //! The installer is idempotent: running it twice leaves the same state as
@@ -42,7 +42,7 @@ struct Cli {
     #[arg(long, value_enum, default_value_t = Host::ClaudeCode, global = true)]
     host: Host,
 
-    /// Overwrite existing symlinks.
+    /// Overwrite existing managed links.
     #[arg(long, global = true)]
     force: bool,
 
@@ -59,7 +59,7 @@ enum Command {
     Uninstall,
     /// Print what's currently installed according to the manifest.
     Status,
-    /// Verify that installed symlinks match the manifest and source skills.
+    /// Verify that installed managed links match the manifest and source skills.
     Verify,
 }
 

--- a/crates/sldo-install/src/main.rs
+++ b/crates/sldo-install/src/main.rs
@@ -2,8 +2,8 @@
 //!
 //! Symlinks the skill directories under `skills/` in this repo into the
 //! selected host agent's skills directory (default: `~/.claude/skills/`), or
-//! into a project-local host directory such as `./.claude/skills/` or
-//! `./.copilot/skills/` when `--local` is passed.
+//! into a project-local host directory such as `./.claude/skills/`,
+//! `./.copilot/skills/`, or `./.codex/skills/` when `--local` is passed.
 //!
 //! The installer is idempotent: running it twice leaves the same state as
 //! running it once. Uninstall reverses every change recorded in the manifest.

--- a/crates/sldo-install/src/manifest.rs
+++ b/crates/sldo-install/src/manifest.rs
@@ -184,13 +184,19 @@ mod tests {
             PathBuf::from("/s2"),
         );
         m.upsert(
+            Host::Codex,
+            "a".into(),
+            PathBuf::from("/t4"),
+            PathBuf::from("/s4"),
+        );
+        m.upsert(
             Host::ClaudeCode,
             "a".into(),
             PathBuf::from("/t3"),
             PathBuf::from("/s3"),
         );
 
-        assert_eq!(m.entries.len(), 2);
+        assert_eq!(m.entries.len(), 3);
         assert_eq!(
             m.find("a", Host::ClaudeCode).unwrap().target,
             PathBuf::from("/t3")
@@ -198,6 +204,10 @@ mod tests {
         assert_eq!(
             m.find("a", Host::GithubCopilot).unwrap().target,
             PathBuf::from("/t2")
+        );
+        assert_eq!(
+            m.find("a", Host::Codex).unwrap().target,
+            PathBuf::from("/t4")
         );
     }
 
@@ -216,11 +226,18 @@ mod tests {
             PathBuf::from("/copilot"),
             PathBuf::from("/s2"),
         );
+        m.upsert(
+            Host::Codex,
+            "a".into(),
+            PathBuf::from("/codex"),
+            PathBuf::from("/s3"),
+        );
 
         let removed = m.remove("a", Host::GithubCopilot);
         assert!(removed.is_some());
-        assert_eq!(m.entries.len(), 1);
+        assert_eq!(m.entries.len(), 2);
         assert!(m.find("a", Host::ClaudeCode).is_some());
+        assert!(m.find("a", Host::Codex).is_some());
         assert!(m.remove("a", Host::GithubCopilot).is_none());
     }
 

--- a/crates/sldo-install/src/manifest.rs
+++ b/crates/sldo-install/src/manifest.rs
@@ -1,5 +1,5 @@
 //! Install manifest: records which skills are installed and where their
-//! symlinks point, so `uninstall` can reverse exactly what `install` did.
+//! managed links point, so `uninstall` can reverse exactly what `install` did.
 
 use anyhow::{Context, Result};
 use chrono::Utc;
@@ -17,9 +17,9 @@ pub struct Entry {
     /// Host id that owns this install (for example `claude-code`).
     #[serde(default = "default_host_id")]
     pub host: String,
-    /// Absolute path to the symlink we created.
+    /// Absolute path to the managed link we created.
     pub target: PathBuf,
-    /// Absolute path to the source skill directory the symlink points at.
+    /// Absolute path to the source skill directory the managed link points at.
     pub source: PathBuf,
     /// ISO-8601 UTC timestamp of the install.
     pub installed_at: String,

--- a/crates/sldo-install/src/paths.rs
+++ b/crates/sldo-install/src/paths.rs
@@ -20,7 +20,8 @@ pub fn home_dir() -> Result<PathBuf> {
     Ok(PathBuf::from(home))
 }
 
-/// Where global installs land: `~/.claude/skills/` or `~/.copilot/skills/`.
+/// Where global installs land, e.g. `~/.claude/skills/`,
+/// `~/.copilot/skills/`, or `~/.codex/skills/`.
 pub fn global_skills_root(home: &Path, host: Host) -> PathBuf {
     home.join(host.descriptor().config_dir).join("skills")
 }
@@ -75,6 +76,21 @@ mod tests {
         assert_eq!(
             local_manifest_path(cwd, Host::GithubCopilot),
             PathBuf::from("/tmp/fake-repo/.copilot/slo-install.toml")
+        );
+    }
+
+    #[test]
+    fn codex_roots_use_codex_config_dir() {
+        let base = Path::new("/tmp/fakehome");
+        assert_eq!(
+            global_skills_root(base, Host::Codex),
+            PathBuf::from("/tmp/fakehome/.codex/skills")
+        );
+
+        let cwd = Path::new("/tmp/fake-repo");
+        assert_eq!(
+            local_manifest_path(cwd, Host::Codex),
+            PathBuf::from("/tmp/fake-repo/.codex/slo-install.toml")
         );
     }
 }

--- a/crates/sldo-install/src/paths.rs
+++ b/crates/sldo-install/src/paths.rs
@@ -3,21 +3,78 @@
 //! Centralizes where the manifest lives and where skills are installed,
 //! so tests can override HOME or CWD without touching install logic.
 
-use anyhow::{Context, Result};
+use anyhow::{bail, Result};
+use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 
 use crate::host::Host;
 
-/// Resolve the user's home directory, honoring `$HOME` (which `tempfile`-backed
-/// tests override). Falls back to `dirs`-style fallback not implemented here —
-/// we require `$HOME` to be set because every test and production environment
-/// we target has one.
+/// Resolve the user's home directory.
+///
+/// Unix-like shells usually provide `$HOME`. Native Windows shells usually
+/// provide `%USERPROFILE%`, or `%HOMEDRIVE%` + `%HOMEPATH%`.
 pub fn home_dir() -> Result<PathBuf> {
-    let home = std::env::var_os("HOME").context(
-        "$HOME is not set. sldo-install cannot locate the user home directory. \
-         Set HOME or pass --skills-dir with an explicit path.",
-    )?;
-    Ok(PathBuf::from(home))
+    let windows_userprofile = if cfg!(windows) {
+        std::env::var_os("USERPROFILE")
+    } else {
+        None
+    };
+    let windows_homedrive = if cfg!(windows) {
+        std::env::var_os("HOMEDRIVE")
+    } else {
+        None
+    };
+    let windows_homepath = if cfg!(windows) {
+        std::env::var_os("HOMEPATH")
+    } else {
+        None
+    };
+
+    if let Some(home) = resolve_home_from_env(
+        std::env::var_os("HOME"),
+        windows_userprofile,
+        windows_homedrive,
+        windows_homepath,
+    ) {
+        return Ok(home);
+    }
+
+    bail!(
+        "Could not locate the user home directory. Set HOME on Unix/macOS, \
+         or USERPROFILE (or HOMEDRIVE + HOMEPATH) on Windows."
+    )
+}
+
+fn resolve_home_from_env(
+    home: Option<OsString>,
+    userprofile: Option<OsString>,
+    homedrive: Option<OsString>,
+    homepath: Option<OsString>,
+) -> Option<PathBuf> {
+    if let Some(home) = non_empty_path(home) {
+        return Some(home);
+    }
+    if let Some(userprofile) = non_empty_path(userprofile) {
+        return Some(userprofile);
+    }
+
+    let drive = homedrive.and_then(non_empty_os_string)?;
+    let path = homepath.and_then(non_empty_os_string)?;
+    let mut combined = drive;
+    combined.push(path);
+    Some(PathBuf::from(combined))
+}
+
+fn non_empty_path(value: Option<OsString>) -> Option<PathBuf> {
+    value.and_then(non_empty_os_string).map(PathBuf::from)
+}
+
+fn non_empty_os_string(value: OsString) -> Option<OsString> {
+    if value.is_empty() {
+        None
+    } else {
+        Some(value)
+    }
 }
 
 /// Where global installs land, e.g. `~/.claude/skills/`,
@@ -91,6 +148,53 @@ mod tests {
         assert_eq!(
             local_manifest_path(cwd, Host::Codex),
             PathBuf::from("/tmp/fake-repo/.codex/slo-install.toml")
+        );
+    }
+
+    #[test]
+    fn home_resolution_prefers_home_when_present() {
+        assert_eq!(
+            resolve_home_from_env(
+                Some(OsString::from("/home/slo")),
+                Some(OsString::from(r"C:\Users\slo")),
+                None,
+                None,
+            ),
+            Some(PathBuf::from("/home/slo"))
+        );
+    }
+
+    #[test]
+    fn home_resolution_accepts_windows_userprofile() {
+        assert_eq!(
+            resolve_home_from_env(None, Some(OsString::from(r"C:\Users\slo")), None, None),
+            Some(PathBuf::from(r"C:\Users\slo"))
+        );
+    }
+
+    #[test]
+    fn home_resolution_accepts_windows_drive_and_path() {
+        assert_eq!(
+            resolve_home_from_env(
+                None,
+                None,
+                Some(OsString::from("C:")),
+                Some(OsString::from(r"\Users\slo")),
+            ),
+            Some(PathBuf::from(r"C:\Users\slo"))
+        );
+    }
+
+    #[test]
+    fn home_resolution_rejects_empty_values() {
+        assert_eq!(
+            resolve_home_from_env(
+                Some(OsString::new()),
+                Some(OsString::new()),
+                Some(OsString::from("C:")),
+                Some(OsString::new()),
+            ),
+            None
         );
     }
 }

--- a/crates/sldo-install/tests/common/claude_runtime.rs
+++ b/crates/sldo-install/tests/common/claude_runtime.rs
@@ -38,7 +38,6 @@
 
 use std::collections::BTreeMap;
 use std::fs;
-use std::os::unix::fs::symlink;
 use std::path::{Path, PathBuf};
 use std::process::{Command, ExitStatus, Stdio};
 use std::time::Duration;
@@ -56,6 +55,54 @@ pub fn repo_root() -> PathBuf {
         .parent()
         .expect("workspace root reachable")
         .to_path_buf()
+}
+
+#[cfg(unix)]
+fn link_dir(source: &Path, target: &Path) -> Result<(), String> {
+    std::os::unix::fs::symlink(source, target)
+        .map_err(|e| format!("symlink {} -> {}: {e}", target.display(), source.display()))
+}
+
+#[cfg(windows)]
+fn link_dir(source: &Path, target: &Path) -> Result<(), String> {
+    if std::os::windows::fs::symlink_dir(source, target).is_ok() {
+        return Ok(());
+    }
+
+    let output = Command::new("cmd")
+        .args(["/C", "mklink", "/J"])
+        .arg(target)
+        .arg(source)
+        .output()
+        .map_err(|e| format!("invoke mklink /J: {e}"))?;
+    if output.status.success() {
+        return Ok(());
+    }
+
+    Err(format!(
+        "mklink /J {} -> {} failed: stdout={} stderr={}",
+        target.display(),
+        source.display(),
+        String::from_utf8_lossy(&output.stdout).trim(),
+        String::from_utf8_lossy(&output.stderr).trim()
+    ))
+}
+
+#[cfg(unix)]
+fn link_file(source: &Path, target: &Path) -> Result<(), String> {
+    std::os::unix::fs::symlink(source, target)
+        .map_err(|e| format!("symlink {} -> {}: {e}", target.display(), source.display()))
+}
+
+#[cfg(windows)]
+fn link_file(source: &Path, target: &Path) -> Result<(), String> {
+    if std::os::windows::fs::symlink_file(source, target).is_ok() {
+        return Ok(());
+    }
+
+    fs::copy(source, target)
+        .map(|_| ())
+        .map_err(|e| format!("copy {} -> {}: {e}", source.display(), target.display()))
 }
 
 // ---------------------------------------------------------------------------
@@ -241,9 +288,9 @@ pub struct TempRepo {
 
 impl TempRepo {
     /// Build a tempdir layout:
-    ///   <root>/.claude/skills/<each>  -> symlink to <repo>/skills/<each>
-    ///   <root>/references/biz         -> symlink to <repo>/references/biz
-    ///   <root>/CLAUDE.md              -> symlink to <repo>/CLAUDE.md
+    ///   <root>/.claude/skills/<each>  -> managed link to <repo>/skills/<each>
+    ///   <root>/references/biz         -> managed link to <repo>/references/biz
+    ///   <root>/CLAUDE.md              -> managed link/copy to <repo>/CLAUDE.md
     ///   <root>/home/.claude/          (empty; HOME redirect target)
     pub fn build(repo_root: &Path) -> Result<Self, String> {
         let root = tempfile::Builder::new()
@@ -252,7 +299,7 @@ impl TempRepo {
             .map_err(|e| format!("cannot create tempdir: {e}"))?;
         let root_path = root.path().to_path_buf();
 
-        // Skills dir + symlinks for each skill (skip non-skill entries like README.md).
+        // Skills dir + managed links for each skill (skip non-skill entries like README.md).
         let claude_skills = root_path.join(".claude").join("skills");
         fs::create_dir_all(&claude_skills)
             .map_err(|e| format!("mkdir {}: {e}", claude_skills.display()))?;
@@ -273,21 +320,18 @@ impl TempRepo {
                 continue;
             }
             let target = claude_skills.join(name);
-            symlink(&p, &target)
-                .map_err(|e| format!("symlink {} -> {}: {e}", target.display(), p.display()))?;
+            link_dir(&p, &target)?;
         }
 
-        // references/biz symlink.
+        // references/biz managed link.
         fs::create_dir_all(root_path.join("references"))
             .map_err(|e| format!("mkdir references: {e}"))?;
         let biz_target = root_path.join("references").join("biz");
-        symlink(repo_root.join("references/biz"), &biz_target)
-            .map_err(|e| format!("symlink references/biz: {e}"))?;
+        link_dir(&repo_root.join("references/biz"), &biz_target)?;
 
-        // CLAUDE.md symlink.
+        // CLAUDE.md managed link/copy.
         let claude_md_target = root_path.join("CLAUDE.md");
-        symlink(repo_root.join("CLAUDE.md"), &claude_md_target)
-            .map_err(|e| format!("symlink CLAUDE.md: {e}"))?;
+        link_file(&repo_root.join("CLAUDE.md"), &claude_md_target)?;
 
         // Empty isolated HOME.
         let home = root_path.join("home");

--- a/crates/sldo-install/tests/e2e_agent_host_m1.rs
+++ b/crates/sldo-install/tests/e2e_agent_host_m1.rs
@@ -17,6 +17,17 @@ fn make_skill(skills_dir: &Path, name: &str) {
     .unwrap();
 }
 
+fn assert_managed_link_to(link: &Path, source: &Path) {
+    assert!(
+        link.exists() || link.is_symlink(),
+        "expected managed link at {}",
+        link.display()
+    );
+    let resolved = fs::canonicalize(link).unwrap();
+    let expected = fs::canonicalize(source).unwrap();
+    assert_eq!(resolved, expected);
+}
+
 fn sldo_install(home: &Path, skills_dir: &Path, extra: &[&str]) -> std::process::Output {
     let mut cmd = Command::new(binary_path());
     cmd.env("HOME", home).arg("--skills-dir").arg(skills_dir);
@@ -61,9 +72,18 @@ fn test_claude_copilot_and_codex_roots_are_distinct() {
         String::from_utf8_lossy(&codex.stderr)
     );
 
-    assert!(home.path().join(".claude/skills/slo-ideate").is_symlink());
-    assert!(home.path().join(".copilot/skills/slo-ideate").is_symlink());
-    assert!(home.path().join(".codex/skills/slo-ideate").is_symlink());
+    assert_managed_link_to(
+        &home.path().join(".claude/skills/slo-ideate"),
+        &src.path().join("slo-ideate"),
+    );
+    assert_managed_link_to(
+        &home.path().join(".copilot/skills/slo-ideate"),
+        &src.path().join("slo-ideate"),
+    );
+    assert_managed_link_to(
+        &home.path().join(".codex/skills/slo-ideate"),
+        &src.path().join("slo-ideate"),
+    );
 
     let manifest = fs::read_to_string(home.path().join(".sldo/install.toml")).unwrap();
     assert!(manifest.contains("host = \"claude-code\""));
@@ -104,9 +124,15 @@ fn test_uninstall_only_removes_selected_host_entries() {
         String::from_utf8_lossy(&uninstall.stderr)
     );
 
-    assert!(home.path().join(".claude/skills/slo-ideate").is_symlink());
+    assert_managed_link_to(
+        &home.path().join(".claude/skills/slo-ideate"),
+        &src.path().join("slo-ideate"),
+    );
     assert!(!home.path().join(".copilot/skills/slo-ideate").exists());
-    assert!(home.path().join(".codex/skills/slo-ideate").is_symlink());
+    assert_managed_link_to(
+        &home.path().join(".codex/skills/slo-ideate"),
+        &src.path().join("slo-ideate"),
+    );
 
     let manifest_path = home.path().join(".sldo/install.toml");
     let manifest = fs::read_to_string(&manifest_path).expect("manifest should keep claude entries");
@@ -191,10 +217,10 @@ fn test_github_copilot_local_install_uses_repo_state() {
         String::from_utf8_lossy(&out.stderr)
     );
 
-    assert!(project
-        .path()
-        .join(".copilot/skills/slo-local")
-        .is_symlink());
+    assert_managed_link_to(
+        &project.path().join(".copilot/skills/slo-local"),
+        &src.path().join("slo-local"),
+    );
     assert!(project.path().join(".copilot/slo-install.toml").exists());
     assert!(!home.path().join(".copilot/skills/slo-local").exists());
 }
@@ -223,7 +249,10 @@ fn test_codex_local_install_uses_repo_state() {
         String::from_utf8_lossy(&out.stderr)
     );
 
-    assert!(project.path().join(".codex/skills/slo-local").is_symlink());
+    assert_managed_link_to(
+        &project.path().join(".codex/skills/slo-local"),
+        &src.path().join("slo-local"),
+    );
     assert!(project.path().join(".codex/slo-install.toml").exists());
     assert!(!home.path().join(".codex/skills/slo-local").exists());
 }
@@ -301,5 +330,8 @@ fn test_install_root_escape_refused_on_verify() {
 
     let stderr = String::from_utf8_lossy(&verify.stderr);
     assert!(stderr.contains("outside the selected host root"));
-    assert!(home.path().join(".claude/skills/slo-ideate").is_symlink());
+    assert_managed_link_to(
+        &home.path().join(".claude/skills/slo-ideate"),
+        &src.path().join("slo-ideate"),
+    );
 }

--- a/crates/sldo-install/tests/e2e_agent_host_m1.rs
+++ b/crates/sldo-install/tests/e2e_agent_host_m1.rs
@@ -31,7 +31,7 @@ fn manifest_path(home: &Path) -> PathBuf {
 }
 
 #[test]
-fn test_claude_and_copilot_roots_are_distinct() {
+fn test_claude_copilot_and_codex_roots_are_distinct() {
     let home = TempDir::new().unwrap();
     let src = TempDir::new().unwrap();
     make_skill(src.path(), "slo-ideate");
@@ -54,12 +54,21 @@ fn test_claude_and_copilot_roots_are_distinct() {
         String::from_utf8_lossy(&copilot.stderr)
     );
 
+    let codex = sldo_install(home.path(), src.path(), &["--host", "codex", "install"]);
+    assert!(
+        codex.status.success(),
+        "codex install failed: {}",
+        String::from_utf8_lossy(&codex.stderr)
+    );
+
     assert!(home.path().join(".claude/skills/slo-ideate").is_symlink());
     assert!(home.path().join(".copilot/skills/slo-ideate").is_symlink());
+    assert!(home.path().join(".codex/skills/slo-ideate").is_symlink());
 
     let manifest = fs::read_to_string(home.path().join(".sldo/install.toml")).unwrap();
     assert!(manifest.contains("host = \"claude-code\""));
     assert!(manifest.contains("host = \"github-copilot\""));
+    assert!(manifest.contains("host = \"codex\""));
 }
 
 #[test]
@@ -78,6 +87,11 @@ fn test_uninstall_only_removes_selected_host_entries() {
     )
     .status
     .success());
+    assert!(
+        sldo_install(home.path(), src.path(), &["--host", "codex", "install"])
+            .status
+            .success()
+    );
 
     let uninstall = sldo_install(
         home.path(),
@@ -92,11 +106,13 @@ fn test_uninstall_only_removes_selected_host_entries() {
 
     assert!(home.path().join(".claude/skills/slo-ideate").is_symlink());
     assert!(!home.path().join(".copilot/skills/slo-ideate").exists());
+    assert!(home.path().join(".codex/skills/slo-ideate").is_symlink());
 
     let manifest_path = home.path().join(".sldo/install.toml");
     let manifest = fs::read_to_string(&manifest_path).expect("manifest should keep claude entries");
     assert!(manifest.contains("host = \"claude-code\""));
     assert!(!manifest.contains("host = \"github-copilot\""));
+    assert!(manifest.contains("host = \"codex\""));
 }
 
 #[test]
@@ -132,6 +148,26 @@ fn test_status_and_verify_report_selected_host() {
 }
 
 #[test]
+fn test_codex_status_and_verify_report_selected_host() {
+    let home = TempDir::new().unwrap();
+    let src = TempDir::new().unwrap();
+    make_skill(src.path(), "slo-ideate");
+
+    let install = sldo_install(home.path(), src.path(), &["--host", "codex", "install"]);
+    assert!(install.status.success());
+
+    let status = sldo_install(home.path(), src.path(), &["--host", "codex", "status"]);
+    assert!(status.status.success());
+    let status_stdout = String::from_utf8_lossy(&status.stdout);
+    assert!(status_stdout.contains("codex"));
+
+    let verify = sldo_install(home.path(), src.path(), &["--host", "codex", "verify"]);
+    assert!(verify.status.success());
+    let verify_stdout = String::from_utf8_lossy(&verify.stdout);
+    assert!(verify_stdout.contains("codex"));
+}
+
+#[test]
 fn test_github_copilot_local_install_uses_repo_state() {
     let home = TempDir::new().unwrap();
     let src = TempDir::new().unwrap();
@@ -164,6 +200,35 @@ fn test_github_copilot_local_install_uses_repo_state() {
 }
 
 #[test]
+fn test_codex_local_install_uses_repo_state() {
+    let home = TempDir::new().unwrap();
+    let src = TempDir::new().unwrap();
+    make_skill(src.path(), "slo-local");
+
+    let project = TempDir::new().unwrap();
+    let out = Command::new(binary_path())
+        .current_dir(project.path())
+        .env("HOME", home.path())
+        .arg("--skills-dir")
+        .arg(src.path())
+        .arg("--host")
+        .arg("codex")
+        .arg("--local")
+        .arg("install")
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "local codex install failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    assert!(project.path().join(".codex/skills/slo-local").is_symlink());
+    assert!(project.path().join(".codex/slo-install.toml").exists());
+    assert!(!home.path().join(".codex/skills/slo-local").exists());
+}
+
+#[test]
 fn test_unknown_host_fails_loud() {
     let home = TempDir::new().unwrap();
     let src = TempDir::new().unwrap();
@@ -179,6 +244,7 @@ fn test_unknown_host_fails_loud() {
     let stderr = String::from_utf8_lossy(&out.stderr);
     assert!(stderr.contains("claude-code"));
     assert!(stderr.contains("github-copilot"));
+    assert!(stderr.contains("codex"));
 }
 
 #[test]

--- a/crates/sldo-install/tests/e2e_agent_host_m2.rs
+++ b/crates/sldo-install/tests/e2e_agent_host_m2.rs
@@ -74,6 +74,7 @@ fn test_capability_matrix_marks_headless_non_claude_hosts_as_unsupported() {
 fn test_readme_links_to_getting_started_and_getting_started_has_first_run_sections() {
     let readme = read("README.md");
     let guide = read("docs/getting-started.md");
+    let workflow = read(".github/workflows/sldo-install.yml");
 
     assert!(
         readme.contains("docs/getting-started.md"),
@@ -82,6 +83,20 @@ fn test_readme_links_to_getting_started_and_getting_started_has_first_run_sectio
     assert!(
         readme.contains("--host codex") && guide.contains("--host codex"),
         "README and getting-started guide must document the Codex install path"
+    );
+    assert!(
+        readme.contains("Windows")
+            && readme.contains("Linux")
+            && guide.contains("Windows PowerShell")
+            && guide.contains("directory junctions"),
+        "README and getting-started guide must document cross-platform installer behavior"
+    );
+    assert!(
+        workflow.contains("ubuntu-latest")
+            && workflow.contains("windows-latest")
+            && workflow.contains("macos-latest")
+            && workflow.contains("cargo test -p sldo-install"),
+        "sldo-install workflow must exercise the installer across Linux, Windows, and macOS"
     );
 
     for heading in [

--- a/crates/sldo-install/tests/e2e_agent_host_m2.rs
+++ b/crates/sldo-install/tests/e2e_agent_host_m2.rs
@@ -20,14 +20,17 @@ fn test_living_docs_distinguish_catalog_from_overlays() {
     let catalog = read("docs/skill-pack-catalog.md");
     let claude = read("CLAUDE.md");
     let copilot = read("copilot-instructions.md");
+    let codex = read("AGENTS.md");
 
     assert!(
         catalog.contains("canonical living catalog"),
         "catalog must identify itself as the canonical living catalog"
     );
     assert!(
-        catalog.contains("CLAUDE.md") && catalog.contains("copilot-instructions.md"),
-        "catalog must point readers to both host overlays"
+        catalog.contains("CLAUDE.md")
+            && catalog.contains("copilot-instructions.md")
+            && catalog.contains("AGENTS.md"),
+        "catalog must point readers to every host overlay"
     );
     assert!(
         claude.contains("Claude Code overlay") && claude.contains("docs/skill-pack-catalog.md"),
@@ -38,10 +41,14 @@ fn test_living_docs_distinguish_catalog_from_overlays() {
             && copilot.contains("docs/skill-pack-catalog.md"),
         "copilot overlay must identify itself as an overlay and point back to the canonical catalog"
     );
+    assert!(
+        codex.contains("Codex overlay") && codex.contains("docs/skill-pack-catalog.md"),
+        "AGENTS.md must identify itself as the Codex overlay and point back to the canonical catalog"
+    );
 }
 
 #[test]
-fn test_capability_matrix_marks_headless_copilot_as_unsupported() {
+fn test_capability_matrix_marks_headless_non_claude_hosts_as_unsupported() {
     let capability = read("docs/slo/design/agent-host-capabilities.md");
 
     assert!(
@@ -49,8 +56,13 @@ fn test_capability_matrix_marks_headless_copilot_as_unsupported() {
         "capability matrix must cover headless runtime automation"
     );
     assert!(
-        capability.contains("GitHub Copilot") && capability.contains("Not supported yet"),
-        "capability matrix must say headless GitHub Copilot automation is not supported yet"
+        capability.contains("GitHub Copilot") && capability.contains("Codex"),
+        "capability matrix must include both non-Claude supported hosts"
+    );
+    assert!(
+        capability.contains("No Copilot or Codex runtime harness is shipped today")
+            || capability.contains("Codex") && capability.contains("Not supported yet"),
+        "capability matrix must say headless GitHub Copilot and Codex automation are not supported yet"
     );
     assert!(
         capability.contains("interactive") || capability.contains("Interactive"),
@@ -66,6 +78,10 @@ fn test_readme_links_to_getting_started_and_getting_started_has_first_run_sectio
     assert!(
         readme.contains("docs/getting-started.md"),
         "README must link to the getting-started guide"
+    );
+    assert!(
+        readme.contains("--host codex") && guide.contains("--host codex"),
+        "README and getting-started guide must document the Codex install path"
     );
 
     for heading in [

--- a/crates/sldo-install/tests/e2e_agent_host_m3.rs
+++ b/crates/sldo-install/tests/e2e_agent_host_m3.rs
@@ -42,6 +42,7 @@ fn test_batch_backend_is_marked_optional_and_claude_specific() {
     let readme = read("README.md");
     let claude = read("CLAUDE.md");
     let copilot = read("copilot-instructions.md");
+    let codex = read("AGENTS.md");
     let catalog = read("docs/skill-pack-catalog.md");
     let architecture = read("docs/ARCHITECTURE.md");
 
@@ -49,6 +50,7 @@ fn test_batch_backend_is_marked_optional_and_claude_specific() {
         ("README", readme.as_str()),
         ("CLAUDE", claude.as_str()),
         ("Copilot overlay", copilot.as_str()),
+        ("Codex overlay", codex.as_str()),
         ("catalog", catalog.as_str()),
         ("architecture", architecture.as_str()),
     ] {
@@ -71,5 +73,9 @@ fn test_batch_backend_is_marked_optional_and_claude_specific() {
     assert!(
         copilot.contains("without installing Claude"),
         "Copilot overlay must make the no-hidden-Claude interactive path explicit"
+    );
+    assert!(
+        codex.contains("host-native interactive research"),
+        "Codex overlay must make the host-native interactive path explicit"
     );
 }

--- a/crates/sldo-install/tests/e2e_agent_host_m5.rs
+++ b/crates/sldo-install/tests/e2e_agent_host_m5.rs
@@ -83,7 +83,7 @@ fn test_explicit_claude_only_skills_are_marked_in_capability_matrix() {
     // batch backend; the live business-judgment runtime harness).
     // When: the capability matrix is read.
     // Then: it still names those surfaces explicitly as Claude-only, and
-    // calls out the GitHub Copilot side as "Not supported yet" rather than
+    // calls out the non-Claude side as "Not supported yet" rather than
     // pretending parity.
     let matrix = capability_matrix();
 
@@ -102,7 +102,7 @@ fn test_explicit_claude_only_skills_are_marked_in_capability_matrix() {
     assert!(
         lower.contains("not supported yet"),
         "capability matrix must keep at least one explicit 'Not supported yet' row so the \
-         host story stays honest about Copilot-side automation gaps"
+         host story stays honest about non-Claude automation gaps"
     );
 
     // The matrix must also note `/slo-second-opinion` in the per-skill

--- a/crates/sldo-install/tests/e2e_slo_sp_m10.rs
+++ b/crates/sldo-install/tests/e2e_slo_sp_m10.rs
@@ -76,8 +76,12 @@ fn get_api_docs_installs_through_generic_pickup() {
         .join("skills")
         .join("get-api-docs");
     assert!(
-        link.is_symlink(),
-        "get-api-docs should install via the generic symlink path — no special case"
+        link.exists() || link.is_symlink(),
+        "get-api-docs should install via the generic managed-link path — no special case"
+    );
+    assert_eq!(
+        fs::canonicalize(&link).unwrap(),
+        fs::canonicalize(&skill_src).unwrap()
     );
 }
 

--- a/crates/sldo-install/tests/e2e_slo_sp_m2.rs
+++ b/crates/sldo-install/tests/e2e_slo_sp_m2.rs
@@ -4,7 +4,7 @@
 //! These tests do not exercise the runtime behavior of the skills (that
 //! happens when Claude Code actually runs them). They verify the static
 //! contract: the SKILL.md file has valid YAML frontmatter with the required
-//! fields, and the installer picks both up and installs them as symlinks.
+//! fields, and the installer picks both up and installs them as managed links.
 
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -110,6 +110,14 @@ fn test_installer_picks_up_ideate_and_retro() {
     let skills_root = home.path().join(".claude").join("skills");
     for name in ["slo-ideate", "slo-retro"] {
         let link = skills_root.join(name);
-        assert!(link.is_symlink(), "expected symlink at {}", link.display());
+        assert!(
+            link.exists() || link.is_symlink(),
+            "expected managed link at {}",
+            link.display()
+        );
+        assert_eq!(
+            fs::canonicalize(&link).unwrap(),
+            fs::canonicalize(src.path().join(name)).unwrap()
+        );
     }
 }

--- a/crates/sldo-install/tests/e2e_v4_template.rs
+++ b/crates/sldo-install/tests/e2e_v4_template.rs
@@ -278,7 +278,7 @@ fn canonical_pointers_now_target_v4() {
 // ---------------------------------------------------------------------------
 // Drift guards — the v4 / v3 templates exist in two places by design:
 //   - skills/slo-plan/references/...  (skill-local copy that travels with
-//     `sldo-install`'s symlink, used at runtime in any project)
+//     `sldo-install`'s managed link, used at runtime in any project)
 //   - docs/slo/templates/...              (human-browsable mirror in this repo)
 // They MUST be byte-identical. The drift guard fails loudly the moment
 // someone edits one without the other.

--- a/crates/sldo-install/tests/install_e2e.rs
+++ b/crates/sldo-install/tests/install_e2e.rs
@@ -31,6 +31,54 @@ fn make_skill(skills_dir: &Path, name: &str) {
     .unwrap();
 }
 
+fn assert_managed_link_to(link: &Path, source: &Path) {
+    assert!(
+        link.exists() || link.is_symlink(),
+        "expected managed link at {}",
+        link.display()
+    );
+    let resolved = fs::canonicalize(link).unwrap();
+    let expected = fs::canonicalize(source).unwrap();
+    assert_eq!(resolved, expected);
+}
+
+#[cfg(unix)]
+fn create_test_dir_link(source: &Path, target: &Path) {
+    std::os::unix::fs::symlink(source, target).unwrap();
+}
+
+#[cfg(windows)]
+fn create_test_dir_link(source: &Path, target: &Path) {
+    if std::os::windows::fs::symlink_dir(source, target).is_ok() {
+        return;
+    }
+
+    let output = Command::new("cmd")
+        .args(["/C", "mklink", "/J"])
+        .arg(target)
+        .arg(source)
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "failed to create Windows test junction: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[cfg(unix)]
+fn remove_test_link(target: &Path) {
+    fs::remove_file(target).unwrap();
+}
+
+#[cfg(windows)]
+fn remove_test_link(target: &Path) {
+    fs::remove_dir(target)
+        .or_else(|_| fs::remove_file(target))
+        .unwrap();
+}
+
 fn sldo_install(home: &Path, skills_dir: &Path, extra: &[&str]) -> std::process::Output {
     let mut cmd = Command::new(binary_path());
     cmd.env("HOME", home).arg("--skills-dir").arg(skills_dir);
@@ -58,8 +106,14 @@ fn test_full_install_uninstall_cycle() {
 
     // Then: symlinks exist and manifest records them
     let target_root = home.path().join(".claude").join("skills");
-    assert!(target_root.join("slo-ideate").is_symlink());
-    assert!(target_root.join("get-api-docs").is_symlink());
+    assert_managed_link_to(
+        &target_root.join("slo-ideate"),
+        &src.path().join("slo-ideate"),
+    );
+    assert_managed_link_to(
+        &target_root.join("get-api-docs"),
+        &src.path().join("get-api-docs"),
+    );
 
     let manifest_path = home.path().join(".sldo").join("install.toml");
     assert!(manifest_path.exists(), "manifest not written");
@@ -181,7 +235,7 @@ fn test_local_install_into_project() {
         .join(".claude")
         .join("skills")
         .join("slo-local");
-    assert!(link.is_symlink());
+    assert_managed_link_to(&link, &src.path().join("slo-local"));
 
     // Global manifest should not exist.
     let global_manifest = home.path().join(".sldo").join("install.toml");
@@ -234,7 +288,7 @@ fn test_skill_without_skill_md_is_skipped() {
     assert!(out.status.success());
 
     let target_root = home.path().join(".claude").join("skills");
-    assert!(target_root.join("slo-real").is_symlink());
+    assert_managed_link_to(&target_root.join("slo-real"), &src.path().join("slo-real"));
     assert!(!target_root.join("not-a-skill").exists());
 }
 
@@ -266,15 +320,12 @@ fn test_uninstall_preserves_user_modified_symlink() {
     let other_target = other.path().join("whatever");
     fs::create_dir_all(&other_target).unwrap();
     let link = home.path().join(".claude").join("skills").join("slo-keep");
-    fs::remove_file(&link).unwrap();
-    std::os::unix::fs::symlink(&other_target, &link).unwrap();
+    remove_test_link(&link);
+    create_test_dir_link(&other_target, &link);
 
     let out = sldo_install(home.path(), src.path(), &["uninstall"]);
     assert!(out.status.success());
 
     // Link should still exist (user's customization preserved).
-    assert!(link.is_symlink());
-    let resolved = fs::canonicalize(&link).unwrap();
-    let expected = fs::canonicalize(&other_target).unwrap();
-    assert_eq!(resolved, expected);
+    assert_managed_link_to(&link, &other_target);
 }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -53,6 +53,7 @@ For the full host-neutral skill inventory, read `docs/skill-pack-catalog.md`.
 - **Ticket-sized planning artifact.** Every bite-sized GitHub issue contract lives at `docs/slo/tickets/ticket-<issue>-<slug>.md` and follows `docs/slo/templates/ticket-contract-template_v_1.md`.
 - **Reality-first ARCHITECTURE.md.** This file records implemented surfaces only.
 - **Host-aware installer roots.** Global installs land in `~/.claude/skills/`, `~/.copilot/skills/`, or `~/.codex/skills/`. Local installs land in `./.claude/skills/`, `./.copilot/skills/`, or `./.codex/skills/`.
+- **Cross-platform installer behavior.** Linux and macOS use directory symlinks. Windows tries directory symlinks first and falls back to directory junctions when symlink privileges are unavailable. Home resolution supports `HOME`, `USERPROFILE`, and `HOMEDRIVE` + `HOMEPATH`.
 - **Shared manifest with explicit host ownership.** `~/.sldo/install.toml` stores install records by host so `status`, `verify`, and `uninstall` stay scoped.
 - **Baseline test command.** `cargo test -p sldo-common -p sldo-install -p sldo-research`.
 - **Current runtime boundary.** GitHub Copilot and Codex are interactive hosts today, not headless runtime targets.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -21,6 +21,7 @@ The repo no longer ships `sldo-plan`, `sldo-run`, or `sldo-tauri` as active work
 | `docs/skill-pack-catalog.md` | Canonical living catalog of shipped skills |
 | `CLAUDE.md` | Claude Code overlay for the catalog |
 | `copilot-instructions.md` | GitHub Copilot overlay for the catalog |
+| `AGENTS.md` | Codex overlay for the catalog |
 | `docs/slo/design/agent-host-capabilities.md` | Capability matrix for install, interactive use, and runtime boundaries |
 
 ## Skill pack
@@ -39,7 +40,7 @@ The skill pack is the primary user-facing product. Each skill lives in `skills/<
 | Utilities | `skills/slo-{freeze,resume,second-opinion}` | Session control, resumption, and disagreement surfacing |
 | Vendored helper | `skills/get-api-docs` | Third-party API doc fetches via `chub` |
 | Examples gallery | `examples/` | Synthetic, non-normative gallery (7 files) showing what shipped SLO outputs look like — read [`examples/README.md`](../examples/README.md). Not installable; not consumed by any skill. |
-| Specialist agents (optional, Claude-only) | `agents/slo-{runbook-review-lead,security-reviewer,design-reviewer,verification-lead}.md` | Host-native agent files for Claude Code that mirror `/slo-critique` persona rotation. Output paths constrained to `docs/slo/critique/` and `docs/slo/verify/`. GitHub Copilot users use `/slo-critique` directly (canonical portable path). See [`docs/slo/design/host-capability-matrix.md`](slo/design/host-capability-matrix.md). |
+| Specialist agents (optional, Claude-only) | `agents/slo-{runbook-review-lead,security-reviewer,design-reviewer,verification-lead}.md` | Host-native agent files for Claude Code that mirror `/slo-critique` persona rotation. Output paths constrained to `docs/slo/critique/` and `docs/slo/verify/`. GitHub Copilot and Codex users use `/slo-critique` directly (canonical portable path). See [`docs/slo/design/host-capability-matrix.md`](slo/design/host-capability-matrix.md). |
 | Distribution channels | `sldo-install` (canonical, multi-host) + optional `.claude-plugin/plugin.json` (Claude-only, additive) | Tagged releases produce a downloadable zip via the SHA-pinned [`release-zip workflow`](../.github/workflows/release-zip.yml). |
 
 For the full host-neutral skill inventory, read `docs/skill-pack-catalog.md`.
@@ -47,14 +48,14 @@ For the full host-neutral skill inventory, read `docs/skill-pack-catalog.md`.
 ## Skill pack invariants (reality at HEAD)
 
 - **Markdown-only skill contract.** The portable unit is `skills/<name>/SKILL.md`.
-- **Canonical catalog plus host overlays.** `docs/skill-pack-catalog.md` is the shared catalog. `CLAUDE.md` and `copilot-instructions.md` are overlays, not competing sources of truth.
+- **Canonical catalog plus host overlays.** `docs/skill-pack-catalog.md` is the shared catalog. `CLAUDE.md`, `copilot-instructions.md`, and `AGENTS.md` are overlays, not competing sources of truth.
 - **Canonical planning artifact.** Every new feature runbook is `docs/RUNBOOK-<FEATURE>.md` and follows `docs/slo/templates/runbook-template_v_4_template.md` (v3 remains in place as the historical artifact for runbooks authored against it).
 - **Ticket-sized planning artifact.** Every bite-sized GitHub issue contract lives at `docs/slo/tickets/ticket-<issue>-<slug>.md` and follows `docs/slo/templates/ticket-contract-template_v_1.md`.
 - **Reality-first ARCHITECTURE.md.** This file records implemented surfaces only.
-- **Host-aware installer roots.** Global installs land in `~/.claude/skills/` or `~/.copilot/skills/`. Local installs land in `./.claude/skills/` or `./.copilot/skills/`.
+- **Host-aware installer roots.** Global installs land in `~/.claude/skills/`, `~/.copilot/skills/`, or `~/.codex/skills/`. Local installs land in `./.claude/skills/`, `./.copilot/skills/`, or `./.codex/skills/`.
 - **Shared manifest with explicit host ownership.** `~/.sldo/install.toml` stores install records by host so `status`, `verify`, and `uninstall` stay scoped.
 - **Baseline test command.** `cargo test -p sldo-common -p sldo-install -p sldo-research`.
-- **Current runtime boundary.** GitHub Copilot is an interactive host today, not a headless runtime target.
+- **Current runtime boundary.** GitHub Copilot and Codex are interactive hosts today, not headless runtime targets.
 
 ### References subtrees
 
@@ -111,7 +112,7 @@ The installed skill is host-neutral for interactive use. `sldo-research` is the 
 | File | Responsibility |
 |---|---|
 | `main.rs` | CLI parsing and command dispatch |
-| `host.rs` | Host descriptor table (`claude-code`, `github-copilot`) |
+| `host.rs` | Host descriptor table (`claude-code`, `github-copilot`, `codex`) |
 | `paths.rs` | Host-specific global and local path resolution |
 | `manifest.rs` | Shared install manifest with per-host ownership |
 | `install.rs` | Install, verify, status, and uninstall behavior |
@@ -160,7 +161,7 @@ The current host line is simple:
 
 - Install support is multi-host.
 - The catalog and the `SKILL.md` contract are host-neutral.
-- Interactive skill use is supported in Claude Code and GitHub Copilot.
+- Interactive skill use is supported in Claude Code, GitHub Copilot, and Codex.
 - Headless runtime automation is still Claude-specific where it exists today.
 - `/slo-research` interactive use is multi-host today; `sldo-research` remains an optional Claude batch backend.
 - `/slo-second-opinion` is host-neutral: it compares the current host against an external provider CLI (Codex or Gemini), and never silently falls back to asking the current host to imitate the other provider.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -2,13 +2,13 @@
 
 This guide is for someone opening SunLitOrchestrate for the first time and wanting one clear path from clone to first successful skill run.
 
-SunLitOrchestrate ships a **skill pack**: a folder of Markdown instruction files that you install into a coding agent. The coding agent is the **host**. Right now the supported hosts are Claude Code and GitHub Copilot.
+SunLitOrchestrate ships a **skill pack**: a folder of Markdown instruction files that you install into a coding agent. The coding agent is the **host**. Right now the supported hosts are Claude Code, GitHub Copilot, and Codex.
 
 ## Quick glossary
 
 - **Skill pack**: the collection of `SKILL.md` files in the `skills/` directory.
-- **Host**: the coding agent that reads those installed skill files, such as Claude Code or GitHub Copilot.
-- **Overlay doc**: the host-specific notes for one host. In this repo those are [CLAUDE.md](../CLAUDE.md) and [copilot-instructions.md](../copilot-instructions.md).
+- **Host**: the coding agent that reads those installed skill files, such as Claude Code, GitHub Copilot, or Codex.
+- **Overlay doc**: the host-specific notes for one host. In this repo those are [CLAUDE.md](../CLAUDE.md), [copilot-instructions.md](../copilot-instructions.md), and [AGENTS.md](../AGENTS.md).
 - **Manifest**: the install record written by `sldo-install` so it knows which host owns which installed symlink.
 
 ## Prerequisites
@@ -17,7 +17,7 @@ You need these before the first run:
 
 - Git, so you can clone the repo.
 - A stable Rust toolchain, because `sldo-install` is a Rust binary you build locally.
-- One supported host: Claude Code or GitHub Copilot.
+- One supported host: Claude Code, GitHub Copilot, or Codex.
 - Semgrep only if you want to use the SAST rule-pack skills right away.
 
 ## Install the skill pack
@@ -36,6 +36,7 @@ Install into Claude Code:
 ```bash
 ./target/release/sldo-install
 ./target/release/sldo-install status
+./target/release/sldo-install verify
 ```
 
 Install into GitHub Copilot:
@@ -43,19 +44,28 @@ Install into GitHub Copilot:
 ```bash
 ./target/release/sldo-install --host github-copilot
 ./target/release/sldo-install --host github-copilot status
+./target/release/sldo-install --host github-copilot verify
+```
+
+Install into Codex:
+
+```bash
+./target/release/sldo-install --host codex
+./target/release/sldo-install --host codex status
+./target/release/sldo-install --host codex verify
 ```
 
 What success looks like:
 
 - `sldo-install` prints the selected target root.
 - `status` prints the installed skills for the host you chose.
-- Global installs land in `~/.claude/skills/` or `~/.copilot/skills/`.
-- Local installs land in `./.claude/skills/` or `./.copilot/skills/` if you add `--local`.
+- Global installs land in `~/.claude/skills/`, `~/.copilot/skills/`, or `~/.codex/skills/`.
+- Local installs land in `./.claude/skills/`, `./.copilot/skills/`, or `./.codex/skills/` if you add `--local`.
 
 ## Run your first skill
 
 1. Open the repo in your chosen host.
-2. Read the matching overlay doc: [CLAUDE.md](../CLAUDE.md) for Claude Code or [copilot-instructions.md](../copilot-instructions.md) for GitHub Copilot.
+2. Read the matching overlay doc: [CLAUDE.md](../CLAUDE.md) for Claude Code, [copilot-instructions.md](../copilot-instructions.md) for GitHub Copilot, or [AGENTS.md](../AGENTS.md) for Codex.
 3. Start with `/slo-ideate` if you have a new product or feature idea.
 4. Expect the first concrete output to be a file like `docs/slo/idea/<slug>.md`.
 
@@ -74,13 +84,14 @@ Run `status` for the same host you installed to:
 ```bash
 ./target/release/sldo-install status
 ./target/release/sldo-install --host github-copilot status
+./target/release/sldo-install --host codex status
 ```
 
 If the install target is right but the host still does not show the skills, restart the session or the editor and check the host's installed-skills UI again.
 
-### Copilot install says there is a conflict in `~/.copilot/skills/`
+### My host install says there is a conflict in its skills directory
 
-That means a path already exists there as a normal directory or file instead of an installer-managed symlink. `sldo-install` refuses to overwrite that silently. Move or remove the conflicting path first, then rerun the install.
+That means a path already exists under the selected host root as a normal directory or file instead of an installer-managed symlink. `sldo-install` refuses to overwrite that silently. Move or remove the conflicting path first, then rerun the install for the same `--host`.
 
 ### `/slo-research` mentions `sldo-research`
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -9,7 +9,7 @@ SunLitOrchestrate ships a **skill pack**: a folder of Markdown instruction files
 - **Skill pack**: the collection of `SKILL.md` files in the `skills/` directory.
 - **Host**: the coding agent that reads those installed skill files, such as Claude Code, GitHub Copilot, or Codex.
 - **Overlay doc**: the host-specific notes for one host. In this repo those are [CLAUDE.md](../CLAUDE.md), [copilot-instructions.md](../copilot-instructions.md), and [AGENTS.md](../AGENTS.md).
-- **Manifest**: the install record written by `sldo-install` so it knows which host owns which installed symlink.
+- **Manifest**: the install record written by `sldo-install` so it knows which host owns which installed managed link.
 
 ## Prerequisites
 
@@ -61,6 +61,8 @@ What success looks like:
 - `status` prints the installed skills for the host you chose.
 - Global installs land in `~/.claude/skills/`, `~/.copilot/skills/`, or `~/.codex/skills/`.
 - Local installs land in `./.claude/skills/`, `./.copilot/skills/`, or `./.codex/skills/` if you add `--local`.
+- On Windows PowerShell, use `.\target\release\sldo-install.exe` with the same flags shown above.
+- Linux and macOS installs use directory symlinks. Windows tries directory symlinks first, then falls back to directory junctions if symlink privileges are unavailable.
 
 ## Run your first skill
 
@@ -75,7 +77,7 @@ If you already have an idea doc, the usual next step is `/slo-research`, then `/
 
 ### `sldo-install` is not found
 
-Make sure you built it first with `cargo build -p sldo-install --release`, then run it from `./target/release/sldo-install`.
+Make sure you built it first with `cargo build -p sldo-install --release`, then run it from `./target/release/sldo-install`. On Windows PowerShell, the path is `.\target\release\sldo-install.exe`.
 
 ### The skills do not appear in my host
 
@@ -91,7 +93,7 @@ If the install target is right but the host still does not show the skills, rest
 
 ### My host install says there is a conflict in its skills directory
 
-That means a path already exists under the selected host root as a normal directory or file instead of an installer-managed symlink. `sldo-install` refuses to overwrite that silently. Move or remove the conflicting path first, then rerun the install for the same `--host`.
+That means a path already exists under the selected host root as a normal directory or file instead of an installer-managed link. `sldo-install` refuses to overwrite that silently. Move or remove the conflicting path first, then rerun the install for the same `--host`.
 
 ### `/slo-research` mentions `sldo-research`
 

--- a/docs/skill-pack-catalog.md
+++ b/docs/skill-pack-catalog.md
@@ -3,7 +3,7 @@
 > **Status**: canonical living catalog of shipped SunLitOrchestrate skills at HEAD.
 > **Audience**: contributors, host-overlay authors, and users deciding which skill to run.
 
-Use this file for the host-neutral list of shipped skills. Use [../CLAUDE.md](../CLAUDE.md) for the Claude Code overlay, [../copilot-instructions.md](../copilot-instructions.md) for the GitHub Copilot overlay, [getting-started.md](getting-started.md) for the first-run path, and [design/agent-host-capabilities.md](design/agent-host-capabilities.md) for current host support boundaries. Acronyms used here (TLA+, BDD, ICP, SEIS, IR35, …) are defined in [GLOSSARY.md](GLOSSARY.md).
+Use this file for the host-neutral list of shipped skills. Use [../CLAUDE.md](../CLAUDE.md) for the Claude Code overlay, [../copilot-instructions.md](../copilot-instructions.md) for the GitHub Copilot overlay, [../AGENTS.md](../AGENTS.md) for the Codex overlay, [getting-started.md](getting-started.md) for the first-run path, and [slo/design/agent-host-capabilities.md](slo/design/agent-host-capabilities.md) for current host support boundaries. Acronyms used here (TLA+, BDD, ICP, SEIS, IR35, ...) are defined in [GLOSSARY.md](GLOSSARY.md).
 
 **Shipped skills at HEAD: 37** (10 sprint flow + 5 ticket flow + 6 power tools + 4 business advisor + 11 business generator + 1 vendored). Skills with mode variants (`/slo-product roadmap|metrics|okrs`, `/slo-marketing b2b|b2c`, `/slo-metrics consumer|b2b`, `/slo-hire swe|ae|designer|ops`) are one skill per row in their section, except `/slo-product` whose three modes are listed individually because the output paths differ. To reconcile against disk, run `ls skills/ | grep -v README` — should be 37 entries.
 
@@ -12,7 +12,7 @@ Use this file for the host-neutral list of shipped skills. Use [../CLAUDE.md](..
 - The portable unit is the Markdown `SKILL.md` contract under `skills/<name>/SKILL.md`.
 - The active Rust workspace members are `sldo-common`, `sldo-research`, `sldo-install`, and `xtasks/sast-verify`.
 - The legacy `sldo-plan`, `sldo-run`, and `sldo-tauri` surfaces are not current workspace members and should not be treated as active interfaces.
-- `sldo-install` can install the same skill pack into Claude Code or GitHub Copilot.
+- `sldo-install` can install the same skill pack into Claude Code, GitHub Copilot, or Codex.
 - Headless runtime automation is still host-specific today. Check [design/agent-host-capabilities.md](design/agent-host-capabilities.md) before promising a runtime surface.
 
 ## Sprint flow
@@ -90,9 +90,9 @@ These skills generate exactly one primary artifact each.
 |---|---|---|
 | `/get-api-docs` | Fetch current third-party API docs via `chub` before coding against an external API | `npm install -g @aisuite/chub` |
 
-## Specialist agents (optional, host-native — Claude Code only)
+## Specialist agents (optional, host-native - Claude Code only)
 
-Additive Claude-only enhancements that mirror `/slo-critique`'s four-persona rotation. Output paths are constrained to `docs/slo/critique/` and `docs/slo/verify/` — same artifact paths the canonical portable path writes. GitHub Copilot users continue to use `/slo-critique` directly (canonical portable path; no second-class treatment).
+Additive Claude-only enhancements that mirror `/slo-critique`'s four-persona rotation. Output paths are constrained to `docs/slo/critique/` and `docs/slo/verify/` - same artifact paths the canonical portable path writes. GitHub Copilot and Codex users continue to use `/slo-critique` directly (canonical portable path; no second-class treatment).
 
 | Agent | Role | Output paths | Copilot fallback |
 |---|---|---|---|
@@ -109,7 +109,7 @@ Synthetic, non-normative gallery at [`examples/`](../examples/) shows what shipp
 
 ## Distribution channels
 
-- `sldo-install` (canonical, multi-host: Claude Code + GitHub Copilot).
+- `sldo-install` (canonical, multi-host: Claude Code + GitHub Copilot + Codex).
 - `.claude-plugin/plugin.json` (optional, additive, Claude-only) — for organizational installs that prefer a one-zip distribution.
 - Tagged releases: SHA-pinned [`release-zip workflow`](../.github/workflows/release-zip.yml) generates a `git archive`-based release zip on `v*` tag push.
 
@@ -118,12 +118,12 @@ Synthetic, non-normative gallery at [`examples/`](../examples/) shows what shipp
 - Every new feature runbook lives at `docs/RUNBOOK-<FEATURE>.md` and follows `docs/slo/templates/runbook-template_v_4_template.md` (v3 remains in place as the historical artifact for runbooks already authored against it).
 - Every ticket-sized issue contract lives at `docs/slo/tickets/ticket-<issue>-<slug>.md` and follows `docs/slo/templates/ticket-contract-template_v_1.md`, which preserves the v4 Contract Block, BDD, evidence, static-analysis, assertion, and resource-bound gates in compact form.
 - `README.md` is the orientation doc, `docs/getting-started.md` is the first-run guide, and this file is the host-neutral skill catalog.
-- Host overlays must stay overlays. They can add session-specific guidance, but they should point back here instead of becoming competing catalogs.
+- Host overlays (`CLAUDE.md`, `copilot-instructions.md`, `AGENTS.md`) must stay overlays. They can add session-specific guidance, but they should point back here instead of becoming competing catalogs.
 - `references/biz/`, `references/security/`, and `references/sast/` are shared scaffolding trees. They are read by skills, but they are not skill directories.
 
 ## Current host boundaries
 
-- Claude Code and GitHub Copilot can both consume the installed `SKILL.md` files.
-- GitHub Copilot should be treated as an interactive host today, not a headless runtime target.
+- Claude Code, GitHub Copilot, and Codex can consume the installed `SKILL.md` files.
+- GitHub Copilot and Codex should be treated as interactive hosts today, not headless runtime targets.
 - `/slo-research` interactive use is host-neutral today; `sldo-research` remains an optional Claude batch backend.
 - The live business judgment runtime harness is still Claude-only today.

--- a/docs/slo/design/agent-host-capabilities.md
+++ b/docs/slo/design/agent-host-capabilities.md
@@ -1,6 +1,6 @@
 # Agent Host Capabilities
 
-This document is the capability matrix for the current host story. Use it when you need to answer a simple question: "does this work in Claude Code, GitHub Copilot, both, or neither?"
+This document is the capability matrix for the current host story. Use it when you need to answer a simple question: "does this work in Claude Code, GitHub Copilot, Codex, or only on one host?"
 
 ## Reading rule
 
@@ -10,16 +10,16 @@ This document is the capability matrix for the current host story. Use it when y
 
 ## Capability matrix
 
-| Capability | Claude Code | GitHub Copilot | Notes |
-|---|---|---|---|
-| Install skills with `sldo-install` | Supported | Supported | Same `SKILL.md` contract; different install roots |
-| Project-local install with `--local` | Supported | Supported | Writes to `./.claude/skills/` or `./.copilot/skills/` |
-| Read the canonical skill catalog | Supported | Supported | Catalog is host-neutral |
-| Interactive use of installed skills | Supported | Supported | Exact UX depends on the host's skill/session model |
-| Host-specific overlay doc | `CLAUDE.md` | `copilot-instructions.md` | Both point back to the same canonical catalog |
-| Optional Claude batch backend (`sldo-research`) | Supported | Not supported yet | The interactive `/slo-research` path is host-neutral; only the optional batch backend is Claude-only |
-| Headless runtime automation | Supported on specific Claude-only paths | Not supported yet | No Copilot runtime harness is shipped today |
-| Live business judgment runtime harness | Supported as opt-in Claude-only automation | Not supported yet | Current harness depends on `claude -p`; the helper module is `crates/sldo-install/tests/common/claude_runtime.rs` |
+| Capability | Claude Code | GitHub Copilot | Codex | Notes |
+|---|---|---|---|---|
+| Install skills with `sldo-install` | Supported | Supported | Supported | Same `SKILL.md` contract; different install roots |
+| Project-local install with `--local` | Supported | Supported | Supported | Writes to `./.claude/skills/`, `./.copilot/skills/`, or `./.codex/skills/` |
+| Read the canonical skill catalog | Supported | Supported | Supported | Catalog is host-neutral |
+| Interactive use of installed skills | Supported | Supported | Supported | Exact UX depends on the host's skill/session model |
+| Host-specific overlay doc | `CLAUDE.md` | `copilot-instructions.md` | `AGENTS.md` | All overlays point back to the same canonical catalog |
+| Optional Claude batch backend (`sldo-research`) | Supported | Not supported yet | Not supported yet | The interactive `/slo-research` path is host-neutral; only the optional batch backend is Claude-only |
+| Headless runtime automation | Supported on specific Claude-only paths | Not supported yet | Not supported yet | No Copilot or Codex runtime harness is shipped today |
+| Live business judgment runtime harness | Supported as opt-in Claude-only automation | Not supported yet | Not supported yet | Current harness depends on `claude -p`; the helper module is `crates/sldo-install/tests/common/claude_runtime.rs` |
 
 ## Per-skill notes
 
@@ -28,7 +28,7 @@ This list covers skills whose host story is non-obvious. Skills not listed here 
 | Skill | Host story | Why it matters |
 |---|---|---|
 | `/slo-second-opinion` | Host-neutral logic. The skill compares whatever the current host produced against an external provider CLI (Codex or Gemini). It does not require Claude. | The skill's "current host said" column captures the agent running this skill, not Claude specifically. The skill must never silently fall back to asking the current host to imitate the other provider. |
-| `/slo-research` | Host-neutral interactive path. Optional Claude batch backend (`sldo-research`) is explicitly Claude-only. | A Copilot user can use `/slo-research` interactively without installing Claude; only the batch backend requires `claude`. |
+| `/slo-research` | Host-neutral interactive path. Optional Claude batch backend (`sldo-research`) is explicitly Claude-only. | A Copilot or Codex user can use `/slo-research` interactively without installing Claude; only the batch backend requires `claude`. |
 | `/slo-rulegen` | Host-neutral. The bug-summary input can come from any agent-driven workflow. | Earlier copy implied "Claude-found bug summary"; that is no longer accurate. |
 | `/slo-sast` | Host-neutral. M1 is parser-only; later milestones shell out to `git`, `gh`, and `semgrep` — none of which are agent CLIs. | The `claude` mention in the M1 anti-pattern list is honest: M1 must not shell out to any agent CLI. |
 | Live business judgment runtime harness | Claude-only by design. | There is no host-neutral abstraction; the runbook explicitly forbids inventing one without a second real implementation. |
@@ -36,12 +36,13 @@ This list covers skills whose host story is non-obvious. Skills not listed here 
 ## Important boundaries
 
 - The installer is multi-host now. The runtime story is not.
-- GitHub Copilot should be treated as an interactive host today, not a headless automation target.
+- GitHub Copilot and Codex should be treated as interactive hosts today, not headless automation targets.
 - `/slo-research` no longer hides a second-agent dependency in the interactive path. Only the optional batch backend remains Claude-specific.
 
 ## What to read next
 
-- [../skill-pack-catalog.md](../skill-pack-catalog.md) for the host-neutral list of shipped skills.
-- [../../CLAUDE.md](../../CLAUDE.md) for the Claude Code overlay.
-- [../../copilot-instructions.md](../../copilot-instructions.md) for the GitHub Copilot overlay.
-- [../getting-started.md](../getting-started.md) for the first-run path.
+- [../../skill-pack-catalog.md](../../skill-pack-catalog.md) for the host-neutral list of shipped skills.
+- [../../../CLAUDE.md](../../../CLAUDE.md) for the Claude Code overlay.
+- [../../../copilot-instructions.md](../../../copilot-instructions.md) for the GitHub Copilot overlay.
+- [../../../AGENTS.md](../../../AGENTS.md) for the Codex overlay.
+- [../../getting-started.md](../../getting-started.md) for the first-run path.

--- a/docs/slo/design/host-capability-matrix.md
+++ b/docs/slo/design/host-capability-matrix.md
@@ -1,25 +1,27 @@
 # Host capability matrix — SunLitOrchestrate
 
-> **Purpose**: Document what each supported host (Claude Code, GitHub Copilot) can install + invoke + run. Drives decisions in M4 (plugin packaging) and M5 (host-native agents).
+> **Purpose**: Document what each supported host (Claude Code, GitHub Copilot, Codex) can install + invoke + run. Drives decisions in M4 (plugin packaging), M5 (host-native agents), and future host additions.
 > **Authored**: 2026-05-01 during /slo-execute M4. Retrieval-date for upstream docs cited inline.
 > **Status**: ACTIVE — consulted by M5 gate and any future runbook touching host-specific install / invocation paths.
 
 ## Matrix
 
-| Capability | Claude Code | GitHub Copilot | Notes |
-|---|---|---|---|
-| Install Markdown skills via `~/<host>/skills/<name>/SKILL.md` | YES (default) | YES (Copilot extension reads `.copilot/skills/`) | Both supported by `sldo-install` today |
-| Install via plugin packaging (`.claude-plugin/plugin.json`) | YES (org-install supported) | NO (no equivalent format) | Claude-only path |
-| Install host-native agents (`agents/<name>.md`) | EXPERIMENTAL — Claude Code agent SDK supports declarative agent files | NO (no equivalent format) | M5 gate input |
-| Invoke skills via slash commands (`/<name>`) | YES | YES | Both treat SKILL.md frontmatter as command registration |
-| Run multi-agent dispatch (lead → specialists) | EXPERIMENTAL | NO | Out of scope for M5 unless an explicit feature-flag fallback is documented |
-| Maintain shared install manifest (`~/.sldo/install.toml`) | YES | YES | Manifest already records per-host entries |
+| Capability | Claude Code | GitHub Copilot | Codex | Notes |
+|---|---|---|---|---|
+| Install Markdown skills via `~/<host>/skills/<name>/SKILL.md` | YES (default, `.claude/skills/`) | YES (`.copilot/skills/`) | YES (`.codex/skills/`) | All three supported by `sldo-install` today |
+| Project-local install via `./.<host>/skills/` | YES | YES | YES | `--local` selects the host-specific project root |
+| Install via plugin packaging (`.claude-plugin/plugin.json`) | YES (org-install supported) | NO (no equivalent format) | NO (no equivalent format) | Claude-only path |
+| Install host-native agents (`agents/<name>.md`) | EXPERIMENTAL - Claude Code agent SDK supports declarative agent files | NO (no equivalent format) | NO (no equivalent format) | M5 gate input |
+| Invoke skills via slash commands (`/<name>`) | YES | YES | YES | All hosts consume the portable Markdown `SKILL.md` contract interactively |
+| Run multi-agent dispatch (lead -> specialists) | EXPERIMENTAL | NO | NO | Out of scope for M5 unless an explicit feature-flag fallback is documented |
+| Maintain shared install manifest (`~/.sldo/install.toml`) | YES | YES | YES | Manifest records per-host entries |
 
 ## Sources (retrieval-date)
 
 - Claude Code plugin format: Anthropic public docs (snapshot 2026-05-01).
 - Anthropic Claude Agent SDK: public docs (snapshot 2026-05-01).
 - GitHub Copilot extensibility: GitHub docs (snapshot 2026-05-01).
+- Codex skill-root behavior: local Codex runtime contract in this repo (`~/.codex/skills/`, `./.codex/skills/`) as of 2026-05-03.
 
 ## Decisions
 
@@ -31,31 +33,31 @@
 
 1. Claude Code organizational installs benefit from a one-zip artifact compared to cloning the repo + running `sldo-install`. Real friction for non-developer Claude Code users.
 2. The plugin manifest points at the existing `skills/` tree (no duplication). Source-of-truth remains `docs/skill-pack-catalog.md`.
-3. `sldo-install` remains canonical for multi-host (Claude Code + GitHub Copilot). README wording made explicit.
+3. `sldo-install` remains canonical for multi-host (Claude Code + GitHub Copilot + Codex). README wording made explicit.
 4. Per F-SEC-3 / F-SEC-4 / F-SEC-5, structural-contract tests enforce SHA-pinning, no-duplication, no-path-traversal, minimum-privilege `permissions:`, `git archive` HEAD-only emission. The hardening is structural, not procedural.
 
 **Out-of-scope reaffirmed**:
 
-- No Copilot plugin path — Copilot has no equivalent format. README does NOT downgrade `sldo-install`.
+- No Copilot or Codex plugin path - neither host has an equivalent format in this repo. README does NOT downgrade `sldo-install`.
 - No registry auto-publish.
 - No artifact signing in M4. A future runbook can add sigstore/cosign once the basic packaging path exercises in production.
 
-### M5 host-native agents — `green-lit, with Copilot fallback documented`
+### M5 host-native agents — `green-lit, with portable fallback documented`
 
-**Decision**: ship 4 agent files under `agents/`. Each file declares `copilot-fallback: /slo-critique persona rotation` (or equivalent) so Copilot users are not second-class. The agent files are an additive Claude-only enhancement; the canonical portable critique flow stays `/slo-critique` persona rotation.
+**Decision**: ship 4 agent files under `agents/`. Each file declares `copilot-fallback: /slo-critique persona rotation` (or equivalent) so non-Claude users are not second-class. The agent files are an additive Claude-only enhancement; the canonical portable critique flow stays `/slo-critique` persona rotation.
 
 **Reasoning**:
 
 1. Anthropic's Claude Agent SDK supports declarative agent files at `agents/<name>.md`.
-2. GitHub Copilot has no host-native agent equivalent. Per the matrix, Copilot users can run `/slo-critique` directly, which performs four-persona rotation in-skill. That IS the fallback.
-3. The structural-contract test asserts each agent file declares `copilot-fallback:` — so the multi-host story is *enforced*, not just *promised*.
+2. GitHub Copilot and Codex have no host-native agent equivalent in this repo. Per the matrix, both can run `/slo-critique` directly, which performs four-persona rotation in-skill. That IS the fallback.
+3. The structural-contract test asserts each agent file declares `copilot-fallback:` — so the portable fallback story is *enforced*, not just *promised*.
 4. Output paths constrained to `{docs/slo/critique/, docs/slo/verify/}` (per F-SEC-6 critique resolution).
 
-**Gate**: M5 may proceed if and only if this matrix says agents are installable on at least one host AND Copilot has a documented fallback. Both conditions hold here.
+**Gate**: M5 may proceed if and only if this matrix says agents are installable on at least one host AND non-Claude hosts have a documented fallback. Both conditions hold here.
 
 ## When to revisit
 
 - New host emerges (e.g., Cursor, Cody) — add a column to the matrix and re-run M4 + M5 gates.
 - Anthropic plugin format changes — update Sources retrieval date and re-verify the plugin.json shape.
-- GitHub Copilot adds host-native plugin/agent install — promote Copilot-fallback rows from "documented fallback" to "first-class" and update agent files.
+- GitHub Copilot or Codex adds host-native plugin/agent install — promote fallback rows from "documented fallback" to "first-class" and update agent files.
 - Stale retrieval-date (> 12 months from authoring) — re-fetch upstream docs and update the matrix.


### PR DESCRIPTION
## Summary
Adds Codex as a first-class SunLitOrchestrate skill host while keeping the existing Claude Code and GitHub Copilot paths intact, and makes `sldo-install` portable across macOS, Linux, and Windows.

## What changed
- Added `codex` to `sldo-install` host selection, with global installs under `~/.codex/skills/` and local installs under `./.codex/skills/`.
- Added installer, manifest, path, status, verify, uninstall, and local-install coverage for Codex.
- Added `AGENTS.md` as the Codex overlay pointing back to the canonical skill catalog.
- Refactored installer link handling into a cross-platform managed-link abstraction: Unix/macOS use symlinks; Windows tries directory symlinks first and falls back to junctions.
- Added Windows home-directory resolution via `USERPROFILE` and `HOMEDRIVE` + `HOMEPATH` when `HOME` is absent.
- Added cross-platform installer CI for Ubuntu, macOS, and Windows.
- Kept text checkouts LF-normalized via `.gitattributes` so Markdown frontmatter contract tests behave the same on Windows and Unix runners.
- Updated README, getting-started, architecture, catalog, host capability, and security docs so the supported-host story is Claude Code + GitHub Copilot + Codex and the installer behavior is documented.
- Tightened README readability with an at-a-glance starting-point table.

## Validation
- `cargo fmt -p sldo-install` passed.
- `cargo test -p sldo-install --test install_e2e --test e2e_agent_host_m1 --test e2e_slo_sp_m2 --test e2e_slo_sp_m10` passed.
- `cargo check -p sldo-install --tests --target x86_64-pc-windows-msvc` passed.
- `cargo check -p sldo-install --tests --target x86_64-unknown-linux-gnu` passed.
- `cargo test -p sast-verify --test sap_imp_m4_workflow_pinning` passed.
- `cargo test -p sldo-install` passed.
- `cargo build -p sldo-install --release` passed.
- `./target/release/sldo-install --host claude-code install` found all 37 skills already installed.
- `./target/release/sldo-install --host claude-code verify` passed for all 37 Claude Code entries.
- `./target/release/sldo-install --host codex install` installed 37 skills into `~/.codex/skills/`.
- `./target/release/sldo-install --host codex verify` passed for all 37 Codex entries.
- `git diff --check` passed.
- GitHub Actions `sldo-install cross-platform` passed on `ubuntu-latest`, `macos-latest`, and `windows-latest` for commit `2bbf8bf`.
- GitHub Actions `SAST rule pack — Semgrep CI` passed for commit `2bbf8bf`.

## Note
The existing unused `Path` import warning in `crates/sldo-install/tests/e2e_biz_followup_m5.rs` still appears during `cargo test -p sldo-install`; it is pre-existing and does not fail the suite.