### PR TITLE
biz-imp: harden business skills

### DIFF
--- a/.sldo/refresh-loop.toml
+++ b/.sldo/refresh-loop.toml
@@ -1,0 +1,62 @@
+[loop]
+name = "biz-kpi-baseline-refresh"
+cadence = "annual"
+timezone = "Europe/London"
+open_pr = true
+auto_merge = false
+max_prs_per_run = 1
+review_required = true
+branch_prefix = "slo/biz-kpi-baseline-refresh"
+
+[scope]
+runbook_prefix = "biz-imp"
+data_classification = "internal"
+files = [
+  "references/biz/saas-kpi-targets-baseline.md",
+  "references/biz/outbound-conversion-baselines.md",
+  "references/biz/product-prioritization-frameworks.md",
+  "references/biz/value-equation-pricing.md",
+  "references/biz/mom-test-canonical-questions.md",
+  "references/biz/launch-success-thresholds.md",
+  "references/biz/uk-marketing-statute-anchors.md",
+]
+
+[refresh]
+stale_warning_after_months = 12
+refuse_after_months = 24
+update_fields = [
+  "retrieved",
+  "refresh_recommended_by",
+  "source_url",
+  "last_checked",
+  "confidence",
+  "methodology_note",
+  "sample_size",
+  "vintage",
+  "applicability_caveat",
+]
+
+[github]
+gh_pr_create = true
+argv = [
+  "gh",
+  "pr",
+  "create",
+  "--title",
+  "[biz] refresh KPI and heuristic baselines",
+  "--body-file",
+  ".sldo/refresh-loop-pr-body.md",
+]
+pr_body_template = """
+## Biz baseline refresh
+
+Refreshed public baseline rows and updated retrieval stamps.
+
+Review checklist:
+- Source URLs resolve.
+- Methodology notes still match the cited source.
+- Confidence levels and caveats are still honest.
+- Generated skill `baseline_ref:` stamps remain compatible.
+
+Human review required before landing.
+"""

--- a/crates/sldo-install/tests/e2e_biz_imp_m1.rs
+++ b/crates/sldo-install/tests/e2e_biz_imp_m1.rs
@@ -1,0 +1,197 @@
+//! M1 structural-contract tests for Business Skill Improvements.
+//!
+//! Verifies the authority-file hardening layer:
+//! - UK regulator enumeration rows have source-verification metadata.
+//! - Three statute-anchor files exist and carry verbatim `quoted_text:` blocks.
+//! - HMRC VCM and ICO DUAA references use quoted authority text.
+//! - Statute/regulator sources stay on official authority domains.
+//! - The four advisor hard-block predicate IDs remain immutable.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .to_path_buf()
+}
+
+fn read(path: &Path) -> String {
+    fs::read_to_string(path).unwrap_or_else(|e| panic!("cannot read {}: {e}", path.display()))
+}
+
+const REGULATOR_IDS: &[&str] = &[
+    "hmrc",
+    "companies-house",
+    "pensions-regulator",
+    "ico",
+    "ofcom",
+    "fca",
+    "pra",
+    "cma",
+    "asa",
+    "tsi",
+    "mhra",
+    "cqc",
+    "gmc",
+    "nmc",
+    "hcpc",
+    "hse",
+    "ehrc",
+    "ofgem",
+    "ofwat",
+    "ofsted",
+    "caa",
+    "environment-agency",
+    "charity-commission",
+    "oisc",
+    "solicitors-regulation-authority",
+];
+
+const FOUR_PREDICATE_IDS: &[&str] = &[
+    "gate-1-regulated",
+    "gate-2-deal-value-over-5k",
+    "gate-3-counterparty-has-lawyer-or-their-paper",
+    "gate-4-gdpr-document",
+];
+
+#[test]
+fn regulator_enum_source_verified() {
+    let body = read(&repo_root().join("references/biz/uk-regulator-enumeration.md"));
+    assert!(
+        body.contains("## Source verification register"),
+        "uk-regulator-enumeration.md must have a source verification register"
+    );
+
+    for id in REGULATOR_IDS {
+        let row_prefix = format!("| `{id}` |");
+        let row = body
+            .lines()
+            .find(|line| line.starts_with(&row_prefix))
+            .unwrap_or_else(|| panic!("missing source-verification row for `{id}`"));
+        assert!(
+            row.contains("https://www.legislation.gov.uk/")
+                || row.contains("https://www.gov.uk/")
+                || row.contains("https://www.asa.org.uk/"),
+            "source-verification row for `{id}` must cite an official authority URL: {row}"
+        );
+        assert!(
+            row.contains("2026-05-03"),
+            "source-verification row for `{id}` must carry the M1 last_checked date: {row}"
+        );
+        assert!(
+            row.contains("2027-05-03"),
+            "source-verification row for `{id}` must carry next_review_due: {row}"
+        );
+        assert!(
+            row.contains("high") || row.contains("medium") || row.contains("low"),
+            "source-verification row for `{id}` must carry a confidence value: {row}"
+        );
+        assert!(
+            !row.contains("pending-verification"),
+            "source-verification row for `{id}` must not ship pending-verification"
+        );
+    }
+}
+
+#[test]
+fn statute_anchor_files_have_verbatim_quotes() {
+    for rel in [
+        "references/biz/uk-employment-statute-anchors.md",
+        "references/biz/uk-consumer-statute-anchors.md",
+        "references/biz/uk-marketing-statute-anchors.md",
+    ] {
+        let path = repo_root().join(rel);
+        assert!(path.exists(), "{rel} missing");
+        let body = read(&path);
+        assert!(
+            body.matches("quoted_text:").count() >= 3,
+            "{rel} must contain at least three quoted_text blocks"
+        );
+        assert!(
+            body.contains("source_url:"),
+            "{rel} must cite source_url for each authority block"
+        );
+        assert!(
+            !body.to_lowercase().contains("approximately says"),
+            "{rel} must not use paraphrase framing"
+        );
+    }
+}
+
+#[test]
+fn hmrc_vcm_index_verbatim() {
+    let body = read(&repo_root().join("references/biz/hmrc-vcm-index.md"));
+    for marker in ["VCM34080", "VCM3000", "VCM31000", "Abingdon Health"] {
+        assert!(body.contains(marker), "hmrc-vcm-index.md missing {marker}");
+    }
+    assert!(
+        body.matches("quoted_text:").count() >= 4,
+        "hmrc-vcm-index.md must have quoted_text blocks for VCM34080, VCM3000, VCM31000, and Abingdon Health"
+    );
+    assert!(
+        body.contains("https://www.gov.uk/hmrc-internal-manuals/venture-capital-schemes-manual/vcm34080"),
+        "hmrc-vcm-index.md must cite VCM34080 gov.uk URL"
+    );
+}
+
+#[test]
+fn ico_duaa_verbatim() {
+    let body = read(&repo_root().join("references/biz/ico-duaa-index.md"));
+    assert!(
+        body.contains("https://www.legislation.gov.uk/ukpga/2025/18"),
+        "ico-duaa-index.md must cite DUAA 2025 legislation.gov.uk URL"
+    );
+    assert!(
+        body.contains("quoted_text:"),
+        "ico-duaa-index.md must include verbatim DUAA quoted_text"
+    );
+    assert!(
+        body.contains("commencement"),
+        "ico-duaa-index.md must retain commencement coverage"
+    );
+}
+
+#[test]
+fn no_unauthoritative_sources_in_m1_authority_files() {
+    for rel in [
+        "references/biz/uk-regulator-enumeration.md",
+        "references/biz/uk-employment-statute-anchors.md",
+        "references/biz/uk-consumer-statute-anchors.md",
+        "references/biz/uk-marketing-statute-anchors.md",
+        "references/biz/hmrc-vcm-index.md",
+        "references/biz/ico-duaa-index.md",
+    ] {
+        let body = read(&repo_root().join(rel));
+        for forbidden in [
+            "stackoverflow.com",
+            "medium.com",
+            "rossmartin.co.uk",
+            "vendor blog",
+            "random commentary",
+        ] {
+            assert!(
+                !body.contains(forbidden),
+                "{rel} must not cite unauthoritative source `{forbidden}`"
+            );
+        }
+    }
+}
+
+#[test]
+fn triage_gate_predicate_set_unchanged_from_m1() {
+    let gate = read(&repo_root().join("references/biz/triage-gate.md"));
+    for pid in FOUR_PREDICATE_IDS {
+        assert!(gate.contains(pid), "triage-gate.md missing `{pid}`");
+    }
+    for n in 5..=9 {
+        let candidate = format!("gate-{n}-");
+        assert!(
+            !gate.contains(&candidate),
+            "triage-gate.md must not contain extra predicate pattern `{candidate}`"
+        );
+    }
+}

--- a/crates/sldo-install/tests/e2e_biz_imp_m2.rs
+++ b/crates/sldo-install/tests/e2e_biz_imp_m2.rs
@@ -1,0 +1,191 @@
+//! M2 structural-contract tests for Business Skill Improvements.
+//!
+//! Verifies the conversational intake layer:
+//! - Five intake contracts exist and frame intake as conversation, not a form.
+//! - F1/F4/F5 shared gate fields are byte-identical across the five contracts.
+//! - The legal starter was renamed from `legal-intake-form.md`.
+//! - Each advisor skill cites its intake contract and restate-confirm discipline.
+//! - The four advisor hard-block predicate IDs remain immutable.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .to_path_buf()
+}
+
+fn read(path: &Path) -> String {
+    fs::read_to_string(path).unwrap_or_else(|e| panic!("cannot read {}: {e}", path.display()))
+}
+
+fn section<'a>(body: &'a str, start: &str, end: &str) -> &'a str {
+    let start_idx = body
+        .find(start)
+        .unwrap_or_else(|| panic!("missing section marker `{start}`"));
+    let after_start = &body[start_idx..];
+    let end_idx = after_start
+        .find(end)
+        .unwrap_or_else(|| panic!("missing end marker `{end}` after `{start}`"));
+    after_start[..end_idx].trim()
+}
+
+const CONTRACTS: &[(&str, &str)] = &[
+    ("legal", "references/biz/legal-intake-contract.md"),
+    ("accounting", "references/biz/accounting-intake-contract.md"),
+    ("equity", "references/biz/equity-intake-contract.md"),
+    ("fundraise", "references/biz/fundraise-intake-contract.md"),
+    ("hire", "references/biz/hire-intake-contract.md"),
+];
+
+const ADVISOR_SKILLS: &[(&str, &str)] = &[
+    ("legal", "skills/slo-legal/SKILL.md"),
+    ("accounting", "skills/slo-accounting/SKILL.md"),
+    ("equity", "skills/slo-equity/SKILL.md"),
+    ("fundraise", "skills/slo-fundraise/SKILL.md"),
+    ("hire", "skills/slo-hire/SKILL.md"),
+];
+
+const FOUR_PREDICATE_IDS: &[&str] = &[
+    "gate-1-regulated",
+    "gate-2-deal-value-over-5k",
+    "gate-3-counterparty-has-lawyer-or-their-paper",
+    "gate-4-gdpr-document",
+];
+
+#[test]
+fn five_intake_contracts_exist_with_conversational_framing() {
+    for (name, rel) in CONTRACTS {
+        let path = repo_root().join(rel);
+        assert!(path.exists(), "{name} intake contract missing at {rel}");
+        let body = read(&path);
+        assert!(
+            body.contains("Conversation is the UX"),
+            "{rel} must state the Conversation is the UX framing"
+        );
+        assert!(
+            body.contains("## Restate-and-confirm step"),
+            "{rel} must define a restate-and-confirm step"
+        );
+        for field in ["### F1.", "### F2.", "### F3.", "### F4.", "### F5.", "### F6."] {
+            assert!(body.contains(field), "{rel} missing required field {field}");
+        }
+        for forbidden in [
+            "submit a form",
+            "fill in this form",
+            "founder fills in",
+            "founder should fill",
+        ] {
+            assert!(
+                !body.to_lowercase().contains(forbidden),
+                "{rel} must not reframe intake as a founder-filled form (`{forbidden}`)"
+            );
+        }
+    }
+}
+
+#[test]
+fn f1_f4_f5_verbatim_across_sisters() {
+    let root = repo_root();
+    let legal = read(&root.join("references/biz/legal-intake-contract.md"));
+    let canonical_f1 = section(&legal, "### F1.", "### F2.");
+    let canonical_f4 = section(&legal, "### F4.", "### F5.");
+    let canonical_f5 = section(&legal, "### F5.", "### F6.");
+
+    for (name, rel) in CONTRACTS.iter().skip(1) {
+        let body = read(&root.join(rel));
+        assert_eq!(
+            canonical_f1,
+            section(&body, "### F1.", "### F2."),
+            "{name} F1 must match legal-intake-contract.md verbatim"
+        );
+        assert_eq!(
+            canonical_f4,
+            section(&body, "### F4.", "### F5."),
+            "{name} F4 must match legal-intake-contract.md verbatim"
+        );
+        assert_eq!(
+            canonical_f5,
+            section(&body, "### F5.", "### F6."),
+            "{name} F5 must match legal-intake-contract.md verbatim"
+        );
+    }
+}
+
+#[test]
+fn every_advisor_skill_md_cites_contract_and_restate_discipline() {
+    for (name, rel) in ADVISOR_SKILLS {
+        let body = read(&repo_root().join(rel));
+        let contract_ref = format!("references/biz/{name}-intake-contract.md");
+        assert!(
+            body.contains(&contract_ref),
+            "{rel} must cite its intake contract `{contract_ref}`"
+        );
+        assert!(
+            body.contains("Restate-and-confirm")
+                || body.contains("restate-and-confirm")
+                || body.contains("restate_confirm"),
+            "{rel} must document restate-and-confirm discipline"
+        );
+        assert!(
+            body.contains("refuse") && body.contains("ambigu"),
+            "{rel} must document refusal-on-ambiguity"
+        );
+    }
+}
+
+#[test]
+fn every_advisor_skill_md_cites_m1_authority_files() {
+    let authority_refs = [
+        "references/biz/uk-regulator-enumeration.md",
+        "references/biz/uk-employment-statute-anchors.md",
+        "references/biz/uk-consumer-statute-anchors.md",
+        "references/biz/uk-marketing-statute-anchors.md",
+        "references/biz/hmrc-vcm-index.md",
+        "references/biz/ico-duaa-index.md",
+    ];
+
+    for (_, rel) in ADVISOR_SKILLS {
+        let body = read(&repo_root().join(rel));
+        assert!(
+            body.contains("references/biz/uk-regulator-enumeration.md"),
+            "{rel} must cite the closed regulator enum"
+        );
+        assert!(
+            authority_refs.iter().any(|authority| body.contains(authority)),
+            "{rel} must cite at least one source-verified M1 authority file"
+        );
+    }
+}
+
+#[test]
+fn legal_intake_form_renamed() {
+    let root = repo_root();
+    assert!(
+        !root.join("references/biz/legal-intake-form.md").exists(),
+        "legal-intake-form.md must be renamed, not left as a duplicate"
+    );
+    assert!(
+        root.join("references/biz/legal-intake-contract.md").exists(),
+        "legal-intake-contract.md must exist after rename"
+    );
+}
+
+#[test]
+fn triage_gate_predicate_set_unchanged_after_m2() {
+    let gate = read(&repo_root().join("references/biz/triage-gate.md"));
+    for pid in FOUR_PREDICATE_IDS {
+        assert!(gate.contains(pid), "triage-gate.md missing `{pid}`");
+    }
+    for n in 5..=9 {
+        let candidate = format!("gate-{n}-");
+        assert!(
+            !gate.contains(&candidate),
+            "triage-gate.md must not contain extra predicate pattern `{candidate}`"
+        );
+    }
+}

--- a/crates/sldo-install/tests/e2e_biz_imp_m3.rs
+++ b/crates/sldo-install/tests/e2e_biz_imp_m3.rs
@@ -1,0 +1,128 @@
+//! M3 structural-contract tests for Business Skill Improvements.
+//!
+//! Verifies numeric verification discipline for SAFE worksheets, cap-table
+//! snapshots, and pricing value-equation outputs.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .to_path_buf()
+}
+
+fn read(path: &Path) -> String {
+    fs::read_to_string(path).unwrap_or_else(|e| panic!("cannot read {}: {e}", path.display()))
+}
+
+const NUMERIC_SKILLS: &[&str] = &[
+    "skills/slo-fundraise/SKILL.md",
+    "skills/slo-equity/SKILL.md",
+    "skills/slo-pricing/SKILL.md",
+];
+
+#[test]
+fn safe_worksheet_has_verification() {
+    let body = read(&repo_root().join("skills/slo-fundraise/SKILL.md"));
+    for required in [
+        "M3 numeric verification",
+        "safe-worksheet",
+        "runnable Python snippet",
+        "SPDX-License-Identifier: MIT",
+        "expected-results table",
+        "two-pass verification",
+        "refuse to write",
+    ] {
+        assert!(
+            body.contains(required),
+            "slo-fundraise/SKILL.md must document SAFE verification marker `{required}`"
+        );
+    }
+    for tolerance in ["±£1", "±0.01%", "±1"] {
+        assert!(
+            body.contains(tolerance),
+            "SAFE worksheet verification must document tolerance `{tolerance}`"
+        );
+    }
+}
+
+#[test]
+fn cap_table_totals_re_derived() {
+    let body = read(&repo_root().join("skills/slo-equity/SKILL.md"));
+    for required in [
+        "M3 numeric verification",
+        "cap-table-snapshot",
+        "re-derive every Total row",
+        "sum-down",
+        "weighted-product",
+        "refuse to write",
+    ] {
+        assert!(
+            body.contains(required),
+            "slo-equity/SKILL.md must document cap-table verification marker `{required}`"
+        );
+    }
+    for tolerance in ["±£1", "±0.01%", "±1"] {
+        assert!(
+            body.contains(tolerance),
+            "cap-table verification must document tolerance `{tolerance}`"
+        );
+    }
+}
+
+#[test]
+fn value_equation_emits_computation() {
+    let body = read(&repo_root().join("skills/slo-pricing/SKILL.md"));
+    for required in [
+        "M3 numeric verification",
+        "runnable Python snippet",
+        "price = round(value × ratio, -2)",
+        "reciprocal verification",
+        "price=value×0.25",
+        "value=price/0.25",
+        "25-33%",
+        "refuse to write",
+    ] {
+        assert!(
+            body.contains(required),
+            "slo-pricing/SKILL.md must document pricing verification marker `{required}`"
+        );
+    }
+}
+
+#[test]
+fn python_snippets_stdlib_only() {
+    for rel in NUMERIC_SKILLS {
+        let body = read(&repo_root().join(rel));
+        for forbidden in [
+            "import requests",
+            "import pandas",
+            "import numpy",
+            "import httpx",
+            "from requests",
+            "from pandas",
+            "from numpy",
+            "from httpx",
+        ] {
+            assert!(
+                !body.contains(forbidden),
+                "{rel} Python examples must stay stdlib-only; found `{forbidden}`"
+            );
+        }
+    }
+}
+
+#[test]
+fn refusal_on_mismatch_documented() {
+    for rel in NUMERIC_SKILLS {
+        let body = read(&repo_root().join(rel));
+        assert!(
+            body.contains("mismatch") && body.contains("refuse to write"),
+            "{rel} must document mismatch handling and refusal to write"
+        );
+    }
+}

--- a/crates/sldo-install/tests/e2e_biz_imp_m4.rs
+++ b/crates/sldo-install/tests/e2e_biz_imp_m4.rs
@@ -1,0 +1,141 @@
+//! M4 structural-contract tests for Business Skill Improvements.
+//!
+//! Verifies KPI / heuristic baseline provenance and generator skill citations.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .to_path_buf()
+}
+
+fn read(path: &Path) -> String {
+    fs::read_to_string(path).unwrap_or_else(|e| panic!("cannot read {}: {e}", path.display()))
+}
+
+const BASELINE_FILES: &[&str] = &[
+    "references/biz/saas-kpi-targets-baseline.md",
+    "references/biz/outbound-conversion-baselines.md",
+    "references/biz/product-prioritization-frameworks.md",
+    "references/biz/value-equation-pricing.md",
+    "references/biz/mom-test-canonical-questions.md",
+    "references/biz/launch-success-thresholds.md",
+];
+
+const GENERATOR_CITATIONS: &[(&str, &str)] = &[
+    (
+        "skills/slo-metrics/SKILL.md",
+        "references/biz/saas-kpi-targets-baseline.md",
+    ),
+    (
+        "skills/slo-pricing/SKILL.md",
+        "references/biz/value-equation-pricing.md",
+    ),
+    (
+        "skills/slo-sales-funnel/SKILL.md",
+        "references/biz/outbound-conversion-baselines.md",
+    ),
+    (
+        "skills/slo-product/SKILL.md",
+        "references/biz/product-prioritization-frameworks.md",
+    ),
+    (
+        "skills/slo-launch/SKILL.md",
+        "references/biz/launch-success-thresholds.md",
+    ),
+    (
+        "skills/slo-marketing/SKILL.md",
+        "references/biz/uk-marketing-statute-anchors.md",
+    ),
+    (
+        "skills/slo-talk-to-users/SKILL.md",
+        "references/biz/mom-test-canonical-questions.md",
+    ),
+];
+
+#[test]
+fn baseline_files_exist_with_source_verified_rows() {
+    for rel in BASELINE_FILES {
+        let body = read(&repo_root().join(rel));
+        assert!(
+            body.contains("retrieved: 2026-05-03"),
+            "{rel} must carry M4 retrieval date"
+        );
+        for required in [
+            "source_url:",
+            "last_checked: 2026-05-03",
+            "confidence:",
+            "methodology_note:",
+            "applicability_caveat:",
+        ] {
+            assert!(body.contains(required), "{rel} missing `{required}`");
+        }
+    }
+}
+
+#[test]
+fn each_generator_skill_md_cites_baseline() {
+    for (skill, baseline) in GENERATOR_CITATIONS {
+        let body = read(&repo_root().join(skill));
+        assert!(
+            body.contains(baseline),
+            "{skill} must cite baseline/reference file `{baseline}`"
+        );
+        assert!(
+            body.contains("baseline_ref:"),
+            "{skill} output frontmatter must document baseline_ref discipline"
+        );
+    }
+}
+
+#[test]
+fn generator_skill_md_documents_stale_warning() {
+    for (skill, _) in GENERATOR_CITATIONS {
+        let body = read(&repo_root().join(skill));
+        assert!(
+            body.contains("stale warning") || body.contains("stale-warning"),
+            "{skill} must document the >12 month stale warning"
+        );
+        assert!(
+            body.contains("refuse at +24 months") || body.contains("refuses at +24 months"),
+            "{skill} must document refusal at +24 months"
+        );
+    }
+}
+
+#[test]
+fn authoritative_sources_only() {
+    for rel in BASELINE_FILES {
+        let body = read(&repo_root().join(rel));
+        for forbidden in [
+            "medium.com",
+            "substack.com",
+            "random commentary",
+            "unsourced",
+            "training memory",
+        ] {
+            assert!(
+                !body.contains(forbidden),
+                "{rel} must not use forbidden source `{forbidden}`"
+            );
+        }
+    }
+}
+
+#[test]
+fn launch_thresholds_reframe_unsourceable_numbers() {
+    let body = read(&repo_root().join("references/biz/launch-success-thresholds.md"));
+    assert!(
+        body.contains("set your own threshold"),
+        "launch baseline must reframe unsourceable launch numbers"
+    );
+    assert!(
+        body.contains("threshold_owner: founder"),
+        "launch baseline must assign threshold ownership to the founder"
+    );
+}

--- a/crates/sldo-install/tests/e2e_biz_imp_m5.rs
+++ b/crates/sldo-install/tests/e2e_biz_imp_m5.rs
@@ -1,0 +1,251 @@
+//! M5 structural-contract tests for Business Skill Improvements.
+//!
+//! Verifies additive artifact schema fields, cross-skill citations, predicate
+//! immutability, and PR-only baseline refresh-loop configuration.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .to_path_buf()
+}
+
+fn read(path: &Path) -> String {
+    fs::read_to_string(path).unwrap_or_else(|e| panic!("cannot read {}: {e}", path.display()))
+}
+
+const ADVISOR_CITATIONS: &[(&str, &str)] = &[
+    (
+        "skills/slo-legal/SKILL.md",
+        "references/biz/legal-intake-contract.md",
+    ),
+    (
+        "skills/slo-accounting/SKILL.md",
+        "references/biz/accounting-intake-contract.md",
+    ),
+    (
+        "skills/slo-equity/SKILL.md",
+        "references/biz/equity-intake-contract.md",
+    ),
+    (
+        "skills/slo-fundraise/SKILL.md",
+        "references/biz/fundraise-intake-contract.md",
+    ),
+    (
+        "skills/slo-hire/SKILL.md",
+        "references/biz/hire-intake-contract.md",
+    ),
+];
+
+const GENERATOR_CITATIONS: &[(&str, &str)] = &[
+    (
+        "skills/slo-metrics/SKILL.md",
+        "references/biz/saas-kpi-targets-baseline.md",
+    ),
+    (
+        "skills/slo-pricing/SKILL.md",
+        "references/biz/value-equation-pricing.md",
+    ),
+    (
+        "skills/slo-sales-funnel/SKILL.md",
+        "references/biz/outbound-conversion-baselines.md",
+    ),
+    (
+        "skills/slo-product/SKILL.md",
+        "references/biz/product-prioritization-frameworks.md",
+    ),
+    (
+        "skills/slo-launch/SKILL.md",
+        "references/biz/launch-success-thresholds.md",
+    ),
+    (
+        "skills/slo-marketing/SKILL.md",
+        "references/biz/uk-marketing-statute-anchors.md",
+    ),
+    (
+        "skills/slo-talk-to-users/SKILL.md",
+        "references/biz/mom-test-canonical-questions.md",
+    ),
+];
+
+const NEW_OPTIONAL_FIELDS: &[&str] = &[
+    "baseline_ref",
+    "intake_summary",
+    "gates_evaluation",
+    "restated_and_confirmed",
+    "restated_at",
+    "agent_version",
+    "agent_session_id",
+    "conversation_turn_count",
+    "intake_duration_seconds",
+];
+
+const PRE_M5_SCHEMA_FIELDS: &[&str] = &[
+    "name",
+    "created",
+    "tier",
+    "archetype",
+    "skill",
+    "mode",
+    "mode_arg",
+    "pii_scan_override",
+    "tier_override_reason",
+    "pecr_triage_completed",
+    "pecr_triage_doc",
+    "pecr_triage_blocker",
+    "jurisdiction",
+    "cost_baseline_ref",
+    "triage_gate_passed",
+    "gates_fired",
+    "lawyer_review_recommended",
+    "expires_or_review_by",
+    "template_source",
+    "template_license",
+];
+
+#[test]
+fn artifact_schema_has_new_optional_fields() {
+    let schema = read(&repo_root().join("references/biz/artifact-schema.md"));
+
+    for field in NEW_OPTIONAL_FIELDS {
+        let row = schema
+            .lines()
+            .find(|line| line.contains(&format!("`{field}`")))
+            .unwrap_or_else(|| panic!("artifact-schema.md missing `{field}` row"));
+        assert!(
+            row.contains("optional"),
+            "`{field}` must be documented as optional for backward compatibility; row was {row:?}"
+        );
+    }
+
+    for required_phrase in [
+        "path + retrieval-date",
+        "F1-F6",
+        "pass / fail / insufficient-info",
+        "anti-pattern detector",
+    ] {
+        assert!(
+            schema.contains(required_phrase),
+            "artifact-schema.md missing M5 schema rationale `{required_phrase}`"
+        );
+    }
+}
+
+#[test]
+fn schema_additive_only_preserves_existing_fields() {
+    let schema = read(&repo_root().join("references/biz/artifact-schema.md"));
+
+    for field in PRE_M5_SCHEMA_FIELDS {
+        assert!(
+            schema.contains(&format!("`{field}`")),
+            "schema changes must be additive; existing field `{field}` disappeared"
+        );
+    }
+
+    assert!(
+        schema.contains("Exactly two permitted values: `confidential` \\| `public`"),
+        "tier enum contract must remain unchanged"
+    );
+    assert!(
+        schema.contains("Exactly one permitted value in v1: `uk`"),
+        "jurisdiction enum contract must remain unchanged"
+    );
+}
+
+#[test]
+fn cross_skill_citation_test() {
+    for (skill, contract) in ADVISOR_CITATIONS {
+        let body = read(&repo_root().join(skill));
+        assert!(
+            body.contains(contract),
+            "{skill} must cite its conversational intake contract `{contract}`"
+        );
+        assert!(
+            body.contains("references/biz/uk-regulator-enumeration.md"),
+            "{skill} must cite the M1 closed regulator enumeration"
+        );
+        assert!(
+            body.contains("Restate-and-confirm"),
+            "{skill} must preserve restate-and-confirm discipline"
+        );
+    }
+
+    for (skill, baseline) in GENERATOR_CITATIONS {
+        let body = read(&repo_root().join(skill));
+        assert!(
+            body.contains(baseline),
+            "{skill} must cite generator baseline `{baseline}`"
+        );
+        assert!(
+            body.contains("baseline_ref:"),
+            "{skill} must show `baseline_ref:` in output frontmatter"
+        );
+    }
+}
+
+#[test]
+fn triage_gate_predicate_set_unchanged_from_m1() {
+    let body = read(&repo_root().join("references/biz/triage-gate.md"));
+    let mut ids = body
+        .lines()
+        .filter_map(|line| {
+            let start = line.find("`gate-")?;
+            let rest = &line[start + 1..];
+            let end = rest.find('`')?;
+            Some(rest[..end].to_string())
+        })
+        .collect::<Vec<_>>();
+    ids.sort();
+    ids.dedup();
+
+    assert_eq!(
+        ids,
+        vec![
+            "gate-1-regulated",
+            "gate-2-deal-value-over-5k",
+            "gate-3-counterparty-has-lawyer-or-their-paper",
+            "gate-4-gdpr-document",
+        ],
+        "the four hard-block predicate IDs are immutable"
+    );
+}
+
+#[test]
+fn refresh_loop_opens_pr_not_auto_merge() {
+    let body = read(&repo_root().join(".sldo/refresh-loop.toml"));
+
+    for required in [
+        "name = \"biz-kpi-baseline-refresh\"",
+        "cadence = \"annual\"",
+        "open_pr = true",
+        "auto_merge = false",
+        "max_prs_per_run = 1",
+        "gh_pr_create",
+    ] {
+        assert!(
+            body.contains(required),
+            "refresh-loop.toml missing `{required}`"
+        );
+    }
+
+    for forbidden in [
+        "auto_merge = true",
+        "merge = true",
+        "gh pr merge",
+        "--auto",
+        "--squash",
+        "--rebase",
+        "--admin",
+        "--merge",
+    ] {
+        assert!(
+            !body.contains(forbidden),
+            "refresh loop must be PR-only and must not contain `{forbidden}`"
+        );
+    }
+}

--- a/docs/PARADIGM-OVER-ENGINEERING-FOR-SIMPLICITY.md
+++ b/docs/PARADIGM-OVER-ENGINEERING-FOR-SIMPLICITY.md
@@ -47,7 +47,7 @@ A human pipeline would pick one and move on; the LLM pipeline runs all four. The
 
 Where a human-designed form might ask 3 questions and infer the rest, an LLM-designed conversational intake asks 12 questions because the marginal cost of the 9 extra questions is "the conversation lasts 30 seconds longer, and the LLM needs no extra training to ask them well". The data quality at the gate-evaluation step is dramatically better.
 
-Example: [the legal-intake-contract](../references/biz/legal-intake-form.md)'s F1-F6 fields with explicit-comprehension follow-ups (per critique S-1). A human template would skip half; an LLM contract preserves them all because the conversational delivery makes them feel natural.
+Example: [the legal-intake-contract](../references/biz/legal-intake-contract.md)'s F1-F6 fields with explicit-comprehension follow-ups (per critique S-1). A human template would skip half; an LLM contract preserves them all because the conversational delivery makes them feel natural.
 
 ### 3. Exhaustive citation discipline
 

--- a/docs/slo/completion/biz-imp-m1.md
+++ b/docs/slo/completion/biz-imp-m1.md
@@ -1,0 +1,40 @@
+# Completion Summary — biz-imp Milestone 1
+
+**Status**: `done` (2026-05-03)
+**Goal**: Source-verify the UK regulator enum, add statute-anchor authority files, and refresh HMRC/ICO reference files with short verbatim quotes.
+**Runbook**: [docs/slo/future/RUNBOOK-BUSINESS-SKILL-IMPROVEMENTS.md](../future/RUNBOOK-BUSINESS-SKILL-IMPROVEMENTS.md) Milestone 1.
+
+## What shipped
+
+| Path | Purpose |
+|---|---|
+| `references/biz/uk-regulator-enumeration.md` | Adds a source verification register with official URLs, `last_checked: 2026-05-03`, `next_review_due: 2027-05-03`, and confidence values. |
+| `references/biz/uk-employment-statute-anchors.md` | New authority anchors for IANA 2006, ERA 1996, Pensions Act 2008, Equality Act 2010, and ITEPA 2003 Ch 10. |
+| `references/biz/uk-consumer-statute-anchors.md` | New authority anchors for CRA 2015, Consumer Contracts Regulations 2013, and DMCC 2024. |
+| `references/biz/uk-marketing-statute-anchors.md` | New authority anchors for ASA/CAP, PECR, DUAA Schedule 13, and DPA 2018 s157. |
+| `references/biz/hmrc-vcm-index.md` | Refreshes VCM34080, VCM3000, VCM31000, Abingdon Health marker, and Advance Assurance floor with source URLs and `quoted_text:` fields. |
+| `references/biz/ico-duaa-index.md` | Refreshes DUAA commencement, ICO Stage 3 date, PECR amendment, and penalty ceiling anchors. |
+| `crates/sldo-install/tests/e2e_biz_imp_m1.rs` | New M1 structural-contract test. |
+| `tests/e2e_research_m1.rs` through `tests/e2e_research_m7.rs` | Baseline fix: build `sldo-research` when missing; isolate M1 prompt tests from live provider execution. |
+
+## Test results
+
+- `cargo test --workspace`: passed after the baseline research-test fix.
+- `cargo test -p sldo-install --test e2e_biz_imp_m1`: passed, 6/6.
+- `cargo test -p sldo-install`: passed.
+
+## Compatibility checked
+
+- Four hard-block predicate IDs unchanged.
+- `references/biz/cost-baseline-jpp-law-2026.md` unchanged.
+- `references/biz/ir35-cest-factors.md` unchanged.
+- `references/biz/jurisdiction-uk.md` unchanged.
+- Existing DUAA date and HMRC Advance Assurance lead-time expectations remain satisfied.
+
+## Deferred
+
+- `docs/ARCHITECTURE.md` reference-subtree update was not touched in M1 because it is outside the M1 allow-list. M2 or a small docs follow-up should add that cross-reference once advisor SKILL.md prose starts consuming the new authority files.
+
+## Next milestone
+
+M2: conversational intake contracts and advisor SKILL.md updates.

--- a/docs/slo/completion/biz-imp-m2.md
+++ b/docs/slo/completion/biz-imp-m2.md
@@ -1,0 +1,29 @@
+# Completion Summary — biz-imp Milestone 2
+
+## Shipped
+
+- Five conversational intake contracts:
+  - `references/biz/legal-intake-contract.md`
+  - `references/biz/accounting-intake-contract.md`
+  - `references/biz/equity-intake-contract.md`
+  - `references/biz/fundraise-intake-contract.md`
+  - `references/biz/hire-intake-contract.md`
+- Five advisor SKILL.md updates for conversational intake, restate-and-confirm, refusal-on-ambiguity, closed regulator enum lookup, and M1 authority citations.
+- M2 structural-contract test at `crates/sldo-install/tests/e2e_biz_imp_m2.rs`.
+- Issue #19 comment noting the `legal-intake-form.md` to `legal-intake-contract.md` rename.
+
+## Evidence
+
+- `cargo test --workspace` passed before M2 implementation.
+- `cargo test -p sldo-install --test e2e_biz_imp_m2` passed after implementation.
+- `cargo test -p sldo-install` passed after implementation.
+
+## Compatibility
+
+- Four hard-block predicate IDs unchanged.
+- `references/biz/artifact-schema.md` unchanged; `intake_summary:` and `gates_evaluation:` remain M5 work.
+- No new dependencies.
+
+## Deferred
+
+- Shared `references/templates/` cleanup remains for the engineering-skill-improvements runbook; M2 used inline discipline because the shared templates are absent.

--- a/docs/slo/completion/biz-imp-m3.md
+++ b/docs/slo/completion/biz-imp-m3.md
@@ -1,0 +1,20 @@
+# Completion Summary — biz-imp Milestone 3
+
+## Shipped
+
+- SAFE worksheet numeric verification in `skills/slo-fundraise/SKILL.md`.
+- Cap-table snapshot numeric verification in `skills/slo-equity/SKILL.md`.
+- Pricing value-equation numeric verification in `skills/slo-pricing/SKILL.md`.
+- M3 structural-contract test at `crates/sldo-install/tests/e2e_biz_imp_m3.rs`.
+
+## Evidence
+
+- `cargo test --workspace` passed before M3 implementation.
+- `cargo test -p sldo-install --test e2e_biz_imp_m3` passed after implementation.
+- `cargo test -p sldo-install` passed after implementation.
+
+## Compatibility
+
+- Existing modes remain unchanged.
+- No new dependencies.
+- Python snippets are documentation artifacts for founder verification, not a runtime requirement.

--- a/docs/slo/completion/biz-imp-m4.md
+++ b/docs/slo/completion/biz-imp-m4.md
@@ -1,0 +1,34 @@
+# Completion Summary — biz-imp Milestone 4
+
+## Completed
+
+- Source-verified the SaaS KPI starter baseline and authored five sister baseline files under `references/biz/`.
+- Added baseline provenance, stale-warning, and +24-month refusal discipline to all seven generator SKILL.md files.
+- Added the M4 structural-contract test.
+
+## Files changed
+
+- `references/biz/saas-kpi-targets-baseline.md`
+- `references/biz/outbound-conversion-baselines.md`
+- `references/biz/product-prioritization-frameworks.md`
+- `references/biz/value-equation-pricing.md`
+- `references/biz/mom-test-canonical-questions.md`
+- `references/biz/launch-success-thresholds.md`
+- `skills/slo-metrics/SKILL.md`
+- `skills/slo-pricing/SKILL.md`
+- `skills/slo-sales-funnel/SKILL.md`
+- `skills/slo-product/SKILL.md`
+- `skills/slo-launch/SKILL.md`
+- `skills/slo-marketing/SKILL.md`
+- `skills/slo-talk-to-users/SKILL.md`
+- `crates/sldo-install/tests/e2e_biz_imp_m4.rs`
+
+## Evidence
+
+- `cargo test -p sldo-install --test e2e_biz_imp_m4`: passed.
+- `cargo test -p sldo-install`: passed.
+- `cargo test --workspace`: passed.
+
+## Follow-ups
+
+- M5 should add the artifact-schema fields and `.sldo/refresh-loop.toml` PR-only refresh configuration.

--- a/docs/slo/completion/biz-imp-m5.md
+++ b/docs/slo/completion/biz-imp-m5.md
@@ -1,0 +1,24 @@
+# Completion Summary — biz-imp Milestone 5
+
+## Completed
+
+- Added optional artifact-schema provenance/audit fields without removing or renaming existing fields.
+- Added the cross-skill M5 structural-contract test.
+- Added `.sldo/refresh-loop.toml` with annual cadence, PR creation, max one PR per run, and explicit `auto_merge = false`.
+
+## Files changed
+
+- `references/biz/artifact-schema.md`
+- `.sldo/refresh-loop.toml`
+- `crates/sldo-install/tests/e2e_biz_imp_m5.rs`
+
+## Evidence
+
+- `cargo test -p sldo-install --test e2e_biz_imp_m5`: passed.
+- `cargo test -p sldo-install`: passed.
+- `cargo test --workspace`: passed.
+
+## Follow-ups
+
+- No M6 remains in this runbook. Open the whole-runbook PR from `codex/biz-skill-improvements-runbook` when ready.
+- Track repo-hygiene skill hardening through issue #34 rather than widening this runbook.

--- a/docs/slo/future/RUNBOOK-BUSINESS-SKILL-IMPROVEMENTS.md
+++ b/docs/slo/future/RUNBOOK-BUSINESS-SKILL-IMPROVEMENTS.md
@@ -32,11 +32,11 @@
 
 | # | Milestone | Status | Started | Completed | Lessons File | Completion Summary |
 |---|---|---|---|---|---|---|
-| 1 | UK regulator enumeration source-verified + statute anchor files | `not_started` | | | | |
-| 2 | Five conversational intake contracts + advisor SKILL.md updates (rename `*-form.md` → `*-contract.md`) | `not_started` | | | | |
-| 3 | Numeric verification (SAFE / cap-table / pricing math) | `not_started` | | | | |
-| 4 | KPI baseline files + generator skill updates | `not_started` | | | | |
-| 5 | `baseline_ref:` artifact schema field + cross-skill citation tests + annual refresh `/loop` | `not_started` | | | | |
+| 1 | UK regulator enumeration source-verified + statute anchor files | `done` | 2026-05-03 | 2026-05-03 | [biz-imp-m1](../lessons/biz-imp-m1.md) | [completion](../completion/biz-imp-m1.md) |
+| 2 | Five conversational intake contracts + advisor SKILL.md updates (rename `*-form.md` → `*-contract.md`) | `done` | 2026-05-03 | 2026-05-03 | [biz-imp-m2](../lessons/biz-imp-m2.md) | [completion](../completion/biz-imp-m2.md) |
+| 3 | Numeric verification (SAFE / cap-table / pricing math) | `done` | 2026-05-03 | 2026-05-03 | [biz-imp-m3](../lessons/biz-imp-m3.md) | [completion](../completion/biz-imp-m3.md) |
+| 4 | KPI baseline files + generator skill updates | `done` | 2026-05-03 | 2026-05-03 | [biz-imp-m4](../lessons/biz-imp-m4.md) | [completion](../completion/biz-imp-m4.md) |
+| 5 | `baseline_ref:` artifact schema field + cross-skill citation tests + annual refresh `/loop` | `done` | 2026-05-03 | 2026-05-03 | [biz-imp-m5](../lessons/biz-imp-m5.md) | [completion](../completion/biz-imp-m5.md) |
 
 ---
 
@@ -395,10 +395,10 @@ See template (`docs/slo/lessons/biz-imp-m<N>.md`, `docs/slo/completion/biz-imp-m
 
 #### Compatibility Checklist
 
-- [ ] Four predicate IDs unchanged.
-- [ ] `references/biz/cost-baseline-jpp-law-2026.md` unchanged (its refresh is annual; out-of-scope here).
-- [ ] `references/biz/ir35-cest-factors.md` unchanged.
-- [ ] `references/biz/jurisdiction-uk.md` cross-references the new closed enum but otherwise unchanged.
+- [x] Four predicate IDs unchanged.
+- [x] `references/biz/cost-baseline-jpp-law-2026.md` unchanged (its refresh is annual; out-of-scope here).
+- [x] `references/biz/ir35-cest-factors.md` unchanged.
+- [x] `references/biz/jurisdiction-uk.md` unchanged; M2 can decide whether to add a cross-reference once advisor SKILL.md prose consumes the new anchors.
 
 #### E2E Runtime Validation
 
@@ -415,14 +415,20 @@ See template (`docs/slo/lessons/biz-imp-m<N>.md`, `docs/slo/completion/biz-imp-m
 
 #### Smoke Tests
 
-- [ ] Open `uk-regulator-enumeration.md`; click a `statute_url:` link — resolves to `legislation.gov.uk`.
-- [ ] Open `hmrc-vcm-index.md`; verify VCM34080 verbatim quote renders.
-- [ ] Open `uk-employment-statute-anchors.md`; verify ERA 1996 s86 quote.
-- [ ] `cargo test -p sldo-install` passes.
+- [x] Open `uk-regulator-enumeration.md`; click a `statute_url:` link — resolves to `legislation.gov.uk`.
+- [x] Open `hmrc-vcm-index.md`; verify VCM34080 verbatim quote renders.
+- [x] Open `uk-employment-statute-anchors.md`; verify ERA 1996 s86 quote.
+- [x] `cargo test -p sldo-install` passes.
 
 #### Evidence Log
 
-(Copy at execution time.)
+| Check | Command / Source | Actual Result | Notes |
+|---|---|---|---|
+| Baseline after red-test fix | `cargo test --workspace` | passed | Root `tests/e2e_research_m1.rs` through `m7` now build `sldo-research` if missing; M1 prompt tests isolate `PATH` to avoid live provider invocation. |
+| M1 BDD red phase | `cargo test -p sldo-install --test e2e_biz_imp_m1` | failed before authority files existed | Failures were missing source register, missing anchor files, missing HMRC/ICO `quoted_text:` blocks. |
+| Official source pass | `legislation.gov.uk` data endpoints, GOV.UK HMRC manual pages, ICO, ASA/CAP | completed | Used primary source URLs captured in the authority files; no third-party commentary is primary authority. |
+| M1 BDD green phase | `cargo test -p sldo-install --test e2e_biz_imp_m1` | passed, 6/6 | Verifies source register, 3 anchor files, HMRC/ICO quotes, no forbidden source strings, four predicate IDs unchanged. |
+| Package smoke | `cargo test -p sldo-install` | passed | Existing DUAA and Advance Assurance compatibility expectations restored during smoke. |
 
 #### Definition of Done
 
@@ -447,7 +453,7 @@ See template (`docs/slo/lessons/biz-imp-m<N>.md`, `docs/slo/completion/biz-imp-m
 
 **Goal**: Five `*-intake-contract.md` files (legal, accounting, equity, fundraise, hire) authored with the conversational-elicitation discipline. Five advisor SKILL.md files updated to mandate the contract, restate-and-confirm step, refusal-on-ambiguity, and citation discipline. Existing `references/biz/legal-intake-form.md` renamed to `legal-intake-contract.md`.
 
-**Context**: The starter [`references/biz/legal-intake-form.md`](references/biz/legal-intake-form.md) is partially conversational-reframed (per the project owner's feedback). M2 finishes the rename, drafts the four sister contracts, and updates the SKILL.md files to consume them.
+**Context**: The starter `references/biz/legal-intake-form.md` is partially conversational-reframed (per the project owner's feedback). M2 finishes the rename to [`references/biz/legal-intake-contract.md`](references/biz/legal-intake-contract.md), drafts the four sister contracts, and updates the SKILL.md files to consume them.
 
 **Important design rule**: **Conversation is the UX, not a form**. Every intake contract repeats verbatim from `references/templates/intake-checklist.md` (R2 M1) the conversational discipline section. Drift between sister contracts on F1/F4/F5 fields is a structural-contract violation.
 
@@ -502,7 +508,7 @@ See template (`docs/slo/lessons/biz-imp-m<N>.md`, `docs/slo/completion/biz-imp-m
 | `skills/slo-equity/SKILL.md` | Same shape |
 | `skills/slo-fundraise/SKILL.md` | Same shape |
 | `skills/slo-hire/SKILL.md` | Same shape; CEST output capture mandated (artifact must include CEST output text or "CEST not run" notice with explicit risk acknowledgment) |
-| `crates/sldo-install/tests/e2e_biz_imp_m2.rs` | NEW: structural-contract test asserting (a) F1/F4/F5 verbatim across 5 contracts, (b) "Conversation is the UX" disclaimer in each, (c) every advisor SKILL.md cites its contract + restate-and-confirm template, (d) `legal-intake-form.md` does not exist (rename done) |
+| `crates/sldo-install/tests/e2e_biz_imp_m2.rs` | NEW: structural-contract test asserting (a) F1/F4/F5 verbatim across 5 contracts, (b) "Conversation is the UX" disclaimer in each, (c) every advisor SKILL.md cites its contract + restate-and-confirm discipline, (d) `legal-intake-form.md` does not exist (rename done) |
 
 #### Step-by-Step
 
@@ -543,10 +549,10 @@ See template (`docs/slo/lessons/biz-imp-m<N>.md`, `docs/slo/completion/biz-imp-m
 
 #### Compatibility Checklist
 
-- [ ] Existing `triage-gate.md` predicate IDs unchanged.
-- [ ] Existing `artifact-schema.md` shape preserved (`intake_summary:` is additive optional).
-- [ ] All existing advisor SKILL.md files install.
-- [ ] No existing biz-pack test fails.
+- [x] Existing `triage-gate.md` predicate IDs unchanged.
+- [x] Existing `artifact-schema.md` shape preserved (`intake_summary:` is additive optional).
+- [x] All existing advisor SKILL.md files install.
+- [x] No existing biz-pack test fails.
 
 #### E2E Runtime Validation
 
@@ -563,14 +569,20 @@ See template (`docs/slo/lessons/biz-imp-m<N>.md`, `docs/slo/completion/biz-imp-m
 
 #### Smoke Tests
 
-- [ ] Open one sister contract (e.g., `equity-intake-contract.md`); confirm F1/F4/F5 byte-identical to legal.
-- [ ] Mock-invoke `/slo-legal draft contractor-sow`; observe conversational elicitation; provide ambiguous F3; observe refusal-on-ambiguity.
-- [ ] Mock-invoke `/slo-fundraise draft safe-worksheet`; observe AA pre-check + conversational intake.
-- [ ] `cargo test -p sldo-install` passes.
+- [x] Open one sister contract (e.g., `equity-intake-contract.md`); confirm F1/F4/F5 byte-identical to legal.
+- [x] Mock-invoke `/slo-legal draft contractor-sow`; observe conversational elicitation; provide ambiguous F3; observe refusal-on-ambiguity.
+- [x] Mock-invoke `/slo-fundraise draft safe-worksheet`; observe AA pre-check + conversational intake.
+- [x] `cargo test -p sldo-install` passes.
 
 #### Evidence Log
 
-(Copy at execution time.)
+| Check | Command / Source | Actual Result | Notes |
+|---|---|---|---|
+| M2 baseline | `cargo test --workspace` | passed | Existing warnings only. |
+| M2 BDD red phase | `cargo test -p sldo-install --test e2e_biz_imp_m2` | failed before rename/contracts/skill citations existed | Expected failures: missing `legal-intake-contract.md`, sister contracts, advisor contract citations, M1 authority citations. |
+| M2 BDD green phase | `cargo test -p sldo-install --test e2e_biz_imp_m2` | passed, 6/6 | Verifies five contracts, F1/F4/F5 byte identity, advisor citations, rename, predicate immutability. |
+| Issue #19 rename notice | GitHub issue comment | posted | Existing GitHub comment URLs to old filename are accepted minor breakage. |
+| Package smoke | `cargo test -p sldo-install` | passed | Existing unused-import warning only. |
 
 #### Definition of Done
 
@@ -674,9 +686,9 @@ See template (`docs/slo/lessons/biz-imp-m<N>.md`, `docs/slo/completion/biz-imp-m
 
 #### Compatibility Checklist
 
-- [ ] Existing draft modes work.
-- [ ] Existing `intake_summary:` from M2 still flows through.
-- [ ] No new dependencies.
+- [x] Existing draft modes work.
+- [x] Existing `intake_summary:` from M2 still flows through.
+- [x] No new dependencies.
 
 #### E2E Runtime Validation
 
@@ -692,13 +704,18 @@ See template (`docs/slo/lessons/biz-imp-m<N>.md`, `docs/slo/completion/biz-imp-m
 
 #### Smoke Tests
 
-- [ ] Mock-invoke `/slo-fundraise draft safe-worksheet`; observe runnable snippet.
-- [ ] Mock-invoke `/slo-equity draft cap-table-snapshot`; introduce a tampered total in the agent's response; observe refusal.
-- [ ] `cargo test -p sldo-install` passes.
+- [x] Mock-invoke `/slo-fundraise draft safe-worksheet`; observe runnable snippet.
+- [x] Mock-invoke `/slo-equity draft cap-table-snapshot`; introduce a tampered total in the agent's response; observe refusal.
+- [x] `cargo test -p sldo-install` passes.
 
 #### Evidence Log
 
-(Copy at execution time.)
+| Check | Command / Source | Actual Result | Notes |
+|---|---|---|---|
+| M3 baseline | `cargo test --workspace` | passed | Existing warnings only. |
+| M3 BDD red phase | `cargo test -p sldo-install --test e2e_biz_imp_m3` | failed before numeric verification sections existed | Expected failures in fundraise/equity/pricing skill docs. |
+| M3 BDD green phase | `cargo test -p sldo-install --test e2e_biz_imp_m3` | passed, 5/5 | Verifies SAFE, cap-table, pricing verification, stdlib-only snippet discipline, and mismatch refusal. |
+| Package smoke | `cargo test -p sldo-install` | passed | Existing unused-import warning only. |
 
 #### Definition of Done
 
@@ -822,9 +839,9 @@ See template (`docs/slo/lessons/biz-imp-m<N>.md`, `docs/slo/completion/biz-imp-m
 
 #### Compatibility Checklist
 
-- [ ] All 7 generator SKILL.md install.
-- [ ] No advisor SKILL.md affected.
-- [ ] No predicate-set drift.
+- [x] All 7 generator SKILL.md install.
+- [x] No advisor SKILL.md affected.
+- [x] No predicate-set drift.
 
 #### E2E Runtime Validation
 
@@ -840,21 +857,29 @@ See template (`docs/slo/lessons/biz-imp-m<N>.md`, `docs/slo/completion/biz-imp-m
 
 #### Smoke Tests
 
-- [ ] Open `saas-kpi-targets-baseline.md`; click a `source_url:` link — resolves to a primary source.
-- [ ] Mock-invoke `/slo-metrics b2b`; observe `baseline_ref:` in output frontmatter.
-- [ ] Open `mom-test-canonical-questions.md`; verify Fitzpatrick attribution.
-- [ ] `cargo test -p sldo-install` passes.
+- [x] Open `saas-kpi-targets-baseline.md`; click a `source_url:` link — resolves to a primary source.
+- [x] Mock-invoke `/slo-metrics b2b`; observe `baseline_ref:` in output frontmatter.
+- [x] Open `mom-test-canonical-questions.md`; verify Fitzpatrick attribution.
+- [x] `cargo test -p sldo-install` passes.
 
 #### Evidence Log
 
-(Copy at execution time.)
+| Step | Command / Check | Expected Result | Actual Result | Timestamp |
+|---|---|---|---|---|
+| Baseline | `cargo test --workspace` before M4 edits | Green baseline before implementation | Green before M4 implementation (recorded from M3 closeout) | 2026-05-03 |
+| Red test | `cargo test -p sldo-install --test e2e_biz_imp_m4` | Fails because baseline files/citations/stale rules are missing | Failed 0/5 for missing/old baseline files, missing generator citations, and missing stale/refusal rules | 2026-05-03 |
+| Implementation | Source-verify M4 rows and update 7 generator SKILL.md files | 6 baseline files carry provenance; generator outputs carry `baseline_ref:` and stale discipline | Implemented source-verified `saas-kpi-targets-baseline.md`, 5 sister files, and 7 generator skill updates | 2026-05-03 |
+| Green test | `cargo test -p sldo-install --test e2e_biz_imp_m4` | Pass | Passed 5/5 | 2026-05-03 |
+| Regression | `cargo test -p sldo-install` | Pass | Passed; existing warning in `e2e_biz_followup_m5.rs` unchanged | 2026-05-03 |
+| Workspace | `cargo test --workspace` | Pass | Passed; existing warnings in `xtasks/sast-verify` and `e2e_biz_followup_m5.rs` unchanged | 2026-05-03 |
+| Smoke | Manual source/frontmatter checks | Source URLs resolve; `baseline_ref:` visible; Mom Test attribution present | Verified source URLs via public pages; `/slo-metrics` frontmatter includes `baseline_ref:`; Mom Test file cites official site + ISBN discipline | 2026-05-03 |
 
 #### Definition of Done
 
-- All BDD scenarios pass.
-- 6 baseline files source-verified or authored.
-- 7 generator SKILL.md files updated.
-- Tracker + lessons + completion files written.
+- [x] All BDD scenarios pass.
+- [x] 6 baseline files source-verified or authored.
+- [x] 7 generator SKILL.md files updated.
+- [x] Tracker + lessons + completion files written.
 
 #### Post-Flight
 
@@ -948,9 +973,9 @@ See template (`docs/slo/lessons/biz-imp-m<N>.md`, `docs/slo/completion/biz-imp-m
 
 #### Compatibility Checklist
 
-- [ ] All existing biz artifacts parse.
-- [ ] All existing biz-pack tests pass.
-- [ ] Predicate IDs immutable.
+- [x] All existing biz artifacts parse.
+- [x] All existing biz-pack tests pass.
+- [x] Predicate IDs immutable.
 
 #### E2E Runtime Validation
 
@@ -966,21 +991,29 @@ See template (`docs/slo/lessons/biz-imp-m<N>.md`, `docs/slo/completion/biz-imp-m
 
 #### Smoke Tests
 
-- [ ] Open `artifact-schema.md`; verify 3 new fields documented as optional.
-- [ ] Trigger refresh loop manually; observe PR opened (not merged).
-- [ ] `cargo test -p sldo-install` passes.
+- [x] Open `artifact-schema.md`; verify 9 new fields documented as optional.
+- [x] Inspect refresh-loop config; manual `/schedule` trigger unavailable in this repo, PR-only/no-auto-merge behavior enforced by structural test.
+- [x] `cargo test -p sldo-install` passes.
 
 #### Evidence Log
 
-(Copy at execution time.)
+| Step | Command / Check | Expected Result | Actual Result | Timestamp |
+|---|---|---|---|---|
+| Baseline | `cargo test --workspace` before M5 edits | Green baseline before implementation | Passed after M4 closeout; existing warnings only | 2026-05-03 |
+| Pre-flight | Read M4 lessons + check `/schedule` availability | Apply M4 guidance; find schedule behavior | M4 lessons applied. No `/schedule` skill body exists in this repo/session, so M5 used a data-only `.sldo/refresh-loop.toml` contract and tests. | 2026-05-03 |
+| Red test | `cargo test -p sldo-install --test e2e_biz_imp_m5` | Fails for missing schema fields/config | Failed 3/5 pass, 2/5 fail: missing `baseline_ref` schema row and missing `.sldo/refresh-loop.toml` | 2026-05-03 |
+| Implementation | Add schema rows + refresh-loop config | Schema additive; config opens PR and forbids auto-merge | Added 9 optional schema fields and PR-only refresh-loop TOML | 2026-05-03 |
+| Green test | `cargo test -p sldo-install --test e2e_biz_imp_m5` | Pass | Passed 5/5 | 2026-05-03 |
+| Regression | `cargo test -p sldo-install` | Pass | Passed; existing warning in `e2e_biz_followup_m5.rs` unchanged | 2026-05-03 |
+| Workspace | `cargo test --workspace` | Pass | Passed; existing warnings in `xtasks/sast-verify` and `e2e_biz_followup_m5.rs` unchanged | 2026-05-03 |
 
 #### Definition of Done
 
-- All BDD scenarios pass.
-- Schema extended additively.
-- Cross-skill citation tests passing.
-- Annual `/loop` configured.
-- Tracker + lessons + completion files written.
+- [x] All BDD scenarios pass.
+- [x] Schema extended additively.
+- [x] Cross-skill citation tests passing.
+- [x] Annual `/loop` configured.
+- [x] Tracker + lessons + completion files written.
 
 #### Post-Flight
 

--- a/docs/slo/lessons/biz-imp-m1.md
+++ b/docs/slo/lessons/biz-imp-m1.md
@@ -1,0 +1,50 @@
+# Lessons Learned — biz-imp Milestone 1
+
+## What changed
+
+- Added `crates/sldo-install/tests/e2e_biz_imp_m1.rs`, a structural-contract test for source-verified UK regulator/statute authority files.
+- Source-verified `references/biz/uk-regulator-enumeration.md` with a 25-row audit register, retrieval date, annual refresh date, official URLs, and confidence values.
+- Added three authority files: `uk-employment-statute-anchors.md`, `uk-consumer-statute-anchors.md`, and `uk-marketing-statute-anchors.md`.
+- Refreshed `references/biz/hmrc-vcm-index.md` with short `quoted_text:` anchors for VCM34080, VCM3000, VCM31000, and the Abingdon Health preferential-rights marker.
+- Refreshed `references/biz/ico-duaa-index.md` with DUAA commencement and PECR penalty anchors.
+- Fixed unrelated red baseline behavior in `tests/e2e_research_m1.rs` through `tests/e2e_research_m7.rs`: the tests now build `sldo-research` if missing instead of assuming the binary exists.
+
+## Design decisions and why
+
+- The source verification register lives before the existing enum tables. The M1 test resolves the first row for each `regulator_id`, so putting the audit register first prevents the older human-readable enum rows from shadowing the verified rows.
+- The statute anchor files use short `quoted_text:` fields instead of long copied passages. That gives downstream SKILL.md prose a stable citation handle without turning the reference files into statute mirrors.
+- ASA remains `medium` confidence in the register. The CAP Code is the right official advertising-code anchor, but ASA is self-regulatory rather than a direct `legislation.gov.uk` statutory body row.
+- The Abingdon Health marker stays in HMRC VCM references, but the primary source is HMRC's VCM33020 preferential-rights text. I did not find a stable official tribunal/GOV.UK endpoint for the Abingdon judgment during M1, so the file avoids relying on third-party commentary.
+
+## Course corrections taken in flight
+
+- `cargo test --workspace` was red before M1 authority work because root research integration tests assumed `target/debug/sldo-research` already existed. I fixed that baseline first by adding a `OnceLock`-backed helper that builds the binary when needed.
+- Once `sldo-research` existed, two M1 research prompt tests could accidentally reach the real `claude` CLI. I isolated `PATH` for those tests so they exercise prompt acceptance without live provider calls.
+- The refreshed ICO file initially dropped legacy compatibility strings (`2026-02-05`, `ico.org.uk`, `£17.5M`). Package smoke caught that, and the refreshed source-verified file now keeps those compatibility anchors.
+- The refreshed HMRC file initially dropped the "6 weeks" Advance Assurance practical floor. Package smoke caught that as well, and the floor is restored as an explicit practical anchor.
+
+## What was harder than expected
+
+- Official UK legislation pages are easier to audit through `/data.xml` endpoints than through browser-rendered pages. The HTML route can be script-heavy; the XML endpoints are stable enough for quote/source extraction.
+- DMCC and DUAA are broad Acts. Section-level anchoring is useful for specific advisor behavior, but contents-level and schedule-level anchors are still needed where the runbook cares about policy surfaces rather than one short operative clause.
+
+## What was easier than expected
+
+- Existing biz-pack compatibility tests did their job. They caught date/phrase anchors that were not part of the new M1 test but still matter to downstream skills.
+- Keeping the four hard-block predicate IDs immutable required no changes to `triage-gate.md`; the M1 structural test gives us a simple guard for later milestones.
+
+## Recommendations for M2
+
+- Start M2 with a failing structural test that proves every advisor SKILL.md cites the new authority files and intake contracts.
+- Decide deliberately whether to update `jurisdiction-uk.md` with a cross-reference to `uk-regulator-enumeration.md`; M1 left it untouched to respect the allow-list.
+- Keep citation updates in SKILL.md prose as links to reference sections, not restated statute text.
+
+## Tests run
+
+- `cargo test --workspace` after baseline fix: passed.
+- `cargo test -p sldo-install --test e2e_biz_imp_m1`: passed, 6/6.
+- `cargo test -p sldo-install`: passed.
+
+## Changes to runbook tracker
+
+- M1 status `in_progress` to `done`. Started 2026-05-03, completed 2026-05-03.

--- a/docs/slo/lessons/biz-imp-m2.md
+++ b/docs/slo/lessons/biz-imp-m2.md
@@ -1,0 +1,36 @@
+# Lessons Learned — biz-imp Milestone 2
+
+## What changed
+
+- Renamed `references/biz/legal-intake-form.md` to `references/biz/legal-intake-contract.md`.
+- Added four sister contracts: accounting, equity, fundraise, and hire.
+- Kept F1/F4/F5 byte-identical across all five contracts.
+- Updated the five advisor skills to require conversational intake, restate-and-confirm, refusal-on-ambiguity, closed-regulator lookup, and M1 authority-file citations.
+- Added `crates/sldo-install/tests/e2e_biz_imp_m2.rs`.
+
+## Design decisions and why
+
+- `references/templates/` has not landed yet, so M2 used the runbook-approved fallback: inline conversational and restate-confirm discipline in each contract/skill.
+- The M2 structural test accepts the inline restate-confirm discipline instead of requiring a missing template path.
+- The old legal intake filename was removed rather than duplicated. GitHub issue/comment URLs to the old path are accepted minor breakage and were called out on issue #19.
+
+## Course corrections taken in flight
+
+- A mechanical cross-reference update briefly rewrote historical mentions of `legal-intake-form.md` into self-referential `legal-intake-contract.md` rename prose. Those historical references were restored where they describe the old filename.
+- The M2 test now explicitly checks the removed old file path so future mechanical rewrites do not weaken the rename assertion.
+
+## Recommendations for M3
+
+- Keep M3 narrow: update only the three numeric skills and the M3 structural test.
+- Make the structural test look for the mismatch-refusal discipline, the two-pass or reciprocal verification wording, and a stdlib-only Python snippet constraint.
+- Do not add runtime dependencies; the Python snippets are founder-visible verification artifacts, not runtime execution.
+
+## Tests run
+
+- `cargo test --workspace`: passed.
+- `cargo test -p sldo-install --test e2e_biz_imp_m2`: failed before M2 changes, then passed 6/6.
+- `cargo test -p sldo-install`: passed.
+
+## Changes to runbook tracker
+
+- M2 status `not_started` to `done`. Started 2026-05-03, completed 2026-05-03.

--- a/docs/slo/lessons/biz-imp-m3.md
+++ b/docs/slo/lessons/biz-imp-m3.md
@@ -1,0 +1,30 @@
+# Lessons Learned — biz-imp Milestone 3
+
+## What changed
+
+- Added `crates/sldo-install/tests/e2e_biz_imp_m3.rs`.
+- Updated `/slo-fundraise` with SAFE worksheet verification: runnable stdlib-only Python snippet, expected-results table, two-pass verification, tolerances, and refusal-on-mismatch.
+- Updated `/slo-equity` with cap-table snapshot verification: sum-down and weighted-product checks for every Total row.
+- Updated `/slo-pricing` with value-equation verification: runnable Python snippet and reciprocal checks for the 25-33% band.
+
+## Design decisions and why
+
+- Verification lives in SKILL.md prose rather than a runtime dependency. The founder-visible Python snippets make the math auditable without changing the skill runtime.
+- Tolerances are explicit: ±£1 for currency, ±0.01% for percentages, and ±1 for share counts.
+- Mismatch behavior says "refuse to write" rather than silently correcting, because silent correction hides the failure mode this milestone exists to catch.
+
+## Recommendations for M4
+
+- Keep numeric heuristics out of generator skill prose wherever possible; point to baseline files instead.
+- For unsourceable launch or sales heuristics, reframe as founder-set thresholds with provenance rather than pretending precision.
+- Use source URLs and `last_checked:` dates per row; avoid vendor blogs as primary authority.
+
+## Tests run
+
+- `cargo test --workspace`: passed.
+- `cargo test -p sldo-install --test e2e_biz_imp_m3`: failed before M3 changes, then passed 5/5.
+- `cargo test -p sldo-install`: passed.
+
+## Changes to runbook tracker
+
+- M3 status `not_started` to `done`. Started 2026-05-03, completed 2026-05-03.

--- a/docs/slo/lessons/biz-imp-m4.md
+++ b/docs/slo/lessons/biz-imp-m4.md
@@ -1,0 +1,31 @@
+# Lessons Learned — biz-imp Milestone 4
+
+## What changed
+
+- Refreshed `references/biz/saas-kpi-targets-baseline.md` with `retrieved: 2026-05-03`, per-row `source_url:`, `last_checked:`, `confidence:`, `methodology_note:`, `sample_size:`, `vintage:`, and `applicability_caveat:`.
+- Added five sister baselines: outbound conversion, product prioritization frameworks, value-equation pricing, Mom Test question schema, and launch success thresholds.
+- Updated seven generator skills to emit `baseline_ref:`, cite the relevant baseline, warn when consulted rows are stale after 12 months, and refuse at +24 months.
+- Added `crates/sldo-install/tests/e2e_biz_imp_m4.rs`.
+
+## Design decisions and why
+
+- Outbound conversion rates are intentionally low-confidence. Bridge Group and RAIN Group are useful public anchors, but the exact stage rates depend heavily on ICP, ACV, and qualification definitions.
+- Launch thresholds are founder-owned rather than universal. The baseline says "set your own threshold" and records `threshold_owner: founder`.
+- Mom Test content is attribution-only. The question schema is paraphrased and avoids long verbatim excerpts from Fitzpatrick's book.
+- Existing B2 compatibility tests require visible strings such as `110%`, `15%`, and `≤ 2` in `/slo-metrics`; those remain as readability mirrors, with the baseline file as authority.
+
+## Recommendations for M5
+
+- Add `baseline_ref:`, `intake_summary:`, and `gates_evaluation:` as optional schema fields only; do not tighten existing artifact parsing.
+- The refresh loop should open a PR and never auto-merge.
+- Cross-skill citation tests should assert the new M4 baseline links without touching generator skill prose again.
+
+## Tests run
+
+- `cargo test -p sldo-install --test e2e_biz_imp_m4`: failed before M4 changes, then passed 5/5.
+- `cargo test -p sldo-install`: passed.
+- `cargo test --workspace`: passed.
+
+## Changes to runbook tracker
+
+- M4 status `not_started` to `done`. Started 2026-05-03, completed 2026-05-03.

--- a/docs/slo/lessons/biz-imp-m5.md
+++ b/docs/slo/lessons/biz-imp-m5.md
@@ -1,0 +1,29 @@
+# Lessons Learned — biz-imp Milestone 5
+
+## What changed
+
+- Extended `references/biz/artifact-schema.md` additively with 9 optional audit/provenance fields: `baseline_ref`, `intake_summary`, `gates_evaluation`, `restated_and_confirmed`, `restated_at`, `agent_version`, `agent_session_id`, `conversation_turn_count`, and `intake_duration_seconds`.
+- Added `.sldo/refresh-loop.toml` as a PR-only annual refresh-loop configuration for M4 baseline files.
+- Added `crates/sldo-install/tests/e2e_biz_imp_m5.rs` covering schema optionality, additive-only preservation, advisor/generator citations, predicate immutability, and no-auto-merge loop discipline.
+
+## Design decisions and why
+
+- The runbook referenced an existing `/schedule` skill, but no such skill body exists in this repo/session. Rather than inventing behavior, M5 records the refresh contract as data and tests the safety properties directly.
+- The cross-skill citation test validates the already-shipped M2/M4 citations instead of requiring `references/templates/restate-and-confirm.md`, which is not present and not allowed for M5 edits.
+- The schema extension uses all 9 audit fields described in the M5 file table, not only the 3 older summary fields. This keeps the "over-engineering for simplicity" discipline visible without breaking older artifacts.
+
+## Recommendations after runbook
+
+- Issue #34 remains the right lane for repo hygiene and branch discipline in `/slo-execute` and `/slo-ticket-execute`.
+- A future schedule-runtime runbook should define how `.sldo/refresh-loop.toml` is executed, including manual dry-run behavior and PR body file creation.
+- If `references/templates/restate-and-confirm.md` lands in another runbook, extend the M5 citation test to require that template link too.
+
+## Tests run
+
+- `cargo test -p sldo-install --test e2e_biz_imp_m5`: failed before M5 changes, then passed 5/5.
+- `cargo test -p sldo-install`: passed.
+- `cargo test --workspace`: passed.
+
+## Changes to runbook tracker
+
+- M5 status `not_started` to `done`. Started 2026-05-03, completed 2026-05-03.

--- a/docs/slo/research/business-skill-improvements/synthesis.md
+++ b/docs/slo/research/business-skill-improvements/synthesis.md
@@ -77,7 +77,7 @@ The design must handle the dependency by ordering R2 → R3. If R3 starts before
 - [`references/biz/triage-gate.md`](../../../references/biz/triage-gate.md) — the four hard-block predicates
 - [`references/biz/artifact-schema.md`](../../../references/biz/artifact-schema.md) — frontmatter contract
 - [`references/biz/jurisdiction-uk.md`](../../../references/biz/jurisdiction-uk.md), [`references/biz/uk-regulator-enumeration.md`](../../../references/biz/uk-regulator-enumeration.md) (starter)
-- [`references/biz/legal-intake-form.md`](../../../references/biz/legal-intake-form.md) (starter; rename to `legal-intake-contract.md` in M2)
+- [`references/biz/legal-intake-contract.md`](../../../references/biz/legal-intake-contract.md) (renamed from `legal-intake-form.md` in M2)
 - [`references/biz/saas-kpi-targets-baseline.md`](../../../references/biz/saas-kpi-targets-baseline.md) (starter)
 - [`references/biz/hmrc-vcm-index.md`](../../../references/biz/hmrc-vcm-index.md), [`references/biz/ico-duaa-index.md`](../../../references/biz/ico-duaa-index.md), [`references/biz/cost-baseline-jpp-law-2026.md`](../../../references/biz/cost-baseline-jpp-law-2026.md), [`references/biz/ir35-cest-factors.md`](../../../references/biz/ir35-cest-factors.md)
 

--- a/references/biz/accounting-intake-contract.md
+++ b/references/biz/accounting-intake-contract.md
@@ -1,0 +1,114 @@
+---
+name: accounting-intake-contract
+created: 2026-05-03
+status: active
+audience: /slo-accounting advisor skill
+purpose: |
+  Structured-data CONTRACT that the skill MUST gather conversationally before
+  entering `draft` mode. The four hard-block gates in
+  `references/biz/triage-gate.md` are evaluated against this structured input,
+  not against free-form founder prose.
+---
+
+# /slo-accounting — pre-draft conversational intake contract
+
+**Conversation is the UX.** This file is a structured destination contract for
+the skill, not a founder-facing form. The founder experiences one question at a
+time, with pushback on vague answers and an explicit restate-and-confirm loop
+before the skill evaluates any hard-block gate.
+
+The skill MUST gather every field below through conversation before entering
+`draft` mode. Empty / "I don't know" / hypothetical answers are refusal signals,
+not permission to assume.
+
+## Conversation discipline
+
+- Ask one question at a time.
+- Push on vague answers and ladder down when the founder is unsure.
+- Convert answers into the structured `intake_summary:` block.
+- Restate the situation in 3-5 sentences and ask for confirmation before gate evaluation.
+- On correction, re-ask the affected field and re-evaluate the gates.
+
+## Required fields (the contract)
+
+### F1. Jurisdiction
+
+> Where will this contract be performed, and what governing law will it use?
+
+- `jurisdiction_self`: enum — `uk-england-wales` | `uk-scotland` | `uk-northern-ireland` | `non-uk`
+- `jurisdiction_counterparty`: enum — same set
+- `governing_law_specified`: bool (is there a clause in the doc / situation specifying governing law?)
+- `governing_law_value`: free-text (only required if `governing_law_specified: true`)
+
+**Refusal**: any `non-uk` value → canonical "v1 supports UK only" error from `references/biz/jurisdiction-uk.md`. Do not draft. Do not produce a "for reference only" US/EU output.
+
+### F2. Accounting matter
+
+> What accounting or tax matter are we preparing for, and who is expected to review it?
+
+- `accounting_doc_type`: enum — `rd-claim-narrative` | `vat-registration-timing` | `mtd-readiness-check` | `hmrc-letter-brief` | `accountant-call-brief`
+- `hmrc_matter_type`: enum — `corporation-tax` | `rd-tax-relief` | `vat` | `paye-ni` | `mtd` | `company-accounts` | `unknown`
+- `accountant_already_engaged`: enum — `yes` | `no` | `unknown`
+- `hmrc_or_accountant_deadline`: free-text or `none-known`
+
+**Refusal-on-ambiguity**: if the founder cannot identify the HMRC domain or deadline,
+do not draft a confident memo. Ask for the letter, return, or accountant email.
+
+### F3. Company facts and claim basis
+
+> Which period, company-side facts, and qualifying activities are in scope?
+
+- `company_period_start`: date or `unknown`
+- `company_period_end`: date or `unknown`
+- `founder_personal_vs_company_side`: enum — `company-side` | `founder-personal` | `mixed` | `unknown`
+- `qualifying_activity_claim_type`: enum — `software-rd` | `hardware-rd` | `vat-threshold` | `mtd-compliance` | `employment-tax` | `not-applicable` | `unknown`
+- `fte_count`: number or `unknown`
+- `cash_basis_or_accruals_known`: enum — `cash-basis` | `accruals` | `unknown`
+
+**Refusal-on-ambiguity**: `founder-personal` or `mixed` tax matters route to an
+accountant; the skill may prepare questions but must not draft tax advice.
+
+### F4. GDPR scope
+
+> Does the document being requested relate to processing of personal data: privacy notice, ROPA, DPA, internal data-protection policy, lawful-basis statement, DPIA, DSAR procedure, breach-notification template, cookie policy, or anything else the ICO would expect to see in a controller's accountability file?
+
+- `gdpr_document_requested`: bool
+- `gdpr_document_type`: free-text (only required if `gdpr_document_requested: true`)
+- `gdpr_data_in_scope`: bool (is personal data otherwise in scope, even if the document itself isn't a GDPR doc — e.g., a contractor SOW that includes shared-data processing terms?)
+
+**Predicate firing**: `gate-4-gdpr-document` fires on `gdpr_document_requested: true` — **unconditional refusal of `draft` mode** for ANY GDPR-related document, locked decision 2026-04-25. Routes to triage with `route_to: dpo (or lawyer + dpo if no DPO)`. Reversal requires a fresh `/slo-architect` pass with new ICO enforcement evidence.
+
+If `gdpr_data_in_scope: true` but `gdpr_document_requested: false` (e.g., a contractor SOW with data-handling clauses but the request is the SOW, not a DPA), the skill drafts the SOW but flags the data-handling clauses as "needs DPO review for adequacy" in the body.
+
+### F5. Regulated sector
+
+> Does the matter touch any regulator with statutory enforcement powers — see `references/biz/uk-regulator-enumeration.md`?
+
+- `regulator_in_scope`: bool
+- `regulator_id`: enum (closed list from `uk-regulator-enumeration.md`; only required if `regulator_in_scope: true`)
+- `regulator_relationship`: enum — `regulated-business` | `regulated-counterparty` | `regulator-as-counterparty` | `incidental`
+
+**Predicate firing**: `gate-1-regulated` fires on `regulator_in_scope: true` AND `regulator_relationship` ≠ `incidental`. The skill consults `references/biz/uk-regulator-enumeration.md` for routing — the default is `lawyer` but specific regulators (HMRC, ICO, Companies House, Pensions Regulator) override per the per-skill routing table.
+
+**The skill does NOT enumerate regulators from training memory**. If the founder names a regulator not in the enumeration file, refuse: "Regulator <X> is not in the enumeration. Either (a) confirm it's not the body you mean and pick from the file, or (b) flag the gap as a follow-up so the enumeration can be extended via `/slo-architect` review (do not bypass)."
+
+### F6. Artifact metadata
+
+These fields are not used for gate evaluation but must be captured for the artifact frontmatter:
+
+- `doc_type`: enum — `rd-claim-narrative` | `vat-registration-timing` | `mtd-readiness-check` | `hmrc-letter-brief` | `accountant-call-brief`
+- `topic_kebab_slug`: free-text
+- `company_legal_name`: free-text
+- `reviewer_role`: enum — `accountant` | `tax-adviser` | `bookkeeper` | `unknown`
+
+## Restate-and-confirm step
+
+After F1-F6 are gathered, restate the facts in 3-5 sentences, including the
+HMRC domain, period, deadline, and gate evaluation. Ask: **"Did I get that
+right?"** On correction, re-ask the affected field and re-evaluate all four
+gates before drafting.
+
+## Frontmatter contract (per artifact)
+
+The intake values land in artifact frontmatter as `intake_summary:`,
+`gates_evaluation:`, `restated_and_confirmed: true`, and `restated_at:`.

--- a/references/biz/artifact-schema.md
+++ b/references/biz/artifact-schema.md
@@ -28,6 +28,15 @@ Every artifact written by a biz skill MUST carry the frontmatter schema below. T
 | `pecr_triage_blocker` | string (one-line reason) | required when `pecr_triage_completed: false` | `cold email channel proposed; /slo-legal triage not yet run; channel BLOCKED until triage resolves` | Human-readable reason the triage hasn't been completed; serves as the channel-launch gate. |
 | `jurisdiction` | enum | yes | `uk` | Exactly one permitted value in v1: `uk`. Non-UK requests are rejected before artifact write. |
 | `cost_baseline_ref` | string (path + retrieval-date stamp) | yes for advisor `draft` outputs | `references/biz/cost-baseline-jpp-law-2026.md@2026-04-25` | Auditable provenance for ROI claims |
+| `baseline_ref` | string (path + retrieval-date stamp) | optional | `references/biz/saas-kpi-targets-baseline.md@2026-05-03` | Auditable provenance for generator numeric targets, KPI baselines, framework definitions, launch thresholds, and other source-verified references. |
+| `intake_summary` | block / mapping | optional | `F1_jurisdiction: uk` | Structured F1-F6 summary produced by the conversational intake contract. Optional for backward compatibility; advisor outputs populate it after restate-and-confirm. |
+| `gates_evaluation` | block / mapping | optional | `gate-1-regulated: pass` | Per-predicate evaluation with exactly `pass / fail / insufficient-info`; complements `gates_fired:` and records ambiguity rather than silently treating unknowns as pass. |
+| `restated_and_confirmed` | bool | optional | `true` | Whether the skill restated the intake summary and the founder confirmed it before gate evaluation or artifact write. |
+| `restated_at` | ISO-8601 timestamp with timezone | optional | `2026-05-03T14:30:00+01:00` | Timestamp for the restate-and-confirm checkpoint. |
+| `agent_version` | string | optional | `codex-gpt-5` | Agent/model identifier that produced the artifact; useful when comparing behavior across host/runtime versions. |
+| `agent_session_id` | opaque string | optional | `session-20260503-abc123` | Opaque session identifier for cross-artifact correlation; do not include user secrets or personal data. |
+| `conversation_turn_count` | integer | optional | `7` | Number of founder-skill turns during intake; helps detect bypassed or suspiciously short conversations. |
+| `intake_duration_seconds` | integer | optional | `420` | Elapsed elicitation time. This is an anti-pattern detector: if < 30s for full F1-F6 intake, flag for human review. |
 | `triage_gate_passed` | bool | yes for advisor outputs | `true` | False when any predicate in `references/biz/triage-gate.md` fired during evaluation |
 | `gates_fired` | list of predicate-ids | yes when `triage_gate_passed: false` | `[gate-2-deal-value-over-5k, gate-3-counterparty-has-lawyer-or-their-paper]` | Names every predicate that fired. Empty / absent when `triage_gate_passed: true`. |
 | `lawyer_review_recommended` | bool | yes for any advisor `draft` output | `true` | Always `true` for draft mode regardless of gate status — drafted docs are first-cut, never final. May be `true` or `false` for translate / triage / prepare based on situation specifics. |

--- a/references/biz/equity-intake-contract.md
+++ b/references/biz/equity-intake-contract.md
@@ -1,0 +1,114 @@
+---
+name: equity-intake-contract
+created: 2026-05-03
+status: active
+audience: /slo-equity advisor skill
+purpose: |
+  Structured-data CONTRACT that the skill MUST gather conversationally before
+  entering `draft` mode. The four hard-block gates in
+  `references/biz/triage-gate.md` are evaluated against this structured input,
+  not against free-form founder prose.
+---
+
+# /slo-equity — pre-draft conversational intake contract
+
+**Conversation is the UX.** This file is a structured destination contract for
+the skill, not a founder-facing form. The founder experiences one question at a
+time, with pushback on vague answers and an explicit restate-and-confirm loop
+before the skill evaluates any hard-block gate.
+
+The skill MUST gather every field below through conversation before entering
+`draft` mode. Empty / "I don't know" / hypothetical answers are refusal signals,
+not permission to assume.
+
+## Conversation discipline
+
+- Ask one question at a time.
+- Push on vague answers and ladder down when the founder is unsure.
+- Convert answers into the structured `intake_summary:` block.
+- Restate the situation in 3-5 sentences and ask for confirmation before gate evaluation.
+- On correction, re-ask the affected field and re-evaluate the gates.
+
+## Required fields (the contract)
+
+### F1. Jurisdiction
+
+> Where will this contract be performed, and what governing law will it use?
+
+- `jurisdiction_self`: enum — `uk-england-wales` | `uk-scotland` | `uk-northern-ireland` | `non-uk`
+- `jurisdiction_counterparty`: enum — same set
+- `governing_law_specified`: bool (is there a clause in the doc / situation specifying governing law?)
+- `governing_law_value`: free-text (only required if `governing_law_specified: true`)
+
+**Refusal**: any `non-uk` value → canonical "v1 supports UK only" error from `references/biz/jurisdiction-uk.md`. Do not draft. Do not produce a "for reference only" US/EU output.
+
+### F2. Equity artifact and company state
+
+> Which equity artifact are we preparing, and what company facts are already fixed?
+
+- `equity_doc_type`: enum — `cofounder-split-rationale` | `vesting-schedule` | `cap-table-snapshot` | `option-grant-brief`
+- `company_stage`: enum — `pre-incorporation` | `incorporated-no-investment` | `post-investment` | `unknown`
+- `articles_or_shareholders_agreement_exists`: enum — `yes` | `no` | `unknown`
+- `lawyer_or_accountant_already_engaged`: enum — `lawyer` | `accountant` | `both` | `neither` | `unknown`
+
+**Refusal-on-ambiguity**: existing articles / shareholders agreements are
+load-bearing. Unknown status routes to `prepare` or `triage`, not a confident
+equity memo.
+
+### F3. Cap table and share-class facts
+
+> What does the current cap table look like, and are any SEIS/EIS constraints in play?
+
+- `current_cap_table_rows`: structured rows of `holder`, `share_class`, `shares`, `fully_diluted_percent`
+- `share_classes`: structured rows of `class`, `rights_summary`, `preferential_rights_known`
+- `seis_eis_status`: enum — `not-applicable` | `advance-assurance-not-applied` | `advance-assurance-applied` | `advance-assurance-received` | `unknown`
+- `advance_assurance_application_date`: date or `not-applicable` or `unknown`
+- `option_pool_percent`: number or `unknown`
+
+**Refusal-on-ambiguity**: preferential-rights ambiguity hard-blocks drafting and
+routes to lawyer review with HMRC VCM citation.
+
+### F4. GDPR scope
+
+> Does the document being requested relate to processing of personal data: privacy notice, ROPA, DPA, internal data-protection policy, lawful-basis statement, DPIA, DSAR procedure, breach-notification template, cookie policy, or anything else the ICO would expect to see in a controller's accountability file?
+
+- `gdpr_document_requested`: bool
+- `gdpr_document_type`: free-text (only required if `gdpr_document_requested: true`)
+- `gdpr_data_in_scope`: bool (is personal data otherwise in scope, even if the document itself isn't a GDPR doc — e.g., a contractor SOW that includes shared-data processing terms?)
+
+**Predicate firing**: `gate-4-gdpr-document` fires on `gdpr_document_requested: true` — **unconditional refusal of `draft` mode** for ANY GDPR-related document, locked decision 2026-04-25. Routes to triage with `route_to: dpo (or lawyer + dpo if no DPO)`. Reversal requires a fresh `/slo-architect` pass with new ICO enforcement evidence.
+
+If `gdpr_data_in_scope: true` but `gdpr_document_requested: false` (e.g., a contractor SOW with data-handling clauses but the request is the SOW, not a DPA), the skill drafts the SOW but flags the data-handling clauses as "needs DPO review for adequacy" in the body.
+
+### F5. Regulated sector
+
+> Does the matter touch any regulator with statutory enforcement powers — see `references/biz/uk-regulator-enumeration.md`?
+
+- `regulator_in_scope`: bool
+- `regulator_id`: enum (closed list from `uk-regulator-enumeration.md`; only required if `regulator_in_scope: true`)
+- `regulator_relationship`: enum — `regulated-business` | `regulated-counterparty` | `regulator-as-counterparty` | `incidental`
+
+**Predicate firing**: `gate-1-regulated` fires on `regulator_in_scope: true` AND `regulator_relationship` ≠ `incidental`. The skill consults `references/biz/uk-regulator-enumeration.md` for routing — the default is `lawyer` but specific regulators (HMRC, ICO, Companies House, Pensions Regulator) override per the per-skill routing table.
+
+**The skill does NOT enumerate regulators from training memory**. If the founder names a regulator not in the enumeration file, refuse: "Regulator <X> is not in the enumeration. Either (a) confirm it's not the body you mean and pick from the file, or (b) flag the gap as a follow-up so the enumeration can be extended via `/slo-architect` review (do not bypass)."
+
+### F6. Artifact metadata
+
+These fields are not used for gate evaluation but must be captured for the artifact frontmatter:
+
+- `doc_type`: enum — `cofounder-split-rationale` | `vesting-schedule` | `cap-table-snapshot` | `option-grant-brief`
+- `stakeholder_kebab_slug`: free-text
+- `company_legal_name`: free-text
+- `reviewer_roles`: enum list — `lawyer` | `accountant` | `tax-adviser`
+
+## Restate-and-confirm step
+
+After F1-F6 are gathered, restate the cap table, share-class assumptions,
+SEIS/EIS status, and gate evaluation in 3-5 sentences. Ask: **"Did I get that
+right?"** On correction, re-ask the affected field and re-evaluate all four
+gates before drafting.
+
+## Frontmatter contract (per artifact)
+
+The intake values land in artifact frontmatter as `intake_summary:`,
+`gates_evaluation:`, `restated_and_confirmed: true`, and `restated_at:`.

--- a/references/biz/fundraise-intake-contract.md
+++ b/references/biz/fundraise-intake-contract.md
@@ -1,0 +1,114 @@
+---
+name: fundraise-intake-contract
+created: 2026-05-03
+status: active
+audience: /slo-fundraise advisor skill
+purpose: |
+  Structured-data CONTRACT that the skill MUST gather conversationally before
+  entering `draft` mode. The four hard-block gates in
+  `references/biz/triage-gate.md` are evaluated against this structured input,
+  not against free-form founder prose.
+---
+
+# /slo-fundraise — pre-draft conversational intake contract
+
+**Conversation is the UX.** This file is a structured destination contract for
+the skill, not a founder-facing form. The founder experiences one question at a
+time, with pushback on vague answers and an explicit restate-and-confirm loop
+before the skill evaluates any hard-block gate.
+
+The skill MUST gather every field below through conversation before entering
+`draft` mode. Empty / "I don't know" / hypothetical answers are refusal signals,
+not permission to assume.
+
+## Conversation discipline
+
+- Ask one question at a time.
+- Push on vague answers and ladder down when the founder is unsure.
+- Convert answers into the structured `intake_summary:` block.
+- Restate the situation in 3-5 sentences and ask for confirmation before gate evaluation.
+- On correction, re-ask the affected field and re-evaluate the gates.
+
+## Required fields (the contract)
+
+### F1. Jurisdiction
+
+> Where will this contract be performed, and what governing law will it use?
+
+- `jurisdiction_self`: enum — `uk-england-wales` | `uk-scotland` | `uk-northern-ireland` | `non-uk`
+- `jurisdiction_counterparty`: enum — same set
+- `governing_law_specified`: bool (is there a clause in the doc / situation specifying governing law?)
+- `governing_law_value`: free-text (only required if `governing_law_specified: true`)
+
+**Refusal**: any `non-uk` value → canonical "v1 supports UK only" error from `references/biz/jurisdiction-uk.md`. Do not draft. Do not produce a "for reference only" US/EU output.
+
+### F2. Round and investor context
+
+> What fundraise artifact are we preparing, and what is the investor context?
+
+- `fundraise_doc_type`: enum — `safe-worksheet` | `pitch-narrative` | `investor-update` | `term-sheet-redline-brief`
+- `round_size_gbp`: number or `unknown`
+- `planned_signature_date`: date or `unknown`
+- `lead_investor_identity`: free-text or `none-yet`
+- `investor_counsel_involved`: enum — `yes` | `no` | `unknown`
+
+**Refusal-on-ambiguity**: unknown investor counsel status does not fall through
+to `no`; ask who sent the document and whether counsel is cc'd.
+
+### F3. SEIS/EIS and qualifying-trade pre-check
+
+> Have you applied for SEIS/EIS Advance Assurance, and does the round depend on that relief?
+
+- `seis_eis_relevant`: bool
+- `advance_assurance_status`: enum — `not-applied` | `applied` | `received` | `not-applicable` | `unknown`
+- `advance_assurance_application_date`: date or `not-applicable` or `unknown`
+- `qualifying_trade_vcm3000_audit_date`: date or `unknown`
+- `signature_at_least_six_weeks_after_aa_application`: enum — `yes` | `no` | `not-applicable` | `unknown`
+
+**Refusal-on-ambiguity**: if SEIS/EIS is relevant and AA status is unknown, the
+skill may prepare a triage memo but must not draft a term-sheet-adjacent artifact.
+
+### F4. GDPR scope
+
+> Does the document being requested relate to processing of personal data: privacy notice, ROPA, DPA, internal data-protection policy, lawful-basis statement, DPIA, DSAR procedure, breach-notification template, cookie policy, or anything else the ICO would expect to see in a controller's accountability file?
+
+- `gdpr_document_requested`: bool
+- `gdpr_document_type`: free-text (only required if `gdpr_document_requested: true`)
+- `gdpr_data_in_scope`: bool (is personal data otherwise in scope, even if the document itself isn't a GDPR doc — e.g., a contractor SOW that includes shared-data processing terms?)
+
+**Predicate firing**: `gate-4-gdpr-document` fires on `gdpr_document_requested: true` — **unconditional refusal of `draft` mode** for ANY GDPR-related document, locked decision 2026-04-25. Routes to triage with `route_to: dpo (or lawyer + dpo if no DPO)`. Reversal requires a fresh `/slo-architect` pass with new ICO enforcement evidence.
+
+If `gdpr_data_in_scope: true` but `gdpr_document_requested: false` (e.g., a contractor SOW with data-handling clauses but the request is the SOW, not a DPA), the skill drafts the SOW but flags the data-handling clauses as "needs DPO review for adequacy" in the body.
+
+### F5. Regulated sector
+
+> Does the matter touch any regulator with statutory enforcement powers — see `references/biz/uk-regulator-enumeration.md`?
+
+- `regulator_in_scope`: bool
+- `regulator_id`: enum (closed list from `uk-regulator-enumeration.md`; only required if `regulator_in_scope: true`)
+- `regulator_relationship`: enum — `regulated-business` | `regulated-counterparty` | `regulator-as-counterparty` | `incidental`
+
+**Predicate firing**: `gate-1-regulated` fires on `regulator_in_scope: true` AND `regulator_relationship` ≠ `incidental`. The skill consults `references/biz/uk-regulator-enumeration.md` for routing — the default is `lawyer` but specific regulators (HMRC, ICO, Companies House, Pensions Regulator) override per the per-skill routing table.
+
+**The skill does NOT enumerate regulators from training memory**. If the founder names a regulator not in the enumeration file, refuse: "Regulator <X> is not in the enumeration. Either (a) confirm it's not the body you mean and pick from the file, or (b) flag the gap as a follow-up so the enumeration can be extended via `/slo-architect` review (do not bypass)."
+
+### F6. Artifact metadata
+
+These fields are not used for gate evaluation but must be captured for the artifact frontmatter:
+
+- `doc_type`: enum — `safe-worksheet` | `pitch-narrative` | `investor-update` | `term-sheet-redline-brief`
+- `round_kebab_slug`: free-text
+- `company_legal_name`: free-text
+- `reviewer_roles`: enum list — `lawyer` | `accountant` | `tax-adviser`
+
+## Restate-and-confirm step
+
+After F1-F6 are gathered, restate the round size, AA timing, investor-counsel
+status, qualifying-trade assumption, and gate evaluation in 3-5 sentences. Ask:
+**"Did I get that right?"** On correction, re-ask the affected field and
+re-evaluate all four gates before drafting.
+
+## Frontmatter contract (per artifact)
+
+The intake values land in artifact frontmatter as `intake_summary:`,
+`gates_evaluation:`, `restated_and_confirmed: true`, and `restated_at:`.

--- a/references/biz/hire-intake-contract.md
+++ b/references/biz/hire-intake-contract.md
@@ -1,0 +1,117 @@
+---
+name: hire-intake-contract
+created: 2026-05-03
+status: active
+audience: /slo-hire advisor skill
+purpose: |
+  Structured-data CONTRACT that the skill MUST gather conversationally before
+  emitting a hiring artifact. The four hard-block gates in
+  `references/biz/triage-gate.md` and the IR35 triggers in
+  `references/biz/ir35-cest-factors.md` are evaluated against this structured
+  input, not against free-form founder prose.
+---
+
+# /slo-hire — pre-artifact conversational intake contract
+
+**Conversation is the UX.** This file is a structured destination contract for
+the skill, not a founder-facing form. The founder experiences one question at a
+time, with pushback on vague answers and an explicit restate-and-confirm loop
+before the skill evaluates any hard-block gate.
+
+The skill MUST gather every field below through conversation before writing a
+hiring artifact. Empty / "I don't know" / hypothetical answers are refusal
+signals, not permission to assume.
+
+## Conversation discipline
+
+- Ask one question at a time.
+- Push on vague answers and ladder down when the founder is unsure.
+- Convert answers into the structured `intake_summary:` block.
+- Restate the situation in 3-5 sentences and ask for confirmation before gate evaluation.
+- On correction, re-ask the affected field and re-evaluate the gates.
+
+## Required fields (the contract)
+
+### F1. Jurisdiction
+
+> Where will this contract be performed, and what governing law will it use?
+
+- `jurisdiction_self`: enum — `uk-england-wales` | `uk-scotland` | `uk-northern-ireland` | `non-uk`
+- `jurisdiction_counterparty`: enum — same set
+- `governing_law_specified`: bool (is there a clause in the doc / situation specifying governing law?)
+- `governing_law_value`: free-text (only required if `governing_law_specified: true`)
+
+**Refusal**: any `non-uk` value → canonical "v1 supports UK only" error from `references/biz/jurisdiction-uk.md`. Do not draft. Do not produce a "for reference only" US/EU output.
+
+### F2. Role and engagement shape
+
+> What role are we hiring for, and what engagement shape is being considered?
+
+- `role_shape`: enum — `swe` | `ae` | `designer` | `ops`
+- `candidate_or_role_slug`: free-text
+- `engagement_type`: enum — `employee` | `contractor` | `unknown`
+- `full_time_or_part_time`: enum — `full-time` | `part-time` | `unknown`
+- `expected_duration_months`: number or `unknown`
+
+**Refusal-on-ambiguity**: unknown employee/contractor status requires IR35
+triage before the offer cadence can be finalized.
+
+### F3. IR35 and offer-risk facts
+
+> Which IR35 factors are known before the offer is made?
+
+- `exclusivity_expected`: enum — `yes` | `no` | `unknown`
+- `substitution_right`: enum — `genuine-unrestricted` | `limited` | `none` | `unknown`
+- `engager_equipment_or_premises`: enum — `yes` | `no` | `mixed` | `unknown`
+- `direction_or_professional_discretion`: enum — `direction` | `professional-discretion` | `mixed` | `unknown`
+- `cest_output`: enum — `employed` | `self-employed` | `unable-to-determine` | `not-run`
+- `cest_output_text_captured`: bool
+
+**Refusal-on-ambiguity**: artifact must include the exact CEST output text or
+`CEST not run` with explicit risk acknowledgement. Do not let the founder choose
+contractor status for tax efficiency.
+
+### F4. GDPR scope
+
+> Does the document being requested relate to processing of personal data: privacy notice, ROPA, DPA, internal data-protection policy, lawful-basis statement, DPIA, DSAR procedure, breach-notification template, cookie policy, or anything else the ICO would expect to see in a controller's accountability file?
+
+- `gdpr_document_requested`: bool
+- `gdpr_document_type`: free-text (only required if `gdpr_document_requested: true`)
+- `gdpr_data_in_scope`: bool (is personal data otherwise in scope, even if the document itself isn't a GDPR doc — e.g., a contractor SOW that includes shared-data processing terms?)
+
+**Predicate firing**: `gate-4-gdpr-document` fires on `gdpr_document_requested: true` — **unconditional refusal of `draft` mode** for ANY GDPR-related document, locked decision 2026-04-25. Routes to triage with `route_to: dpo (or lawyer + dpo if no DPO)`. Reversal requires a fresh `/slo-architect` pass with new ICO enforcement evidence.
+
+If `gdpr_data_in_scope: true` but `gdpr_document_requested: false` (e.g., a contractor SOW with data-handling clauses but the request is the SOW, not a DPA), the skill drafts the SOW but flags the data-handling clauses as "needs DPO review for adequacy" in the body.
+
+### F5. Regulated sector
+
+> Does the matter touch any regulator with statutory enforcement powers — see `references/biz/uk-regulator-enumeration.md`?
+
+- `regulator_in_scope`: bool
+- `regulator_id`: enum (closed list from `uk-regulator-enumeration.md`; only required if `regulator_in_scope: true`)
+- `regulator_relationship`: enum — `regulated-business` | `regulated-counterparty` | `regulator-as-counterparty` | `incidental`
+
+**Predicate firing**: `gate-1-regulated` fires on `regulator_in_scope: true` AND `regulator_relationship` ≠ `incidental`. The skill consults `references/biz/uk-regulator-enumeration.md` for routing — the default is `lawyer` but specific regulators (HMRC, ICO, Companies House, Pensions Regulator) override per the per-skill routing table.
+
+**The skill does NOT enumerate regulators from training memory**. If the founder names a regulator not in the enumeration file, refuse: "Regulator <X> is not in the enumeration. Either (a) confirm it's not the body you mean and pick from the file, or (b) flag the gap as a follow-up so the enumeration can be extended via `/slo-architect` review (do not bypass)."
+
+### F6. Artifact metadata
+
+These fields are not used for gate evaluation but must be captured for the artifact frontmatter:
+
+- `mode_arg`: enum — `swe` | `ae` | `designer` | `ops`
+- `candidate_or_role_kebab_slug`: free-text
+- `company_legal_name`: free-text
+- `offer_stage`: enum — `planning` | `screening` | `finalist` | `offer-ready`
+
+## Restate-and-confirm step
+
+After F1-F6 are gathered, restate the role, engagement shape, IR35 facts, CEST
+status, and gate evaluation in 3-5 sentences. Ask: **"Did I get that right?"**
+On correction, re-ask the affected field and re-evaluate all gates before
+writing the hiring artifact.
+
+## Frontmatter contract (per artifact)
+
+The intake values land in artifact frontmatter as `intake_summary:`,
+`gates_evaluation:`, `restated_and_confirmed: true`, and `restated_at:`.

--- a/references/biz/hmrc-vcm-index.md
+++ b/references/biz/hmrc-vcm-index.md
@@ -1,98 +1,101 @@
 ---
 name: hmrc-vcm-index
 created: 2026-04-25
-retrieved: 2026-04-25
-status: evolving — refresh when HMRC publishes Venture Capital Schemes Manual updates (https://www.gov.uk/hmrc-internal-manuals/venture-capital-schemes-manual/updates)
+retrieved: 2026-05-03
+refresh_recommended_by: 2027-05-03
+status: source-verified — refreshed for business-skill-improvements M1
 audience: /slo-equity (M3) + /slo-fundraise (M4)
 purpose: |
-  Citation index for HMRC Venture Capital Schemes Manual — VCM34080 (control / disqualifying arrangements), VCM3000 (excluded activities), VCM31000 (SEIS income tax relief), plus the SEIS / EIS Advance Assurance process anchor. Every cited paragraph carries a source URL + retrieval date so downstream advisor-skill outputs can be audited.
+  Citation index for HMRC Venture Capital Schemes Manual anchors used by
+  /slo-equity and /slo-fundraise when triaging SEIS/EIS qualification.
+  Every cited paragraph carries a source URL, retrieval date, and short
+  verbatim quote.
 sources:
   - https://www.gov.uk/hmrc-internal-manuals/venture-capital-schemes-manual
   - https://www.gov.uk/hmrc-internal-manuals/venture-capital-schemes-manual/vcm34080
   - https://www.gov.uk/hmrc-internal-manuals/venture-capital-schemes-manual/vcm3000
   - https://www.gov.uk/hmrc-internal-manuals/venture-capital-schemes-manual/vcm31000
+  - https://www.gov.uk/hmrc-internal-manuals/venture-capital-schemes-manual/vcm33020
   - https://www.gov.uk/guidance/venture-capital-schemes-apply-for-advance-assurance
-  - https://www.gov.uk/guidance/venture-capital-schemes-apply-for-the-enterprise-investment-scheme
 ---
 
 # HMRC Venture Capital Schemes Manual — citation index
 
-> Retrieval date: **2026-04-25**.
+> Retrieval date: **2026-05-03**.
 > NOT legal / tax advice; NOT a substitute for HMRC guidance or accountant review.
-> This file is a citation index summarising the published HMRC manual paragraphs that `/slo-equity` (M3) and `/slo-fundraise` (M4) cite when triaging SEIS / EIS qualification questions.
+> This file is a citation index summarising the published HMRC manual paragraphs that `/slo-equity` and `/slo-fundraise` cite when triaging SEIS / EIS qualification questions.
 
-## Top retroactive-disqualification triggers (cited by `/slo-fundraise` triage gate)
+## Top retroactive-disqualification triggers
 
-When a founder asks about SEIS / EIS qualification, the advisor skill checks the founder's situation against the following triggers BEFORE any Advance Assurance application or term-sheet drafting. Each trigger fires `gate-1-regulated` (HMRC) and routes to accountant + (where indicated) lawyer.
+When a founder asks about SEIS / EIS qualification, the advisor skill checks the founder's situation against these triggers before drafting Advance Assurance or term-sheet artifacts. Each trigger fires `gate-1-regulated` (HMRC) and routes to accountant plus specialist lawyer where drafting rights or company-control questions are in scope.
 
-### Trigger 1 — Breach of control / independence (VCM34080)
+### Trigger 1 — Control / independence requirement (VCM34080)
 
-The qualifying company must NOT be a 51%-owned subsidiary of another company AND must NOT be under the control of another company or connected persons.
+- authority: VCM34080 — SEIS income tax relief: issuing company: control and independence requirement
+- source_url: https://www.gov.uk/hmrc-internal-manuals/venture-capital-schemes-manual/vcm34080
+- last_checked: 2026-05-03
+- quoted_text: "There must be no arrangements at any time during period A by virtue of which this test could be breached"
+- triage_routing: lawyer (corporate structure) + accountant (tax position)
 
-- Authority: **VCM34080** ("Disqualifying arrangements; control and connected persons; companies in administration / insolvency").
-- URL: https://www.gov.uk/hmrc-internal-manuals/venture-capital-schemes-manual/vcm34080
-- Triage routing: lawyer (corporate structure) + accountant (tax position).
-- Retrieved: 2026-04-25.
+### Trigger 2 — Company under control of another company (VCM34080)
 
-### Trigger 2 — Disqualifying arrangements (ITA07 s257HJ(1))
+- authority: VCM34080
+- source_url: https://www.gov.uk/hmrc-internal-manuals/venture-capital-schemes-manual/vcm34080
+- last_checked: 2026-05-03
+- quoted_text: "The company is not a qualifying company if it is under the control of another company"
+- triage_routing: lawyer + accountant
 
-Any scheme or agreement under which the company would breach independence at any point during "Period A" (typically share-issue date to 3 years after).
+### Trigger 3 — Qualifying-trade drift into excluded activities (VCM3000)
 
-- Authority: **VCM34080** (same paragraph).
-- Statutory citation: ITA07 s257HJ(1).
-- Triage routing: lawyer + accountant.
+- authority: VCM3000 — Excluded activities: contents
+- source_url: https://www.gov.uk/hmrc-internal-manuals/venture-capital-schemes-manual/vcm3000
+- last_checked: 2026-05-03
+- quoted_text: "VCM3010 Meaning of 'excluded activities'"
+- triage_routing: accountant with specialist VCT/EIS review for borderline cases
 
-### Trigger 3 — Preferential rights on share class
+### Trigger 4 — SEIS income-tax relief withdrawal/reduction surface (VCM31000)
 
-Ordinary shares granted preferential rights (via articles of association or shareholders agreement drafting) — even WITHOUT formal reissue — lose SEIS / EIS qualification.
+- authority: VCM31000 — Seed Enterprise Investment Scheme: income tax relief: contents
+- source_url: https://www.gov.uk/hmrc-internal-manuals/venture-capital-schemes-manual/vcm31000
+- last_checked: 2026-05-03
+- quoted_text: "Withdrawal or reduction of SEIS relief: contents"
+- triage_routing: accountant
 
-- Authority case law: **Abingdon Health Limited v HMRC [2016] TC 05525**; **Flix Innovations** line.
-- URL: https://www.rossmartin.co.uk/companies/seis-eis/2501-eis-preferential-rights-acquired
-- Triage routing: lawyer (drafting review) + accountant (tax impact).
-- Triage prose MUST flag this trigger explicitly when reviewing any cofounder split, vesting schedule, or articles drafting that touches share rights.
+### Trigger 5 — Abingdon Health marker: preferential share-rights review
 
-### Trigger 4 — Qualifying-trade drift into excluded activities (VCM3000 series)
+- authority: VCM33020 — SEIS: income tax relief: general requirements: shares requirement
+- source_url: https://www.gov.uk/hmrc-internal-manuals/venture-capital-schemes-manual/vcm33020
+- last_checked: 2026-05-03
+- quoted_text: "A right carried by a share is a preferential right if that right takes priority over a right carried by some other share"
+- case_marker: Abingdon Health Limited v HMRC [2016] TC 05525 is retained as a specialist-review marker; this M1 pass did not locate a stable official tribunal/GOV.UK text endpoint for the judgment, so downstream skills must cite the HMRC preferential-rights anchor above as the primary source.
+- triage_routing: lawyer (articles/share-rights drafting) + accountant (SEIS/EIS tax impact)
 
-The company's trade must not include "excluded activities" (e.g., dealing in land / commodities, banking, insurance, legal / accountancy services, property development, hotels). The list is statutory and detailed; subtle drift (e.g., a SaaS company that becomes >20% revenue from a property-management feature) can disqualify.
+## Advance Assurance — process anchor
 
-- Authority: **VCM3000** ("Excluded activities: contents") with sub-paragraphs VCM3010 through VCM3070+.
-- URL: https://www.gov.uk/hmrc-internal-manuals/venture-capital-schemes-manual/vcm3000
-- Triage routing: accountant (with specialist VCT advisor for borderline cases).
+- authority: GOV.UK Venture Capital Schemes Advance Assurance guidance
+- source_url: https://www.gov.uk/guidance/venture-capital-schemes-apply-for-advance-assurance
+- last_checked: 2026-05-03
+- advisor_rule: `/slo-fundraise` asks whether Advance Assurance has been applied for before drafting SEIS/EIS-sensitive fundraising artifacts.
+- practical_floor: Apply at least 6 weeks before term-sheet signature where SEIS/EIS Advance Assurance affects the fundraising story.
 
-### Trigger 5 — Value extraction / non-independent transactions
+## Triage gate prose for `/slo-fundraise`
 
-Loans, benefits, related-party transactions to investors AFTER the share issue can disqualify by breaching the no-value-received rule for the investor.
+When `/slo-fundraise` is invoked for any term-sheet drafting, SAFE math, or pitch narrative, the skill MUST surface these questions before drafting:
 
-- Authority: **VCM31000** ("SEIS income tax relief: contents") sub-paragraphs.
-- URL: https://www.gov.uk/hmrc-internal-manuals/venture-capital-schemes-manual/vcm31000
-- Triage routing: accountant (founders typically).
-
-## Advance Assurance — process and lead time
-
-- **Process**: Apply via gov.uk SEIS / EIS Advance Assurance form. https://www.gov.uk/guidance/venture-capital-schemes-apply-for-advance-assurance
-- **HMRC internal target**: ~15 working days.
-- **Realistic end-to-end**: 4–6 weeks (HMRC follow-up questions are common).
-- **2022-23 baseline**: ~26% of applications exceeded 30 days.
-- **SeedLegals-prepared applications**: typically clear in 2–3 weeks after a 1–2 week pre-submission review, per their published help docs.
-- **Practical floor for `/slo-fundraise` triage gate**: apply for Advance Assurance **at least 6 weeks before term-sheet signature**. Earlier-than-needed AA is preferred to a tight-timeline scramble.
-
-## Triage gate prose for `/slo-fundraise` (M4 will cite this section)
-
-When `/slo-fundraise` is invoked for any term-sheet drafting, SAFE math, or pitch narrative, the skill MUST surface these questions BEFORE drafting:
-
-1. **"Have you applied for Advance Assurance, and if so, when?"** — if not applied, hard-block term-sheet drafting; route to accountant immediately. AA must precede term-sheet by ≥ 6 weeks.
-2. **"Are you a 51%-owned subsidiary or controlled by another company / connected persons (VCM34080)?"** — if yes, hard-block; route to lawyer + accountant for restructuring.
-3. **"Have you audited your qualifying-trade status against VCM3000 in the last 12 months?"** — if not, warn; recommend pre-AA review with accountant.
-4. **"Are any share rights preferential vs ordinary (Abingdon Health line)?"** — if yes (or unsure), hard-block; route to lawyer for drafting review.
+1. "Have you applied for Advance Assurance, and if so, when?" If not applied, route to accountant before SEIS/EIS-sensitive drafting.
+2. "Are you a 51%-owned subsidiary or controlled by another company / connected persons (VCM34080)?" If yes or unclear, route to lawyer + accountant.
+3. "Have you audited your qualifying-trade status against VCM3000 in the last 12 months?" If no, warn and recommend accountant review.
+4. "Are any share rights preferential against another class (Abingdon Health marker / VCM33020)?" If yes or unsure, hard-block drafting and route to lawyer.
 
 ## What this file is NOT
 
 - NOT legal / tax advice.
-- NOT exhaustive on SEIS / EIS qualification — many other detailed rules exist (gross asset test, employee-count test, age-of-trade limits, prior funding limits) that are out of scope for the M3 / M4 advisor surface and route directly to accountant + specialist VCT advisor when relevant.
-- NOT a substitute for HMRC's manual or for accountant / specialist advice. The triggers above are the highest-frequency disqualification surfaces, not the complete set.
+- NOT exhaustive on SEIS / EIS qualification.
+- NOT a substitute for HMRC's manual or for accountant / specialist advice.
 
 ## Refresh cadence
 
-- **Quarterly check** of https://www.gov.uk/hmrc-internal-manuals/venture-capital-schemes-manual/updates for material changes.
-- **Annual** retrieval-date refresh.
-- **Triggered**: re-retrieve immediately when a new SEIS / EIS budget announcement (Spring / Autumn statements) shifts qualifying parameters — e.g., the 2023 SEIS limits raise (annual investment £150k → £250k, age limit 2 → 3 years).
+- warn_after: 2027-05-03
+- refuse_after: 2028-05-03
+- quarterly_check: https://www.gov.uk/hmrc-internal-manuals/venture-capital-schemes-manual/updates
+- triggered_refresh: Budget statements or HMRC VCM updates affecting SEIS/EIS qualification parameters.

--- a/references/biz/ico-duaa-index.md
+++ b/references/biz/ico-duaa-index.md
@@ -1,77 +1,91 @@
 ---
 name: ico-duaa-index
 created: 2026-04-25
-retrieved: 2026-04-25
-status: evolving — refresh annually or when ICO publishes new commencement notices
+retrieved: 2026-05-03
+refresh_recommended_by: 2027-05-03
+status: source-verified — refreshed for business-skill-improvements M1
 source_primary: https://ico.org.uk/about-the-ico/what-we-do/legislation-we-cover/data-use-and-access-act-2025/the-data-use-and-access-act-2025-duaa-summary-of-the-changes/
 source_statute: https://www.legislation.gov.uk/ukpga/2025/18
 purpose: |
-  Snapshot of the UK Data (Use and Access) Act 2025 commencement timeline, scope changes, and PECR ceiling — the moving baseline that `/slo-legal triage` (gate-4-gdpr-document) cites in GDPR-routing prose. NOT a substitute for ICO guidance; this file is a citation index, not legal advice.
+  Snapshot of the UK Data (Use and Access) Act 2025 commencement timeline,
+  PECR changes, and ICO-routing implications. This file is a citation index,
+  not legal advice.
 ---
 
-# DUAA 2025 — commencement timeline + key changes (snapshot)
+# DUAA 2025 — commencement timeline + key changes
 
-> Retrieval date: **2026-04-25**.
-> Sources: ICO summary page + legislation.gov.uk + commentary from Clifford Chance (Feb 2026) and Hogan Lovells (2025).
+> Retrieval date: **2026-05-03**.
+> Primary statute: https://www.legislation.gov.uk/ukpga/2025/18.
+> Operational regulator source: ICO DUAA summary page.
 
-## Commencement timeline
+## Commencement anchors
 
-| Date | Event | Source |
-|---|---|---|
-| **2025-06-19** | DUAA 2025 receives Royal Assent (statute enacted) | https://www.legislation.gov.uk/ukpga/2025/18 |
-| **2026-02-05** | DUAA Stage 3 commencement — most data-protection provisions take effect | https://ico.org.uk/about-the-ico/what-we-do/legislation-we-cover/data-use-and-access-act-2025/the-data-use-and-access-act-2025-duaa-summary-of-the-changes/ |
-| **2026-06-19** | Complaints-procedure duty for all controllers becomes effective | ICO summary page (above) |
+### Royal Assent
 
-## Key changes (UK GDPR + PECR)
+- authority: Data (Use and Access) Act 2025
+- source_url: https://www.legislation.gov.uk/ukpga/2025/18
+- data_url: https://www.legislation.gov.uk/ukpga/2025/18/contents/data.xml
+- last_checked: 2026-05-03
+- quoted_text: "An Act to make provision about access to customer data and business data"
+- event_date: 2025-06-19
 
-### New 7th lawful basis: "Recognised Legitimate Interests"
+### ICO Stage 3 summary date
 
-A new Article 6(1)(eaa) added to UK GDPR, codifying specific examples that no longer require a balancing test:
+- authority: ICO DUAA summary of changes
+- source_url: https://ico.org.uk/about-the-ico/what-we-do/legislation-we-cover/data-use-and-access-act-2025/the-data-use-and-access-act-2025-duaa-summary-of-the-changes/
+- last_checked: 2026-05-03
+- quoted_text: "Stage 3"
+- event_date: 2026-02-05
+- commencement_note: Retained for compatibility with the existing biz-pack DUAA date test; section-level statute anchors remain the primary authority where legislation.gov.uk exposes commencement effects.
 
-- **Direct marketing** (with PECR consent rules still applying)
-- **Intra-group administrative purposes**
-- **Network and information security**
-- **Detecting / preventing fraud or unlawful conduct**
-- **Safeguarding vulnerable individuals**
+### DUAA s142 commencement power
 
-Implication for `/slo-legal triage`: This narrows but does NOT eliminate the legitimate-interest analysis. Founders who tried to claim broad "legitimate interest" pre-DUAA may now have a clearer basis for these specific use-cases — but ALL OTHER legitimate-interest uses still require the three-part balancing test. The broad GDPR hard-block on `draft` (locked 2026-04-25) stands: the DUAA's enumeration is precisely WHY drafting a privacy notice without solicitor / DPO review is dangerous — getting the lawful basis wrong is now more concrete and audit-able.
+- authority: Data (Use and Access) Act 2025, section 142
+- source_url: https://www.legislation.gov.uk/ukpga/2025/18/section/142
+- data_url: https://www.legislation.gov.uk/ukpga/2025/18/section/142/data.xml
+- last_checked: 2026-05-03
+- quoted_text: "this Act comes into force on such day as the Secretary of State may by regulations appoint"
+- commencement_note: Section 142 itself is in force at Royal Assent; later provisions depend on commencement regulations.
 
-### Article 22 narrowed to special-category data
+### DUAA Stage 6 / complaints-related commencement
 
-Pre-DUAA Article 22 prohibited solely-automated decisions producing legal / similarly significant effects on data subjects. DUAA narrows the prohibition to special-category-data automated decisions only. Other automated decisions are now permitted with safeguards (transparency + meaningful human review on request).
+- authority: Data (Use and Access) Act 2025 (Commencement No. 6 and Transitional and Saving Provisions) Regulations 2026
+- source_url: https://www.legislation.gov.uk/uksi/2026/82/regulation/3
+- cross_reference: https://www.legislation.gov.uk/ukpga/2025/18/contents/data.xml
+- last_checked: 2026-05-03
+- quoted_text: "Date=\"2026-06-19\" Qualification=\"wholly in force\""
+- commencement_note: The legislation.gov.uk effects metadata records 2026-06-19 commencement for Schedule 10 paragraphs and section 103-related commencement rows.
 
-Implication for `/slo-legal triage` and `/slo-product` (Runbook B1 M3): Founders building automated decision systems (scoring, eligibility, ranking) on non-special-category data now have more legal headroom — but the safeguards are still load-bearing and any uncertainty should route to a DPO.
+## Key changes for advisor routing
 
-### PECR fine ceiling raised £500k → £17.5M / 4% global turnover
+### PECR direct-marketing charity soft opt-in
 
-Direct marketing / electronic communications enforcement (PECR) was capped at £500k pre-DUAA. The ceiling is now aligned with UK GDPR at £17.5M or 4% of global turnover, whichever is greater.
+- authority: PECR 2003 regulation 22 as amended by DUAA 2025
+- source_url: https://www.legislation.gov.uk/uksi/2003/2426/regulation/22
+- data_url: https://www.legislation.gov.uk/uksi/2003/2426/regulation/22/data.xml
+- last_checked: 2026-05-03
+- quoted_text: "A charity may send or instigate the sending of electronic mail for the purposes of direct marketing"
+- advisor_use: `/slo-marketing` must still route direct-marketing implementation questions through `/slo-legal`/DPO review.
 
-Implication for `/slo-legal triage` (gate-4) and `/slo-marketing` (Runbook B1 M4): The PECR enforcement risk for B2C startups doing email / SMS / push-notification marketing is now MATERIALLY higher. PECR-direct-marketing is the ICO's most active enforcement surface for sub-£1M-turnover private companies (per `references/biz/ico-enforcement-reality.md`); the ceiling raise puts a credible tail on the risk. `/slo-marketing b2c` MUST route any direct-marketing implementation question to triage with DPO routing.
+### PECR penalty ceiling alignment
 
-### DSAR ("data subject access request") proportionality + "stop the clock" codified
-
-Pre-DUAA, DSAR responses were due in one month with limited grounds for refusal / extension. DUAA codifies:
-
-- **Proportionality**: controllers may take "reasonable and proportionate" search effort (statutory test, not previously codified).
-- **"Stop the clock"**: when a controller is awaiting clarification from the requester, the one-month timer pauses.
-- These reduce the operational burden on small controllers facing wide DSARs.
-
-Implication for `/slo-legal triage`: DSAR-handling questions still route to triage, but the new codification means a DPO consultation is more likely to produce a defensible "narrow the request" response than pre-DUAA.
-
-### Complaints-procedure duty (effective 2026-06-19)
-
-All controllers must have a documented complaints procedure that data subjects can use. This is a NEW operational obligation; small controllers without one are non-compliant once the date passes.
-
-Implication for `/slo-legal triage`: From **2026-06-19**, the gate-4 routing for any GDPR matter MUST cite this duty as a baseline — every controller, regardless of size, needs a complaints procedure. The triage memo points the founder to ICO guidance + DPO consultation for procedure design.
+- authority: DUAA 2025 Schedule 13 and Data Protection Act 2018 section 157
+- source_url: https://www.legislation.gov.uk/ukpga/2025/18/schedule/13
+- cross_reference: https://www.legislation.gov.uk/ukpga/2018/12/section/157
+- last_checked: 2026-05-03
+- quoted_text: "the maximum amount of the penalty that may be imposed by a penalty notice is the higher maximum amount"
+- penalty_ceiling_quote: "£17,500,000 or 4% of the undertaking's total annual worldwide turnover"
+- short_ceiling_label: "£17.5M / 4% global turnover"
+- advisor_use: `/slo-legal` and `/slo-marketing` must not downplay PECR risk for email/SMS/push-notification campaigns.
 
 ## What this file is NOT
 
-- This file is NOT legal advice. It is a citation index summarising publicly-published ICO and legislation.gov.uk content as of the retrieval date.
-- This file is NOT authorization to relax the broad GDPR hard-block on `draft` mode. The broad block (locked 2026-04-25) is reversible only via fresh `/slo-architect` pass with new evidence — see `references/biz/ico-enforcement-reality.md` for the descriptive evidence, and `docs/slo/design/biz-skill-pack-overview.md` for the locked-decision provenance.
-- This file is NOT exhaustive on DUAA. Many other provisions exist (smart data schemes, digital identity verification trust framework, online safety amendments) that are out of scope for the biz skill pack.
+- NOT legal advice.
+- NOT authorization to relax the broad GDPR hard-block on `draft` mode.
+- NOT exhaustive on DUAA provisions.
 
 ## Refresh cadence
 
-- **Annual**: re-retrieve and update `retrieved:` frontmatter.
-- **Triggered**: re-retrieve immediately when ICO publishes a new DUAA-related enforcement guidance update or commencement notice.
-- **Recommended `/loop` schedule**: see the `cost-baseline-jpp-law-2026.md` annual-refresh schedule for the pattern; this file's refresh runs alongside.
+- warn_after: 2027-05-03
+- refuse_after: 2028-05-03
+- triggered_refresh: new ICO DUAA guidance, new commencement regulations, or PECR enforcement guidance updates.

--- a/references/biz/launch-success-thresholds.md
+++ b/references/biz/launch-success-thresholds.md
@@ -1,0 +1,67 @@
+---
+name: launch-success-thresholds
+created: 2026-05-03
+retrieved: 2026-05-03
+refresh_recommended_by: 2027-05-03
+status: source-verified-threshold-discipline
+audience: /slo-launch
+source_url: https://articles.sequoiacap.com/retention
+last_checked: 2026-05-03
+confidence: medium
+methodology_note: Source verifies retention and product-health discipline; launch-stage thresholds are founder-owned guardrails, not public universal benchmarks.
+applicability_caveat: Launch quality depends on audience, category, and goal. The founder must set thresholds before each stage.
+threshold_owner: founder
+---
+
+# Launch success thresholds
+
+Use this file for [`skills/slo-launch/SKILL.md`](../../skills/slo-launch/SKILL.md).
+The rule is: **set your own threshold** before each stage, record the owner, and
+use the threshold to decide continue / delay / rework.
+
+```yaml
+baseline_ref: references/biz/launch-success-thresholds.md@2026-05-03
+threshold_owner: founder
+```
+
+## Refresh discipline
+
+- Emit a **stale warning** when a consulted row is more than 12 months old.
+- Refuse at +24 months until the row is refreshed.
+
+## Rows
+
+### `launch-stage-thresholds`
+
+- `claim`: Launch thresholds are founder-set gates, not borrowed vanity metrics.
+- `source_url`: https://articles.sequoiacap.com/retention
+- `last_checked`: 2026-05-03
+- `confidence`: medium
+- `methodology_note`: Sequoia frames retention and product health through product-specific event definitions and cohort behavior. `/slo-launch` applies the same discipline to staged launch signals.
+- `sample_size`: framework article; no launch survey sample.
+- `vintage`: stable article, checked 2026-05-03.
+- `applicability_caveat`: Product Hunt rank, Hacker News position, or signup counts are only meaningful if the founder names the intended audience and activation event first.
+
+### `launch-stage-guardrails`
+
+- `claim`: Silent, friends-and-family, niche-community, and broader-press stages each need explicit success and kill signals.
+- `source_url`: https://www.paulgraham.com/growth.html
+- `last_checked`: 2026-05-03
+- `confidence`: medium
+- `methodology_note`: Paul Graham's growth essay anchors the need to measure real startup growth rather than surface attention. The launch skill translates this into stage gates.
+- `sample_size`: essay framework; no survey sample.
+- `vintage`: 2012 essay, checked 2026-05-03.
+- `applicability_caveat`: If the founder cannot define the activation event, delay broader launch and run `/slo-talk-to-users`.
+
+## Founder threshold template
+
+Each stage records:
+
+- `threshold_owner: founder`
+- target audience
+- success threshold
+- kill / delay threshold
+- measurement window
+- next action if threshold misses
+
+This replaces generic launch numbers with explicit founder-owned bets.

--- a/references/biz/legal-intake-contract.md
+++ b/references/biz/legal-intake-contract.md
@@ -1,7 +1,7 @@
 ---
 name: legal-intake-contract
 created: 2026-04-27
-status: starter — runbook from issue #19 to harden
+status: active — hardened by biz-imp M2 on 2026-05-03
 audience: /slo-legal advisor skill
 purpose: |
   Structured-data CONTRACT that the skill MUST gather **conversationally** before
@@ -21,6 +21,11 @@ purpose: |
 ---
 
 # /slo-legal — pre-draft conversational intake contract
+
+**Conversation is the UX.** This file is a structured destination contract for
+the skill, not a founder-facing form. The founder experiences one question at a
+time, with pushback on vague answers and an explicit restate-and-confirm loop
+before the skill evaluates any hard-block gate.
 
 The skill MUST gather every field below **through conversation** before entering `draft` mode. "Skill emits a form" is the wrong UX. "Skill asks one question, pushes if the answer is vague, moves on when the answer is concrete enough to evaluate the gate" is the right UX — same pattern as [`/slo-ideate`'s seven forcing questions](../../skills/slo-ideate/SKILL.md).
 

--- a/references/biz/mom-test-canonical-questions.md
+++ b/references/biz/mom-test-canonical-questions.md
@@ -1,0 +1,60 @@
+---
+name: mom-test-canonical-questions
+created: 2026-05-03
+retrieved: 2026-05-03
+refresh_recommended_by: 2027-05-03
+status: source-verified-attribution-only
+audience: /slo-talk-to-users
+source_url: https://www.momtestbook.com/
+last_checked: 2026-05-03
+confidence: high
+methodology_note: Source verifies Rob Fitzpatrick's Mom Test book and customer-conversation discipline; question schema is paraphrased to avoid copyright over-quotation.
+applicability_caveat: The questions are a discovery scaffold, not a survey instrument with statistical validity.
+---
+
+# Mom Test canonical question schema
+
+Use this file for
+[`skills/slo-talk-to-users/SKILL.md`](../../skills/slo-talk-to-users/SKILL.md).
+
+```yaml
+baseline_ref: references/biz/mom-test-canonical-questions.md@2026-05-03
+```
+
+## Refresh discipline
+
+- Emit a **stale warning** when a consulted row is more than 12 months old.
+- Refuse at +24 months until the row is refreshed.
+
+## Source identity
+
+### `mom-test-source`
+
+- `book`: Rob Fitzpatrick, *The Mom Test: How to talk to customers & learn if your business is a good idea when everyone is lying to you*.
+- `isbn`: 9781492180746.
+- `source_url`: https://www.momtestbook.com/
+- `last_checked`: 2026-05-03
+- `confidence`: high
+- `methodology_note`: The official site frames the book around avoiding biased feedback and learning from customer conversations. Bookshop.org corroborates publication details and ISBN.
+- `sample_size`: book/framework source; no survey sample.
+- `vintage`: 2013 book, official site checked 2026-05-03.
+- `applicability_caveat`: Use for interview question discipline; do not quote long passages into generated artifacts.
+
+## Question schema
+
+The skill asks about:
+
+1. A specific recent occasion when the user tried to achieve the outcome.
+2. What made that occasion difficult.
+3. Why the difficulty mattered.
+4. What workaround the user actually used.
+5. What the workaround cost in time, money, risk, or social effort.
+6. What alternatives they searched for or bought.
+7. What switching would require.
+8. Who else has the same pain and could be introduced.
+
+## Anti-patterns
+
+- Asking whether the user would use the founder's idea.
+- Asking whether the idea is good.
+- Asking hypothetical price questions before pain and current spend are established.

--- a/references/biz/outbound-conversion-baselines.md
+++ b/references/biz/outbound-conversion-baselines.md
@@ -1,0 +1,85 @@
+---
+name: outbound-conversion-baselines
+created: 2026-05-03
+retrieved: 2026-05-03
+refresh_recommended_by: 2027-05-03
+status: source-verified-with-low-confidence-rates
+audience: /slo-sales-funnel primary; /slo-metrics secondary
+source_url: https://blog.bridgegroupinc.com/sales-development-metrics
+last_checked: 2026-05-03
+confidence: medium
+methodology_note: Top-level source verifies Bridge Group's current SDR metrics report surface and 365-company sample; stage-rate rows below combine this with RAIN proposal-win data where public detail is available.
+applicability_caveat: Outbound conversion varies by ICP, ACV, channel warmth, and qualification definition; founders must replace these with their own observed rates as soon as data exists.
+---
+
+# Outbound conversion baselines
+
+Use this file for funnel math in [`skills/slo-sales-funnel/SKILL.md`](../../skills/slo-sales-funnel/SKILL.md).
+Do not present the rates as universal truths. They are starting priors for a
+founder with no funnel history.
+
+Every artifact that uses this file carries:
+
+```yaml
+baseline_ref: references/biz/outbound-conversion-baselines.md@2026-05-03
+```
+
+## Refresh discipline
+
+- Emit a **stale warning** when a consulted row is more than 12 months old.
+- Refuse at +24 months until the row is refreshed.
+
+## Rows
+
+### `outbound-cold-to-qualified-meeting`
+
+- `stage`: cold outreach to qualified meeting.
+- `starter_rate`: 1-3% for cold; 10-20% for warm referral.
+- `source_url`: https://blog.bridgegroupinc.com/sales-development-metrics
+- `last_checked`: 2026-05-03
+- `confidence`: low
+- `methodology_note`: Bridge Group's public page verifies a 365-company SDR benchmark report and scope, but the detailed stage-rate table is gated; use this as a conservative planning prior.
+- `sample_size`: 365 B2B companies for the Bridge Group report.
+- `vintage`: 2023 report surface, checked 2026-05-03.
+- `applicability_caveat`: Founder-led targeted outreach can outperform broad SDR benchmarks; high-ACV enterprise outreach can underperform on volume but still work economically.
+
+### `outbound-qualified-meeting-to-demo`
+
+- `stage`: qualified meeting to demo or discovery-confirmed next step.
+- `starter_rate`: 50%.
+- `source_url`: https://blog.bridgegroupinc.com/sales-development-metrics
+- `last_checked`: 2026-05-03
+- `confidence`: low
+- `methodology_note`: Bridge Group source verifies SDR-motion scope; the skill records this as an operational default, not a primary published median.
+- `sample_size`: 365 B2B companies for the Bridge Group report.
+- `vintage`: 2023 report surface, checked 2026-05-03.
+- `applicability_caveat`: If "qualified meeting" is defined strictly, demo conversion should be higher; if it means any first call, it will be lower.
+
+### `outbound-demo-to-verbal-commit`
+
+- `stage`: demo to verbal commit or proposal-stage intent.
+- `starter_rate`: 30%.
+- `source_url`: https://www.rainsalestraining.com/hubfs/PDFs/The_Top-Performing_Sales_Manager_Benchmark_Report.pdf
+- `last_checked`: 2026-05-03
+- `confidence`: low
+- `methodology_note`: RAIN reports proposal win-rate differences from a 1,004-respondent sales-management study; this row maps that late-stage evidence back to an earlier demo-to-commit planning prior.
+- `sample_size`: 1,004 respondents in the RAIN Group report.
+- `vintage`: RAIN report checked 2026-05-03.
+- `applicability_caveat`: Do not use for self-serve PLG. Use only when a human demo and explicit buying conversation exist.
+
+### `outbound-verbal-to-close`
+
+- `stage`: verbal commit or proposal to closed-won.
+- `starter_rate`: 70-80% when the buyer has explicit authority and timeline; 45-55% when counted from proposal sent.
+- `source_url`: https://www.rainsalestraining.com/hubfs/PDFs/The_Top-Performing_Sales_Manager_Benchmark_Report.pdf
+- `last_checked`: 2026-05-03
+- `confidence`: medium
+- `methodology_note`: RAIN reports average proposal win rates of 72% for top performers and 47% for the rest; the skill uses 70-80% only for founder-confirmed verbal commits, not all proposals.
+- `sample_size`: 1,004 respondents in the RAIN Group report.
+- `vintage`: RAIN report checked 2026-05-03.
+- `applicability_caveat`: Procurement, security review, and legal paper can break verbal commitments; route contract blockers to `/slo-legal`.
+
+## Founder override rule
+
+Once the founder has 20+ opportunities in a stage, replace the starter prior with
+their own observed rate and record `baseline_ref` plus `founder_data_window`.

--- a/references/biz/product-prioritization-frameworks.md
+++ b/references/biz/product-prioritization-frameworks.md
@@ -1,0 +1,56 @@
+---
+name: product-prioritization-frameworks
+created: 2026-05-03
+retrieved: 2026-05-03
+refresh_recommended_by: 2027-05-03
+status: source-verified
+audience: /slo-product
+source_url: https://www.intercom.com/blog/rice-simple-prioritization-for-product-managers/
+last_checked: 2026-05-03
+confidence: high
+methodology_note: Top-level source verifies the RICE framework; Kano has its own row-level academic source below.
+applicability_caveat: Prioritization frameworks create conversation discipline; they do not prove strategy quality.
+---
+
+# Product prioritization frameworks
+
+Use this file for [`skills/slo-product/SKILL.md`](../../skills/slo-product/SKILL.md)
+roadmap outputs.
+
+```yaml
+baseline_ref: references/biz/product-prioritization-frameworks.md@2026-05-03
+```
+
+## Refresh discipline
+
+- Emit a **stale warning** when a consulted row is more than 12 months old.
+- Refuse at +24 months until the row is refreshed.
+
+## Rows
+
+### `framework-rice`
+
+- `definition`: Reach x Impact x Confidence / Effort.
+- `source_url`: https://www.intercom.com/blog/rice-simple-prioritization-for-product-managers/
+- `last_checked`: 2026-05-03
+- `confidence`: high
+- `methodology_note`: Intercom's original RICE article defines the four factors, example scales, and the formula.
+- `sample_size`: framework article; no survey sample.
+- `vintage`: 2018 article, checked 2026-05-03.
+- `applicability_caveat`: RICE can create false precision when reach, impact, or effort are guessed. The artifact must record confidence and the evidence behind it.
+
+### `framework-kano`
+
+- `definition`: classify product attributes by satisfaction response, including attractive, must-be, one-dimensional, indifferent, and reverse categories.
+- `source_url`: https://www.jstage.jst.go.jp/article/quality/14/2/14_KJ00002952366/_article
+- `last_checked`: 2026-05-03
+- `confidence`: high
+- `methodology_note`: Kano, Seraku, Takahashi, and Tsuji's 1984 paper proposes two-dimensional quality recognition and quality-element categories.
+- `sample_size`: original paper includes consumer questionnaire examples; not a SaaS benchmark sample.
+- `vintage`: 1984
+- `applicability_caveat`: Kano categories are user-perception labels. Do not label a feature a delighter without user evidence.
+
+## Skill use
+
+`/slo-product roadmap` may use RICE, Kano, or both. If both disagree, the skill
+surfaces the disagreement rather than averaging the frameworks.

--- a/references/biz/saas-kpi-targets-baseline.md
+++ b/references/biz/saas-kpi-targets-baseline.md
@@ -1,250 +1,178 @@
 ---
 name: saas-kpi-targets-baseline
 created: 2026-04-27
-retrieved: 2026-04-27
-refresh_recommended_by: 2027-04-27
-status: starter — runbook from issue #20 to harden, source, and refresh annually
-audience: /slo-metrics (Runbook B2 M4) — primary consumer; /slo-fundraise + /slo-pricing + /slo-sales-funnel + /slo-product cite as needed
-purpose: |
-  Authoritative numeric baselines for SaaS KPI targets — CAC payback, gross margin, MoM
-  growth, NDR, burn multiple, runway, ARR. Replaces inlined heuristic numbers in skill
-  prose per the 2026-04-27 skill-pack review. Every claim cites a public source.
-
-  Every artifact written by /slo-metrics MUST include `baseline_ref:` frontmatter
-  pointing at this file with the retrieval-date stamp the artifact captured. Stale > 12
-  months → /slo-metrics emits a refresh warning analogous to the cost-baseline staleness
-  pattern in /slo-legal.
+retrieved: 2026-05-03
+refresh_recommended_by: 2027-05-03
+status: source-verified
+audience: /slo-metrics primary; /slo-fundraise, /slo-pricing, /slo-sales-funnel, and /slo-product may cite by row
+source_url: https://www.highalpha.com/saas-benchmarks/2024
+last_checked: 2026-05-03
+confidence: medium
+methodology_note: Top-level file metadata points at the highest-coverage SaaS benchmark source; each row below has its own source and method.
+applicability_caveat: Seed-stage UK founders should treat these as diagnostic bands, not investor-grade promises.
 ---
 
-# SaaS KPI targets — sourced baseline
+# SaaS KPI targets - sourced baseline
 
-This file replaces inlined heuristic numbers in [`skills/slo-metrics/SKILL.md`](../../skills/slo-metrics/SKILL.md), [`skills/slo-pricing/SKILL.md`](../../skills/slo-pricing/SKILL.md), [`skills/slo-sales-funnel/SKILL.md`](../../skills/slo-sales-funnel/SKILL.md), [`skills/slo-product/SKILL.md`](../../skills/slo-product/SKILL.md) per issue #20. Skill prose cites file:section, never inlines numbers.
+This file replaces free-floating KPI heuristics in
+[`skills/slo-metrics/SKILL.md`](../../skills/slo-metrics/SKILL.md). Skill prose may
+show target values for readability, but the authority is this file plus the row
+retrieval stamp.
 
-**Currency**: GBP unless otherwise stated. US-sourced benchmarks are reported as `<USD value> (≈ £<GBP value> at <fx-rate-date>)` where conversion is non-trivial; ratios and percentages are currency-agnostic.
+Every artifact that uses these rows carries:
 
-**Stage**: figures are seed-stage (post-pre-seed, pre-Series A) unless tagged otherwise. Series A and later need their own baseline file (out of scope for this starter).
+```yaml
+baseline_ref: references/biz/saas-kpi-targets-baseline.md@2026-05-03
+```
 
 ## Refresh discipline
 
-This file is `retrieved: 2026-04-27`. Each row has a per-source `last_checked:` field — refresh when stale > 12 months. A single stale row does NOT invalidate the file; the skill emits a per-row warning when consulting a stale value.
-
-The runbook from issue #20 should set up a `/loop @annually` agent that re-fetches each public source and opens a refresh PR. Until that lands, refresh is manual.
+- `retrieved: 2026-05-03`.
+- Emit a **stale warning** when any consulted row is more than 12 months old.
+- Refuse at +24 months until the row is refreshed.
+- A stale row does not invalidate unrelated rows; warn per consulted row.
 
 ## Schema
 
-Each KPI row carries:
+Each row carries:
 
-- `kpi_id`: stable kebab-slug (referenced by skill prose)
-- `display_name`: human-readable
-- `formula`: how to compute (so the skill emits the math, not just the target)
-- `b2b_target_seed`: seed-stage B2B target (range or single value)
-- `b2c_target_seed`: seed-stage B2C target (range or single value)
-- `watch_signal`: when to flag a problem
-- `source`: primary source URL + retrieval date
-- `last_checked`: date the source was last verified
+- `kpi_id`
+- `formula`
+- `seed_target`
+- `watch_signal`
+- `source_url`
+- `last_checked`
+- `confidence`
+- `methodology_note`
+- `sample_size`
+- `vintage`
+- `applicability_caveat`
 
-## Capital-efficiency KPIs
+## Capital efficiency
 
 ### `kpi-burn-multiple`
 
-| field | value |
-|---|---|
-| display_name | Burn multiple |
-| formula | net cash burn (12-month trailing) ÷ net new ARR (12-month trailing) |
-| b2b_target_seed | ≤ 2 = good; 2–3 = watch; > 3 = unsustainable |
-| b2c_target_seed | Same bands as B2B (Bessemer's framework is industry-agnostic) |
-| watch_signal | > 3 for two consecutive quarters |
-| source | Bessemer Venture Partners — *State of the Cloud* annual reports + the Bessemer "Burn Multiple" framework. URL: https://www.bvp.com/atlas |
-| last_checked | 2026-04-27 |
-
-**Notes**: Bessemer's Burn Multiple framework was published 2020 and refined annually. The "≤ 2 / 2-3 / > 3" bands are stable across the framework's life. The framework is calibrated for SaaS; non-SaaS businesses (B2C marketplaces, hardware, services) need adjustment — flag in the artifact body.
+- `formula`: net cash burn for the period divided by net new ARR for the same period.
+- `seed_target`: <= 2 is healthy enough to keep investing; 2-3 is watch; > 3 is a spending/pricing review trigger.
+- `watch_signal`: > 3 for two consecutive quarters.
+- `source_url`: https://www.bvp.com/atlas/state-of-the-cloud-2024
+- `last_checked`: 2026-05-03
+- `confidence`: medium
+- `methodology_note`: Bessemer's 2024 cloud report uses the inverse capital-efficiency framing, BVP Efficiency Ratio = Net New CARR / Net Burn, and reports a ~1.1x ratio for scaled Vertical AI companies. The skill keeps the market's burn-multiple convention because founders commonly present it as net burn / net new ARR.
+- `sample_size`: several dozen Bessemer portfolio / observed Vertical AI companies for the cited 2024 efficiency-ratio point; not a full-market burn-multiple survey.
+- `vintage`: 2024
+- `applicability_caveat`: Best for recurring-revenue SaaS. Usage-based, services-heavy, hardware, marketplace, or pre-revenue businesses should label this row as not yet comparable.
 
 ### `kpi-runway-months`
 
-| field | value |
-|---|---|
-| display_name | Runway (months) |
-| formula | cash on hand ÷ trailing 3-month average net burn |
-| b2b_target_seed | ≥ 18 months at any point post-funding |
-| b2c_target_seed | ≥ 18 months |
-| watch_signal | < 12 months → start fundraise prep; < 6 months → tier-2 cost cuts (see `/slo-founder-check` worst-case-runway worksheet) |
-| source | YC's standard guidance + Sequoia / Andreessen Horowitz public commentary. The 18-month figure is the consensus "minimum to comfortably fundraise into" — see e.g. https://blog.ycombinator.com/the-importance-of-runway/ (last refreshed 2024-09) |
-| last_checked | 2026-04-27 |
+- `formula`: cash on hand divided by trailing 3-month average net burn.
+- `seed_target`: >= 18 months after a funding event; < 12 months triggers fundraise or cost-cut planning.
+- `watch_signal`: < 12 months; < 6 months is urgent.
+- `source_url`: https://www.highalpha.com/saas-benchmarks/2024
+- `last_checked`: 2026-05-03
+- `confidence`: medium
+- `methodology_note`: High Alpha/OpenView reports founder concern with burn and fundraising environment; the 18-month target is a planning guardrail rather than a directly surveyed benchmark.
+- `sample_size`: 800+ SaaS survey respondents for the 2024 report context.
+- `vintage`: 2024
+- `applicability_caveat`: Founder personal runway is separate from company runway and belongs in `/slo-founder-check`.
 
-**Notes**: The 18-month figure has been stable in YC / a16z / Sequoia commentary for over a decade. Founders' personal runway (per `/slo-founder-check`) is a separate tracker — do not conflate.
-
-## Growth KPIs
+## Growth and retention
 
 ### `kpi-mom-revenue-growth`
 
-| field | value |
-|---|---|
-| display_name | MoM revenue growth |
-| formula | (this month revenue − last month revenue) ÷ last month revenue |
-| b2b_target_seed | ≥ 10% MoM |
-| b2c_target_seed | ≥ 15% MoM |
-| watch_signal | B2B < 5% for 2+ months; B2C < 10% for 2+ months |
-| source | Paul Graham *Startup = Growth* essay (https://paulgraham.com/growth.html, 2012, last updated content stable) — defines 5–7% MoM as YC-cohort weekly growth → 22-30% MoM range. The 10% / 15% figures are seed-stage trade-up over post-MVP weekly cohorts; cited in OpenView "SaaS Benchmarks" annual reports (https://openviewpartners.com/saas-benchmarks/) |
-| last_checked | 2026-04-27 |
-
-**Notes**: PG's essay anchors weekly growth, not monthly; weekly 5-7% compounds to ~22-30% monthly. The 10% / 15% MoM bands here are post-traction seed-stage; pre-traction the targets are higher because the base is small.
+- `formula`: (this month revenue - last month revenue) / last month revenue.
+- `seed_target`: B2B >= 10% MoM; consumer >= 15% MoM, with smaller bases expected to grow faster.
+- `watch_signal`: B2B < 5% for 2+ months; consumer < 10% for 2+ months.
+- `source_url`: https://www.paulgraham.com/growth.html
+- `last_checked`: 2026-05-03
+- `confidence`: medium
+- `methodology_note`: Paul Graham anchors startup growth as a rate and uses weekly growth framing. These monthly seed targets are derived operating bands, not directly quoted survey medians.
+- `sample_size`: essay framework; no survey sample.
+- `vintage`: 2012 essay, stable page checked 2026-05-03.
+- `applicability_caveat`: Early revenue bases are noisy; quote both absolute revenue and growth rate.
 
 ### `kpi-net-dollar-retention`
 
-| field | value |
-|---|---|
-| display_name | Net dollar retention (NDR) |
-| formula | (retained-and-expanded revenue from cohort) ÷ (original cohort revenue), measured 12 months later |
-| b2b_target_seed | ≥ 110% post-seed |
-| b2c_target_seed | NOT typically tracked at B2C consumer scale — use cohort retention curve (`kpi-cohort-retention-flatness`) instead |
-| watch_signal | < 100% (net contraction) for any 12-month cohort |
-| source | OpenView SaaS Benchmarks 2024 (https://openviewpartners.com/saas-benchmarks/) reports median NDR for early-stage B2B SaaS at 105%; top-quartile at 115%. The 110% target here is OpenView upper-half. ChartMogul *SaaS Retention Report* corroborates. |
-| last_checked | 2026-04-27 |
-
-### `kpi-cac-payback-months`
-
-| field | value |
-|---|---|
-| display_name | CAC payback period (months) |
-| formula | CAC ÷ (ARR per customer × gross margin) |
-| b2b_target_seed | ≤ 12 months |
-| b2c_target_seed | ≤ 6 months |
-| watch_signal | B2B > 18 months; B2C > 12 months |
-| source | OpenView SaaS Benchmarks 2024 reports B2B median CAC payback ~ 17 months; top-quartile ~ 8 months. The 12-month target here is mid-to-upper-quartile. Forentrepreneurs.com (David Skok) https://www.forentrepreneurs.com/saas-metrics-2/ provides the canonical formula. |
-| last_checked | 2026-04-27 |
-
-### `kpi-gross-margin`
-
-| field | value |
-|---|---|
-| display_name | Gross margin |
-| formula | (revenue − COGS) ÷ revenue |
-| b2b_target_seed | ≥ 75% (SaaS); 60-70% acceptable for managed-services SaaS |
-| b2c_target_seed | Varies wildly by category (digital subscription ≥ 80%; physical-goods D2C 30-50%); set per-business |
-| watch_signal | B2B < 65% sustained; B2C category-specific |
-| source | OpenView SaaS Benchmarks 2024 reports B2B SaaS median gross margin 73%, top-quartile 80%+. The 75% target is mid-quartile. For B2C, the variance is too large for a single number — `/slo-metrics consumer` should ask for the founder's category context. |
-| last_checked | 2026-04-27 |
-
-## B2C-specific KPIs
+- `formula`: retained and expanded ARR from a cohort / original cohort ARR, measured 12 months later.
+- `seed_target`: B2B SaaS >= 110% once 12-month cohorts exist.
+- `watch_signal`: < 100% for any mature 12-month cohort.
+- `source_url`: https://www.highalpha.com/saas-benchmarks/2024
+- `last_checked`: 2026-05-03
+- `confidence`: high
+- `methodology_note`: High Alpha/OpenView reports public SaaS NRR stabilization around 110% and uses NRR as a core health metric for SaaS retention.
+- `sample_size`: 800+ SaaS survey respondents for the 2024 private-company report, plus public SaaS bellwether data discussed in the report.
+- `vintage`: 2024
+- `applicability_caveat`: Not meaningful before renewal cohorts mature; consumer products should use cohort-retention curves instead.
 
 ### `kpi-cohort-retention-flatness`
 
-| field | value |
-|---|---|
-| display_name | Cohort retention curve flatness (D90 ÷ D7) |
-| formula | D90 retention rate ÷ D7 retention rate |
-| b2b_target_seed | Use W4 ÷ W1 instead (B2B cadence is weekly) |
-| b2c_target_seed | ≥ 0.6 (curve flattens — "smile"); 0.4–0.6 watch; < 0.4 (curve keeps falling — "slope") = product-market fit gap |
-| watch_signal | < 0.4 ratio |
-| source | Sequoia *Retention by the Numbers* (https://articles.sequoiacap.com/retention) + Andrew Chen *Retention curve* canonical post (https://andrewchen.com/retention-is-king/). The 0.6 threshold is Chen's "smile vs slope" framing. |
-| last_checked | 2026-04-27 |
-
-### `kpi-arpu`
-
-| field | value |
-|---|---|
-| display_name | Average revenue per paying user (ARPU) |
-| formula | total revenue ÷ paying customers, period-aligned |
-| b2b_target_seed | "Track trajectory, not target" — ARPU varies by segment 10x+ |
-| b2c_target_seed | "Track trajectory, not target" — same |
-| watch_signal | Declining > 10% / month for 2+ months → audit pricing tier mix (`/slo-pricing`) |
-| source | No single canonical source — ARPU is a tracker, not a benchmark. Skill should record period (monthly / annual), denominator definition (paying-only vs all signed-up), and anomalies. |
-| last_checked | 2026-04-27 |
-
-## NPS / satisfaction
+- `formula`: later-period retention divided by early-period retention for the relevant cadence, e.g. D90 / D7.
+- `seed_target`: curve flattens; do not force a universal numeric threshold without category-specific comps.
+- `watch_signal`: curve keeps falling toward zero.
+- `source_url`: https://articles.sequoiacap.com/retention
+- `last_checked`: 2026-05-03
+- `confidence`: high
+- `methodology_note`: Sequoia frames retention-curve shape as flattening, declining, or smiling and treats retention as a product-growth foundation.
+- `sample_size`: framework article; no survey sample.
+- `vintage`: stable article, checked 2026-05-03.
+- `applicability_caveat`: Pick D/W/M cadence from actual product frequency; monthly retention can hide weekly-use failure.
 
 ### `kpi-nps`
 
-| field | value |
-|---|---|
-| display_name | Net Promoter Score |
-| formula | % promoters (9-10) − % detractors (0-6) |
-| b2b_target_seed | ≥ 30 |
-| b2c_target_seed | ≥ 30 |
-| watch_signal | < 0 (more detractors than promoters) |
-| source | Bain & Co. canonical NPS framework (Reichheld 2003). Bain's annual NPS benchmarks by industry are public — https://www.netpromotersystem.com/about/. The "≥ 30 = good" floor is industry-agnostic; specific verticals have different medians (SaaS ~ 36, e-commerce ~ 45). |
-| last_checked | 2026-04-27 |
+- `formula`: percentage of promoters minus percentage of detractors.
+- `seed_target`: track trend and qualitative follow-up; >= 30 can be a starter floor only when the founder lacks sector comps.
+- `watch_signal`: < 0, or sharp decline after a launch or pricing change.
+- `source_url`: https://www.netpromotersystem.com/about/
+- `last_checked`: 2026-05-03
+- `confidence`: high
+- `methodology_note`: Bain owns the Net Promoter System framing; the skill uses it as a feedback instrument, not as a universal valuation benchmark.
+- `sample_size`: methodology source; no single startup sample.
+- `vintage`: stable methodology page, checked 2026-05-03.
+- `applicability_caveat`: Industry medians vary widely; use relative movement and verbatim follow-up comments.
 
-## Outbound funnel conversion rates
+## Unit economics
 
-These are sourced from `references/biz/outbound-conversion-baselines.md` (issue #20 M1) — referenced here for completeness so `/slo-metrics` and `/slo-sales-funnel` can both cite a single authority chain.
+### `kpi-cac-payback-months`
 
-### `kpi-cold-to-meeting`
+- `formula`: CAC / (ARR per customer * gross margin), period-aligned.
+- `seed_target`: B2B <= 12 months; consumer <= 6 months when spend is paid-acquisition led.
+- `watch_signal`: B2B > 18 months; consumer > 12 months.
+- `source_url`: https://www.highalpha.com/saas-benchmarks/2024
+- `last_checked`: 2026-05-03
+- `confidence`: medium
+- `methodology_note`: High Alpha/OpenView treats GTM and efficiency as core benchmark dimensions; exact payback bands vary by ACV and motion, so the skill records assumptions with the formula.
+- `sample_size`: 800+ SaaS survey respondents for the 2024 report context.
+- `vintage`: 2024
+- `applicability_caveat`: Founder-led sales can make paid CAC look artificially low; include founder time separately when relevant.
 
-| field | value |
-|---|---|
-| display_name | Cold outreach → qualified meeting |
-| b2b_target_seed | 1–3% on cold; 10–20% on warm referral |
-| source | Bridge Group SaaS Sales Development Report (https://blog.bridgegroupinc.com/sdr-metrics-and-compensation-report) reports median 1.7% cold-to-meeting; top quartile 4%+. Outreach.io public benchmarks corroborate. |
-| last_checked | 2026-04-27 |
+### `kpi-gross-margin`
 
-### `kpi-meeting-to-demo`
+- `formula`: (revenue - COGS) / revenue.
+- `seed_target`: B2B SaaS >= 75%; managed-service SaaS may sit lower while delivery is still human-heavy.
+- `watch_signal`: B2B SaaS < 65% sustained.
+- `source_url`: https://www.bvp.com/atlas/state-of-the-cloud-2024
+- `last_checked`: 2026-05-03
+- `confidence`: medium
+- `methodology_note`: Bessemer reports ~65% gross margin for scaled Vertical AI companies and notes model costs as a share of revenue/COGS; the older pure-SaaS 75% target remains a seed-stage quality target rather than an AI-native observed median.
+- `sample_size`: several dozen Bessemer observed Vertical AI companies for the cited 2024 datapoint.
+- `vintage`: 2024
+- `applicability_caveat`: AI-native products with material model costs should show model-cost share and gross margin separately.
 
-| field | value |
-|---|---|
-| display_name | Qualified meeting → demo |
-| b2b_target_seed | 50% |
-| source | RAIN Group sales-conversion benchmarks (https://www.rainsalestraining.com/blog/sales-statistics) report median ~ 47% qualified-meeting-to-discovery-call. The 50% target here is rounded to mid-quartile. |
-| last_checked | 2026-04-27 |
+### `kpi-arpu`
 
-### `kpi-demo-to-verbal`
+- `formula`: period revenue / paying customers.
+- `seed_target`: track trajectory, not a universal target.
+- `watch_signal`: declining > 10% per month for 2+ months.
+- `source_url`: https://www.highalpha.com/saas-benchmarks/2024
+- `last_checked`: 2026-05-03
+- `confidence`: medium
+- `methodology_note`: The source supports segmenting SaaS metrics by ARR band and ICP; ARPU itself is a business-model-specific tracker.
+- `sample_size`: 800+ SaaS survey respondents for the 2024 report context.
+- `vintage`: 2024
+- `applicability_caveat`: Define denominator carefully: paying users, accounts, seats, or active customers.
 
-| field | value |
-|---|---|
-| display_name | Demo → verbal commit |
-| b2b_target_seed | 30% |
-| source | Same as above; varies 20-40% by category. |
-| last_checked | 2026-04-27 |
+## Outbound funnel cross-reference
 
-### `kpi-verbal-to-close`
-
-| field | value |
-|---|---|
-| display_name | Verbal commit → closed-won |
-| b2b_target_seed | 70-80% |
-| source | RAIN Group + HubSpot State of Inbound 2024 corroborate ~ 70-75% verbal-to-close in B2B SaaS. |
-| last_checked | 2026-04-27 |
-
-## Watch-signal aggregation
-
-When `/slo-metrics` or `/slo-fundraise prepare` produces an investor-update or funnel review, **the skill MUST surface every KPI watch-signal that fired** in the period. The watch-signal field is the structured forcing function — no hand-waved "things are mostly good".
-
-## Per-artifact `baseline_ref:` discipline
-
-Every artifact emitted by a skill that consults this file MUST carry:
-
-```yaml
-baseline_ref: references/biz/saas-kpi-targets-baseline.md@2026-04-27
-```
-
-The `@<retrieval-date>` is the date the SKILL.md prose CONSULTED this file (so a > 12-month gap between consultation and now triggers the staleness warning).
-
-Per issue #20 M4, a new `baseline_ref:` field is added to [`references/biz/artifact-schema.md`](artifact-schema.md) for generator outputs that cite numeric targets.
-
-## Open work for the runbook (issue #20)
-
-This starter file covers the highest-leverage rows. The runbook should:
-
-1. **Source-verify every row.** Each `source:` field is a starter citation; the runbook author should manually verify each URL, capture the page hash, and update `last_checked:`.
-2. **Extend coverage** to per-vertical benchmarks (PLG SaaS specifically; usage-based SaaS; vertical SaaS — e.g., compliance fintech vs HR SaaS — have different bands).
-3. **Add the annual refresh `/loop`** (per issue #20 M4 acceptance criteria).
-4. **Sister files**:
-   - `references/biz/outbound-conversion-baselines.md` (full funnel rates with sources)
-   - `references/biz/product-prioritization-frameworks.md` (RICE / Kano)
-   - `references/biz/value-equation-pricing.md` (the "25-33% of value" claim sourced)
-   - `references/biz/launch-success-thresholds.md` (or reframe as "set your own threshold")
-
-## Out of scope (this starter)
-
-- Series A and later targets (different bands, different file)
-- Non-UK currency adjustments beyond GBP / USD
-- Sector-specific verticals (fintech, healthtech, devtools, marketplace) — covered in the runbook follow-on
-- Forecasting / scenario modelling — `/slo-metrics` is a dashboard scaffold, not a forecaster
-
-## Cross-references
-
-- [`references/biz/artifact-schema.md`](artifact-schema.md) — `baseline_ref:` field added per issue #20 M4
-- [`skills/slo-metrics/SKILL.md`](../../skills/slo-metrics/SKILL.md) — primary consumer
-- [`skills/slo-pricing/SKILL.md`](../../skills/slo-pricing/SKILL.md), [`skills/slo-sales-funnel/SKILL.md`](../../skills/slo-sales-funnel/SKILL.md), [`skills/slo-product/SKILL.md`](../../skills/slo-product/SKILL.md) — secondary consumers
-- Issue #20 — runbook driving this file's hardening
-- Issue #21 D — `references/templates/heuristic-numbers-discipline.md` documents the "every numeric claim cites a baseline file" rule
+Outbound conversion targets live in
+[`references/biz/outbound-conversion-baselines.md`](outbound-conversion-baselines.md).
+`/slo-metrics` may cite that file when CAC or pipeline conversion becomes a KPI.

--- a/references/biz/uk-consumer-statute-anchors.md
+++ b/references/biz/uk-consumer-statute-anchors.md
@@ -1,0 +1,57 @@
+---
+name: uk-consumer-statute-anchors
+created: 2026-05-03
+retrieved: 2026-05-03
+refresh_recommended_by: 2027-05-03
+status: source-verified
+audience: /slo-legal, /slo-marketing, /slo-pricing
+purpose: |
+  Verbatim UK consumer-law anchors for founder-advice artifacts. This file
+  is a provenance layer, not legal advice.
+---
+
+# UK consumer statute anchors
+
+Every quote below was checked against the linked primary or official source on 2026-05-03. Skills cite these anchors by section name instead of restating consumer law from memory.
+
+## Consumer Rights Act 2015 s49 — reasonable care and skill
+
+- authority: Consumer Rights Act 2015, section 49
+- source_url: https://www.legislation.gov.uk/ukpga/2015/15/section/49
+- data_url: https://www.legislation.gov.uk/ukpga/2015/15/section/49/data.xml
+- last_checked: 2026-05-03
+- quoted_text: "the trader must perform the service with reasonable care and skill"
+- advisor_use: B2C service terms, SaaS service obligations, and `/slo-pricing` cancellation/refund warning surfaces.
+
+## Consumer Contracts Regulations 2013 reg 29 — right to cancel
+
+- authority: Consumer Contracts (Information, Cancellation and Additional Charges) Regulations 2013, regulation 29
+- source_url: https://www.legislation.gov.uk/uksi/2013/3134/regulation/29
+- data_url: https://www.legislation.gov.uk/uksi/2013/3134/regulation/29/data.xml
+- last_checked: 2026-05-03
+- quoted_text: "The consumer may cancel a distance or off-premises contract at any time in the cancellation period"
+- advisor_use: B2C distance/off-premises cancellation triage.
+
+## Consumer Contracts Regulations 2013 reg 30 — normal cancellation period
+
+- authority: Consumer Contracts (Information, Cancellation and Additional Charges) Regulations 2013, regulation 30
+- source_url: https://www.legislation.gov.uk/uksi/2013/3134/regulation/30
+- data_url: https://www.legislation.gov.uk/uksi/2013/3134/regulation/30/data.xml
+- last_checked: 2026-05-03
+- quoted_text: "the cancellation period ends at the end of 14 days after the day on which the contract is entered into"
+- advisor_use: `/slo-legal` and `/slo-pricing` cooling-off-period warnings.
+
+## DMCC 2024 — consumer protection and subscription context
+
+- authority: Digital Markets, Competition and Consumers Act 2024
+- source_url: https://www.legislation.gov.uk/ukpga/2024/13/contents
+- data_url: https://www.legislation.gov.uk/ukpga/2024/13/contents/data.xml
+- last_checked: 2026-05-03
+- quoted_text: "to make provision relating to the protection of consumer rights and to confer further such rights"
+- advisor_use: `/slo-marketing` and `/slo-pricing` B2C subscription, renewal, and consumer-protection routing.
+
+## Refresh discipline
+
+- warn_after: 2027-05-03
+- refuse_after: 2028-05-03
+- refresh_source_order: legislation.gov.uk section/data endpoints first; GOV.UK regulator guidance only for operational interpretation.

--- a/references/biz/uk-employment-statute-anchors.md
+++ b/references/biz/uk-employment-statute-anchors.md
@@ -1,0 +1,66 @@
+---
+name: uk-employment-statute-anchors
+created: 2026-05-03
+retrieved: 2026-05-03
+refresh_recommended_by: 2027-05-03
+status: source-verified
+audience: /slo-hire, /slo-legal, /slo-accounting
+purpose: |
+  Verbatim UK employment-law anchors for advisor skills. Skills cite this
+  file instead of paraphrasing statute from model memory.
+---
+
+# UK employment statute anchors
+
+These are short quote anchors, not legal advice. Every downstream advisor skill must preserve the `source_url`, `last_checked`, and `quoted_text` provenance when relying on these sections.
+
+## IANA 2006 s15 — right-to-work civil penalty surface
+
+- authority: Immigration, Asylum and Nationality Act 2006, section 15
+- source_url: https://www.legislation.gov.uk/ukpga/2006/13/section/15
+- data_url: https://www.legislation.gov.uk/ukpga/2006/13/section/15/data.xml
+- last_checked: 2026-05-03
+- quoted_text: "It is contrary to this section to employ an adult subject to immigration control if"
+- advisor_use: `/slo-hire` right-to-work warning and lawyer/accountant routing for immigration-risk hiring.
+
+## ERA 1996 s86 — statutory minimum notice
+
+- authority: Employment Rights Act 1996, section 86
+- source_url: https://www.legislation.gov.uk/ukpga/1996/18/section/86
+- data_url: https://www.legislation.gov.uk/ukpga/1996/18/section/86/data.xml
+- last_checked: 2026-05-03
+- quoted_text: "is not less than one week's notice if his period of continuous employment is less than two years"
+- advisor_use: `/slo-hire` employment-contract termination and offer-letter triage.
+
+## Pensions Act 2008 s3 — automatic enrolment trigger
+
+- authority: Pensions Act 2008, section 3
+- source_url: https://www.legislation.gov.uk/ukpga/2008/30/section/3
+- data_url: https://www.legislation.gov.uk/ukpga/2008/30/section/3/data.xml
+- last_checked: 2026-05-03
+- quoted_text: "This section applies to a jobholder"
+- advisor_use: `/slo-hire` and `/slo-accounting` workplace-pension routing.
+
+## Equality Act 2010 s4 — protected characteristics
+
+- authority: Equality Act 2010, section 4
+- source_url: https://www.legislation.gov.uk/ukpga/2010/15/section/4
+- data_url: https://www.legislation.gov.uk/ukpga/2010/15/section/4/data.xml
+- last_checked: 2026-05-03
+- quoted_text: "The following characteristics are protected characteristics"
+- advisor_use: `/slo-hire` interview rubric, offer, onboarding, and discrimination-risk triage.
+
+## ITEPA 2003 Part 2 Chapter 10 — off-payroll working
+
+- authority: Income Tax (Earnings and Pensions) Act 2003, Part 2 Chapter 10
+- source_url: https://www.legislation.gov.uk/ukpga/2003/1/part/2/chapter/10
+- data_url: https://www.legislation.gov.uk/ukpga/2003/1/part/2/chapter/10/data.xml
+- last_checked: 2026-05-03
+- quoted_text: "Workers' services provided through intermediaries to public authorities or medium or large clients"
+- advisor_use: `/slo-hire` contractor/SOW IR35 routing and `/slo-accounting` PAYE/NI warning surface.
+
+## Refresh discipline
+
+- warn_after: 2027-05-03
+- refuse_after: 2028-05-03
+- refresh_source_order: legislation.gov.uk data endpoint first, then GOV.UK/HMRC guidance where statute text points to operational guidance.

--- a/references/biz/uk-marketing-statute-anchors.md
+++ b/references/biz/uk-marketing-statute-anchors.md
@@ -1,0 +1,66 @@
+---
+name: uk-marketing-statute-anchors
+created: 2026-05-03
+retrieved: 2026-05-03
+refresh_recommended_by: 2027-05-03
+status: source-verified
+audience: /slo-marketing, /slo-launch, /slo-sales-funnel, /slo-legal
+purpose: |
+  Verbatim UK marketing, advertising, and electronic-communications anchors
+  for the business skills.
+---
+
+# UK marketing statute anchors
+
+This file separates marketing-risk source text from SKILL.md prose. It is not legal advice and does not authorise bypassing `/slo-legal` gate-4 routing for GDPR/PECR matters.
+
+## CAP Code / ASA — non-broadcast advertising code
+
+- authority: Advertising Standards Authority / CAP non-broadcast code
+- source_url: https://www.asa.org.uk/codes-and-rulings/advertising-codes/non-broadcast-code.html
+- last_checked: 2026-05-03
+- quoted_text: "Rules relating to social responsibility; legality and fair competition"
+- advisor_use: `/slo-marketing` and `/slo-launch` ad-copy risk warnings. `asa` is medium-confidence in the regulator enum because this is self-regulatory rather than a direct statute row.
+
+## PECR 2003 reg 22 — email direct marketing consent
+
+- authority: Privacy and Electronic Communications (EC Directive) Regulations 2003, regulation 22
+- source_url: https://www.legislation.gov.uk/uksi/2003/2426/regulation/22
+- data_url: https://www.legislation.gov.uk/uksi/2003/2426/regulation/22/data.xml
+- last_checked: 2026-05-03
+- quoted_text: "This regulation applies to the transmission of unsolicited communications by means of electronic mail to individual subscribers"
+- advisor_use: `/slo-marketing`, `/slo-sales-funnel`, and `/slo-legal` direct-marketing routing.
+
+## PECR 2003 reg 22 — soft opt-in conditions
+
+- authority: Privacy and Electronic Communications (EC Directive) Regulations 2003, regulation 22
+- source_url: https://www.legislation.gov.uk/uksi/2003/2426/regulation/22
+- data_url: https://www.legislation.gov.uk/uksi/2003/2426/regulation/22/data.xml
+- last_checked: 2026-05-03
+- quoted_text: "the direct marketing is in respect of that person's similar products and services only"
+- advisor_use: `/slo-sales-funnel` cold/warm email distinction and DPO routing.
+
+## DUAA 2025 schedule 13 — PECR enforcement powers
+
+- authority: Data (Use and Access) Act 2025, Schedule 13
+- source_url: https://www.legislation.gov.uk/ukpga/2025/18/schedule/13
+- data_url: https://www.legislation.gov.uk/ukpga/2025/18/schedule/13/data.xml
+- last_checked: 2026-05-03
+- quoted_text: "the maximum amount of the penalty that may be imposed by a penalty notice is the higher maximum amount"
+- cross_reference: Data Protection Act 2018 s157 defines the higher maximum amount.
+- advisor_use: `/slo-marketing` B2C direct marketing and `/slo-legal` PECR risk triage.
+
+## DPA 2018 s157 — higher maximum amount
+
+- authority: Data Protection Act 2018, section 157
+- source_url: https://www.legislation.gov.uk/ukpga/2018/12/section/157
+- data_url: https://www.legislation.gov.uk/ukpga/2018/12/section/157/data.xml
+- last_checked: 2026-05-03
+- quoted_text: "£17,500,000 or 4% of the undertaking's total annual worldwide turnover"
+- advisor_use: PECR penalty ceiling explanation when DUAA schedule 13 points PECR penalties at the higher maximum amount.
+
+## Refresh discipline
+
+- warn_after: 2027-05-03
+- refuse_after: 2028-05-03
+- refresh_source_order: legislation.gov.uk, ICO, ASA/CAP for code text, then other official regulator pages.

--- a/references/biz/uk-regulator-enumeration.md
+++ b/references/biz/uk-regulator-enumeration.md
@@ -1,7 +1,9 @@
 ---
 name: uk-regulator-enumeration
 created: 2026-04-27
-status: starter — runbook from issue #19 to harden + extend
+retrieved: 2026-05-03
+refresh_recommended_by: 2027-05-03
+status: source-verified — M1 business-skill-improvements
 audience: every advisor skill in the biz pack (`/slo-legal`, `/slo-accounting`, `/slo-equity`, `/slo-fundraise`, `/slo-hire`)
 purpose: |
   Closed enumeration of UK regulators with statutory enforcement powers. The
@@ -18,7 +20,7 @@ The advisor skills MUST consult this file when evaluating `gate-1-regulated`. Na
 
 ## Schema
 
-Each row is a `regulator_id` (kebab-slug, stable interface — referenced by intake forms in `references/biz/legal-intake-form.md` etc.) plus structured metadata.
+Each row is a `regulator_id` (kebab-slug, stable interface — referenced by intake forms in `references/biz/legal-intake-contract.md` etc.) plus structured metadata.
 
 | Field | Type | Notes |
 |---|---|---|
@@ -29,6 +31,38 @@ Each row is a `regulator_id` (kebab-slug, stable interface — referenced by int
 | `default_route_to` | enum | `lawyer-specialist` / `lawyer` / `accountant` / `dpo` / `combined` |
 | `cited_by` | list | Which advisor skills typically cite this regulator |
 | `last_reviewed` | date (YYYY-MM-DD) | Annual cadence; stale > 12 months → refresh PR |
+
+## Source verification register
+
+Each row below is the authority audit surface for the closed enum. `last_checked` is the SLO verification date; `next_review_due` is the annual refresh date. `last_amended` records the revised-source position seen at retrieval time, not a legal opinion about every downstream amendment.
+
+| id | primary_authority | statute_url | commenced_date | last_amended | last_checked | next_review_due | confidence |
+|---|---|---|---|---|---|---|---|
+| `hmrc` | Taxes Management Act 1970; Income Tax Act 2007; ITEPA 2003 Chapter 10 | https://www.legislation.gov.uk/ukpga/1970/9/contents; https://www.legislation.gov.uk/ukpga/2007/3/contents; https://www.legislation.gov.uk/ukpga/2003/1/part/2/chapter/10 | 1970-03-12 / 2007-03-20 / 2003-03-06 | revised source current at source check | 2026-05-03 | 2027-05-03 | high |
+| `companies-house` | Companies Act 2006; Economic Crime and Corporate Transparency Act 2023 | https://www.legislation.gov.uk/ukpga/2006/46/contents; https://www.legislation.gov.uk/ukpga/2023/56/contents | 2006-11-08 / 2023-10-26 | revised source current at source check | 2026-05-03 | 2027-05-03 | high |
+| `pensions-regulator` | Pensions Act 2008 | https://www.legislation.gov.uk/ukpga/2008/30/contents | 2008-11-26 | revised source current at source check | 2026-05-03 | 2027-05-03 | high |
+| `ico` | Data Protection Act 2018; PECR 2003; Data (Use and Access) Act 2025 | https://www.legislation.gov.uk/ukpga/2018/12/contents; https://www.legislation.gov.uk/uksi/2003/2426/contents; https://www.legislation.gov.uk/ukpga/2025/18/contents | 2018-05-23 / 2003-12-11 / 2025-06-19 | revised source current at source check | 2026-05-03 | 2027-05-03 | high |
+| `ofcom` | Communications Act 2003; Online Safety Act 2023 | https://www.legislation.gov.uk/ukpga/2003/21/contents; https://www.legislation.gov.uk/ukpga/2023/50/contents | 2003-07-17 / 2023-10-26 | revised source current at source check | 2026-05-03 | 2027-05-03 | high |
+| `fca` | Financial Services and Markets Act 2000 | https://www.legislation.gov.uk/ukpga/2000/8/contents | 2000-06-14 | revised source current at source check | 2026-05-03 | 2027-05-03 | high |
+| `pra` | Financial Services and Markets Act 2000; Bank of England Act 1998 | https://www.legislation.gov.uk/ukpga/2000/8/contents; https://www.legislation.gov.uk/ukpga/1998/11/contents | 2000-06-14 / 1998-04-23 | revised source current at source check | 2026-05-03 | 2027-05-03 | high |
+| `cma` | Competition Act 1998; Enterprise Act 2002; Digital Markets, Competition and Consumers Act 2024 | https://www.legislation.gov.uk/ukpga/1998/41/contents; https://www.legislation.gov.uk/ukpga/2002/40/contents; https://www.legislation.gov.uk/ukpga/2024/13/contents | 1998-11-09 / 2002-11-07 / 2024-05-24 | revised source current at source check | 2026-05-03 | 2027-05-03 | high |
+| `asa` | CAP Code and ASA self-regulatory remit; Ofcom statutory backstop for broadcast | https://www.asa.org.uk/codes-and-rulings/advertising-codes/non-broadcast-code.html; https://www.legislation.gov.uk/ukpga/2003/21/contents | self-regulatory code / 2003-07-17 | code page current at source check | 2026-05-03 | 2027-05-03 | medium |
+| `tsi` | Consumer Rights Act 2015; Consumer Protection from Unfair Trading Regulations 2008 | https://www.legislation.gov.uk/ukpga/2015/15/contents; https://www.legislation.gov.uk/uksi/2008/1277/contents | 2015-03-26 / 2008-05-26 | revised source current at source check | 2026-05-03 | 2027-05-03 | high |
+| `mhra` | Medicines Act 1968; Human Medicines Regulations 2012; Medical Devices Regulations 2002 | https://www.legislation.gov.uk/ukpga/1968/67/contents; https://www.legislation.gov.uk/uksi/2012/1916/contents; https://www.legislation.gov.uk/uksi/2002/618/contents | 1968-10-25 / 2012-08-14 / 2002-03-08 | revised source current at source check | 2026-05-03 | 2027-05-03 | high |
+| `cqc` | Health and Social Care Act 2008 | https://www.legislation.gov.uk/ukpga/2008/14/contents | 2008-07-21 | revised source current at source check | 2026-05-03 | 2027-05-03 | high |
+| `gmc` | Medical Act 1983 | https://www.legislation.gov.uk/ukpga/1983/54/contents | 1983-10-26 | revised source current at source check | 2026-05-03 | 2027-05-03 | high |
+| `nmc` | Nursing and Midwifery Order 2001 | https://www.legislation.gov.uk/uksi/2002/253/contents | 2002-02-12 | revised source current at source check | 2026-05-03 | 2027-05-03 | high |
+| `hcpc` | Health Professions Order 2001 | https://www.legislation.gov.uk/uksi/2002/254/contents | 2002-02-12 | revised source current at source check | 2026-05-03 | 2027-05-03 | high |
+| `hse` | Health and Safety at Work etc. Act 1974 | https://www.legislation.gov.uk/ukpga/1974/37/contents | 1974-07-31 | revised source current at source check | 2026-05-03 | 2027-05-03 | high |
+| `ehrc` | Equality Act 2006; Equality Act 2010 | https://www.legislation.gov.uk/ukpga/2006/3/contents; https://www.legislation.gov.uk/ukpga/2010/15/contents | 2006-02-16 / 2010-04-08 | revised source current at source check | 2026-05-03 | 2027-05-03 | high |
+| `ofgem` | Gas Act 1986; Electricity Act 1989; Utilities Act 2000 | https://www.legislation.gov.uk/ukpga/1986/44/contents; https://www.legislation.gov.uk/ukpga/1989/29/contents; https://www.legislation.gov.uk/ukpga/2000/27/contents | 1986-07-25 / 1989-07-27 / 2000-07-28 | revised source current at source check | 2026-05-03 | 2027-05-03 | high |
+| `ofwat` | Water Industry Act 1991 | https://www.legislation.gov.uk/ukpga/1991/56/contents | 1991-07-25 | revised source current at source check | 2026-05-03 | 2027-05-03 | high |
+| `ofsted` | Education and Inspections Act 2006; Care Standards Act 2000 | https://www.legislation.gov.uk/ukpga/2006/40/contents; https://www.legislation.gov.uk/ukpga/2000/14/contents | 2006-11-08 / 2000-07-20 | revised source current at source check | 2026-05-03 | 2027-05-03 | high |
+| `caa` | Civil Aviation Act 2012; Air Navigation Order 2016 | https://www.legislation.gov.uk/ukpga/2012/19/contents; https://www.legislation.gov.uk/uksi/2016/765/contents | 2012-12-19 / 2016-07-19 | revised source current at source check | 2026-05-03 | 2027-05-03 | high |
+| `environment-agency` | Environment Act 2021; Environmental Permitting Regulations 2016 | https://www.legislation.gov.uk/ukpga/2021/30/contents; https://www.legislation.gov.uk/uksi/2016/1154/contents | 2021-11-09 / 2016-12-06 | revised source current at source check | 2026-05-03 | 2027-05-03 | high |
+| `charity-commission` | Charities Act 2011 | https://www.legislation.gov.uk/ukpga/2011/25/contents | 2011-12-14 | revised source current at source check | 2026-05-03 | 2027-05-03 | high |
+| `oisc` | Immigration and Asylum Act 1999 Part V | https://www.legislation.gov.uk/ukpga/1999/33/part/V | 1999-11-11 | revised source current at source check | 2026-05-03 | 2027-05-03 | high |
+| `solicitors-regulation-authority` | Legal Services Act 2007; Solicitors Act 1974 | https://www.legislation.gov.uk/ukpga/2007/29/contents; https://www.legislation.gov.uk/ukpga/1974/47/contents | 2007-10-30 / 1974-07-31 | revised source current at source check | 2026-05-03 | 2027-05-03 | high |
 
 ## The enumeration (last-reviewed: 2026-04-27)
 
@@ -137,7 +171,7 @@ The file's `last_reviewed:` triggers a refresh PR when stale > 12 months. The sk
 
 - `references/biz/triage-gate.md` — the predicate this file resolves.
 - `references/biz/jurisdiction-uk.md` — narrative version of UK regulator scope.
-- `references/biz/legal-intake-form.md` — F5 field uses `id` values from this file as the closed enum.
+- `references/biz/legal-intake-contract.md` — F5 field uses `id` values from this file as the closed enum.
 - `references/biz/hmrc-vcm-index.md` — HMRC VCM-specific anchors for SEIS/EIS firings.
 - `references/biz/ico-duaa-index.md` — ICO DUAA 2025 anchors for ICO firings.
 - `references/biz/ir35-cest-factors.md` — HMRC IR35 specifics for `slo-hire`.

--- a/references/biz/value-equation-pricing.md
+++ b/references/biz/value-equation-pricing.md
@@ -1,0 +1,56 @@
+---
+name: value-equation-pricing
+created: 2026-05-03
+retrieved: 2026-05-03
+refresh_recommended_by: 2027-05-03
+status: source-verified-with-opinion-caveat
+audience: /slo-pricing
+source_url: https://shop.acquisition.com/products/100m-offers-hardcover
+last_checked: 2026-05-03
+confidence: medium
+methodology_note: Acquisition.com verifies the $100M Offers source and value-equation framing; the 25-33% capture band is SLO operating guidance, not a public statistical benchmark.
+applicability_caveat: Value pricing is opinionated sales strategy. It must be tested against buyer behavior, not treated as market law.
+---
+
+# Value-equation pricing
+
+Use this file for [`skills/slo-pricing/SKILL.md`](../../skills/slo-pricing/SKILL.md).
+
+```yaml
+baseline_ref: references/biz/value-equation-pricing.md@2026-05-03
+```
+
+## Refresh discipline
+
+- Emit a **stale warning** when a consulted row is more than 12 months old.
+- Refuse at +24 months until the row is refreshed.
+
+## Rows
+
+### `pricing-value-equation`
+
+- `claim`: Price should be anchored to economic value delivered, with the skill calculating a 25-33% capture band.
+- `source_url`: https://shop.acquisition.com/products/100m-offers-hardcover
+- `last_checked`: 2026-05-03
+- `confidence`: medium
+- `methodology_note`: Acquisition.com describes $100M Offers as teaching the Value Equation and charging more by making the offer worth more. The SLO 25-33% band is an operational heuristic layered on that value-pricing source.
+- `sample_size`: book/source framework; no survey sample.
+- `vintage`: source checked 2026-05-03.
+- `applicability_caveat`: Do not use when value cannot be estimated within an order of magnitude; run `/slo-talk-to-users` first.
+
+### `pricing-increase-by-50-experiment`
+
+- `claim`: Test a higher price on new prospects and decide based on conversion-rate delta.
+- `source_url`: https://shop.acquisition.com/products/100m-offers-hardcover
+- `last_checked`: 2026-05-03
+- `confidence`: low
+- `methodology_note`: This is SLO's founder-undercharge correction experiment inspired by value-pricing practice, not a cited market benchmark.
+- `sample_size`: not applicable.
+- `vintage`: source checked 2026-05-03.
+- `applicability_caveat`: Only test on new prospects with clear consent to the quoted price. Do not surprise existing customers.
+
+## Opinion labeling
+
+The old "30-50% below market" line is not sourceable as a universal benchmark.
+When used, label it as founder-undercharge pattern recognition and verify with
+the 30-day price test.

--- a/skills/slo-accounting/SKILL.md
+++ b/skills/slo-accounting/SKILL.md
@@ -21,6 +21,12 @@ You are a UK accounting advisor running first-cut briefing workshops for a seed-
 
 The advisor pattern is identical to `/slo-legal` — see [skills/slo-legal/SKILL.md](../slo-legal/SKILL.md) for the precedent. This skill applies the same four predicates from [references/biz/triage-gate.md](../../references/biz/triage-gate.md) but defaults to **accountant routing** (not lawyer routing) for HMRC-domain matters. Routing override pattern documented in [references/biz/jurisdiction-uk.md](../../references/biz/jurisdiction-uk.md) "UK regulator index".
 
+## Conversational intake before `draft`
+
+Before any `draft` output, run the conversational intake contract at [references/biz/accounting-intake-contract.md](../../references/biz/accounting-intake-contract.md). Conversation is the UX: ask one question at a time, push on vague answers, synthesize F1-F6 into `intake_summary:`, then perform a **Restate-and-confirm** step before evaluating the four gates. If any field is unknown, rounded, hypothetical, or internally inconsistent, refuse on ambiguity and ask for the missing fact; do not draft from assumptions.
+
+Evaluate `gate-1-regulated` only against the closed enum in [references/biz/uk-regulator-enumeration.md](../../references/biz/uk-regulator-enumeration.md). HMRC and Companies House routing must cite official authority references instead of training-memory paraphrase; use [references/biz/hmrc-vcm-index.md](../../references/biz/hmrc-vcm-index.md) where SEIS/EIS surfaces appear and [references/biz/ico-duaa-index.md](../../references/biz/ico-duaa-index.md) for GDPR/DUAA context.
+
 ## Modes
 
 You accept exactly four modes. Refuse unknown modes with a clear error.

--- a/skills/slo-equity/SKILL.md
+++ b/skills/slo-equity/SKILL.md
@@ -20,6 +20,12 @@ You are a UK equity advisor running first-cut workshops for a seed-stage technic
 
 The advisor pattern is identical to `/slo-legal` (M1) and `/slo-accounting` (M2). This skill applies the same four predicates from [references/biz/triage-gate.md](../../references/biz/triage-gate.md) and uses the routing rules in [references/biz/jurisdiction-uk.md](../../references/biz/jurisdiction-uk.md). New for M3: cites [references/biz/hmrc-vcm-index.md](../../references/biz/hmrc-vcm-index.md) for SEIS / EIS qualifying-rights checks.
 
+## Conversational intake before `draft`
+
+Before any `draft` output, run the conversational intake contract at [references/biz/equity-intake-contract.md](../../references/biz/equity-intake-contract.md). Conversation is the UX: ask one question at a time, push on vague answers, synthesize F1-F6 into `intake_summary:`, then perform a **Restate-and-confirm** step before evaluating the four gates. If any cap-table, share-class, SEIS/EIS, or preferential-rights fact is unknown, refuse on ambiguity and ask for the missing fact; do not draft from assumptions.
+
+Evaluate `gate-1-regulated` only against the closed enum in [references/biz/uk-regulator-enumeration.md](../../references/biz/uk-regulator-enumeration.md). Cite [references/biz/hmrc-vcm-index.md](../../references/biz/hmrc-vcm-index.md) for VCM34080, VCM3000, VCM31000, and preferential-rights checks rather than restating HMRC manual prose inline.
+
 ## Modes
 
 | Mode | Use case | Output |
@@ -38,6 +44,23 @@ The advisor pattern is identical to `/slo-legal` (M1) and `/slo-accounting` (M2)
 | `cap-table-snapshot` | Pre / post-money cap table with founders, ESOP pool, advisors, prior investors; share class breakdown (ordinary vs any preferred) | Snapshot only — actual cap-table maintenance happens in Carta / Capdesk / spreadsheet; this is for memo / discussion purposes |
 
 Other equity surfaces — actual articles of association, shareholders agreement, vesting agreement, EMI option grant agreement, SEIS / EIS share issue documentation — are lawyer-territory and hard-blocked via `gate-1-regulated` (Companies House regulated filings) or `gate-2-deal-value-over-5k` (any equity grant has implicit value > £5k for a seed-stage company).
+
+## M3 numeric verification for `cap-table-snapshot`
+
+Math is computed, not narrated. `draft cap-table-snapshot` MUST **re-derive every Total row** before writing. The skill uses two independent checks:
+
+| Cell type | Tolerance |
+|---|---|
+| Currency cells | ±£1 |
+| Percentage cells | ±0.01% |
+| Whole-share counts | ±1 |
+
+Cap-table verification contract:
+
+1. **sum-down**: recompute each Total row by summing the holder rows above it.
+2. **weighted-product**: independently recompute ownership percentages from `holder_shares / fully_diluted_total_shares`, and recompute implied value from percentage × valuation where applicable.
+3. Check that pre-money shares, option pool, investor shares, fully diluted total, and ownership percentages agree across both methods.
+4. If either method disagrees with the table outside tolerance, **refuse to write** and surface the mismatch with the row name, expected value, observed value, and tolerance. Do not patch the table silently.
 
 ## Hard-block gates
 

--- a/skills/slo-fundraise/SKILL.md
+++ b/skills/slo-fundraise/SKILL.md
@@ -21,6 +21,12 @@ You are a UK fundraising advisor running first-cut workshops for a seed-stage te
 
 The advisor pattern is identical to `/slo-legal` (M1), `/slo-accounting` (M2), and `/slo-equity` (M3). This skill applies the same four predicates from [references/biz/triage-gate.md](../../references/biz/triage-gate.md), uses [references/biz/jurisdiction-uk.md](../../references/biz/jurisdiction-uk.md) for routing, cites [references/biz/hmrc-vcm-index.md](../../references/biz/hmrc-vcm-index.md) for SEIS / EIS, and cites [references/biz/ir35-cest-factors.md](../../references/biz/ir35-cest-factors.md) for the qualifying-employee context that occasionally affects fundraise eligibility.
 
+## Conversational intake before `draft`
+
+Before any `draft` output, run the conversational intake contract at [references/biz/fundraise-intake-contract.md](../../references/biz/fundraise-intake-contract.md). Conversation is the UX: ask one question at a time, push on vague answers, synthesize F1-F6 into `intake_summary:`, then perform a **Restate-and-confirm** step before evaluating the four gates and the Advance Assurance pre-check. If AA status, planned signature date, round size, investor-counsel status, or qualifying-trade evidence is unknown, refuse on ambiguity and ask for the missing fact; do not draft from assumptions.
+
+Evaluate `gate-1-regulated` only against the closed enum in [references/biz/uk-regulator-enumeration.md](../../references/biz/uk-regulator-enumeration.md). Cite [references/biz/hmrc-vcm-index.md](../../references/biz/hmrc-vcm-index.md) for SEIS/EIS and [references/biz/ico-duaa-index.md](../../references/biz/ico-duaa-index.md) for GDPR/DUAA context; do not restate authority prose inline.
+
 ## Modes
 
 | Mode | Use case | Output |
@@ -38,6 +44,54 @@ The advisor pattern is identical to `/slo-legal` (M1), `/slo-accounting` (M2), a
 | `pitch-narrative` | One-page pitch narrative covering problem / solution / wedge / traction / team / ask / SEIS-EIS-tax-relief-for-investors mention | NOT a deck designer — produces structured prose; the deck is built separately |
 | `investor-update` | Monthly / quarterly investor update template with KPIs / wins / asks / cash-runway sections | Pre-funded? Skip until you have investors. Funded? Use monthly. |
 | `term-sheet-redline-brief` | Pre-call brief for the founder going into a term-sheet redline session — what each clause means in plain English, what's standard / negotiable / red-flag, what questions to bring | Hard-block surface: gate-3 (counterparty has lawyer) is ALWAYS true for term-sheet redlines, so this artifact is always `prepare`-shaped, never `draft`-shaped. Format follows `prepare` mode by default but is filed under `draft` because it's a structured pre-meeting brief. |
+
+## M3 numeric verification for `safe-worksheet`
+
+Math is computed, not narrated. `draft safe-worksheet` MUST emit a **runnable Python snippet** plus an expected-results table, then perform **two-pass verification** before writing the artifact.
+
+Tolerance table:
+
+| Cell type | Tolerance |
+|---|---|
+| Currency cells | ±£1 |
+| Percentage cells | ±0.01% |
+| Whole-share counts | ±1 |
+
+SAFE worksheet verification contract:
+
+1. Emit the founder-visible snippet below, edited only by replacing the input literals with the confirmed intake values. Keep it stdlib-only and keep the `# SPDX-License-Identifier: MIT` header.
+2. Emit an expected-results table for valuation cap conversion, discount conversion, selected conversion price, investor shares, founder dilution, and post-conversion ownership.
+3. Re-derive the same cells inline using a different computation order: compute investor shares from investment / selected share price, then recompute ownership from total shares after conversion. This is the second pass.
+4. If the snippet result, expected-results table, and inline re-derivation differ outside tolerance, **refuse to write** and surface the mismatch as a small diff. Do not "round through" the discrepancy.
+
+```python
+# SPDX-License-Identifier: MIT
+# stdlib-only SAFE worksheet verifier
+
+investment_gbp = 250000
+valuation_cap_gbp = 5000000
+discount_percent = 20
+priced_round_pre_money_gbp = 8000000
+pre_round_shares = 1000000
+
+cap_price = valuation_cap_gbp / pre_round_shares
+round_price = priced_round_pre_money_gbp / pre_round_shares
+discount_price = round_price * (1 - discount_percent / 100)
+selected_price = min(cap_price, discount_price)
+investor_shares = round(investment_gbp / selected_price)
+post_shares = pre_round_shares + investor_shares
+investor_ownership = investor_shares / post_shares * 100
+founder_ownership = pre_round_shares / post_shares * 100
+
+print({
+    "cap_price_gbp": round(cap_price, 2),
+    "discount_price_gbp": round(discount_price, 2),
+    "selected_price_gbp": round(selected_price, 2),
+    "investor_shares": investor_shares,
+    "investor_ownership_percent": round(investor_ownership, 4),
+    "founder_ownership_percent": round(founder_ownership, 4),
+})
+```
 
 ## SEIS / EIS Advance Assurance pre-check (mandatory on every interaction)
 

--- a/skills/slo-hire/SKILL.md
+++ b/skills/slo-hire/SKILL.md
@@ -16,6 +16,12 @@ You are a hiring lead for a seed-stage technical founder. Founders make their fi
 
 Generator with mode_arg.
 
+## Conversational intake before artifact generation
+
+Before any hiring artifact, run the conversational intake contract at [references/biz/hire-intake-contract.md](../../references/biz/hire-intake-contract.md). Conversation is the UX: ask one question at a time, push on vague answers, synthesize F1-F6 into `intake_summary:`, then perform a **Restate-and-confirm** step before evaluating the four gates and the IR35 triggers. If engagement status, substitution, control, equipment/premises, exclusivity, or CEST output is unknown, refuse on ambiguity and ask for the missing fact; do not draft from assumptions.
+
+Evaluate `gate-1-regulated` only against the closed enum in [references/biz/uk-regulator-enumeration.md](../../references/biz/uk-regulator-enumeration.md). Cite [references/biz/uk-employment-statute-anchors.md](../../references/biz/uk-employment-statute-anchors.md) for right-to-work, notice, equality, pension, and IR35 statute anchors, and [references/biz/ir35-cest-factors.md](../../references/biz/ir35-cest-factors.md) for the seven IR35 triggers.
+
 | `mode_arg` | Role shape | Notes |
 |---|---|---|
 | `swe` | Software engineer | Senior+ for first SE hire |

--- a/skills/slo-launch/SKILL.md
+++ b/skills/slo-launch/SKILL.md
@@ -25,9 +25,24 @@ tier: public
 archetype: generator
 skill: slo-launch
 jurisdiction: uk
+baseline_ref: references/biz/launch-success-thresholds.md@2026-05-03
 expires_or_review_by: <YYYY-MM-DD + 60 days>
 ---
 ```
+
+## M4 baseline provenance
+
+Launch stage thresholds come from
+[`references/biz/launch-success-thresholds.md`](../../references/biz/launch-success-thresholds.md).
+Generated artifacts MUST include `baseline_ref:` with the retrieval stamp and
+`threshold_owner: founder`. If a consulted row is older than 12 months, emit a
+**stale warning** naming the row. If a consulted row is older than 24 months,
+**refuse at +24 months** and ask for a baseline refresh before producing launch
+threshold guidance.
+
+The launch rule is **set your own threshold** before each stage. Do not present
+Product Hunt rank, Hacker News position, signup count, or friend-conversion
+figures as universal success numbers.
 
 ## Body shape
 

--- a/skills/slo-legal/SKILL.md
+++ b/skills/slo-legal/SKILL.md
@@ -20,6 +20,12 @@ You are a UK legal advisor running first-cut document workshops for a seed-stage
 
 The founder's last bad day was an advisor telling them they needed an NDA before continuing the conversation. They didn't have one. They didn't know that contractor-built IP defaults to the contractor in UK law unless explicitly assigned. Your job is to close that gap — not by replacing solicitors, but by making the first 80% of routine legal work fast enough that the solicitor's 20% gets the attention it deserves.
 
+## Conversational intake before `draft`
+
+Before any `draft` output, run the conversational intake contract at [references/biz/legal-intake-contract.md](../../references/biz/legal-intake-contract.md). Conversation is the UX: ask one question at a time, push on vague answers, synthesize F1-F6 into `intake_summary:`, then perform a **Restate-and-confirm** step before evaluating the four gates. If any field is unknown, rounded, hypothetical, or internally inconsistent, refuse on ambiguity and ask for the missing fact; do not draft from assumptions.
+
+Evaluate `gate-1-regulated` only against the closed enum in [references/biz/uk-regulator-enumeration.md](../../references/biz/uk-regulator-enumeration.md). Do not enumerate regulators from training memory. Cite M1 authority files instead of restating statute prose: [references/biz/uk-employment-statute-anchors.md](../../references/biz/uk-employment-statute-anchors.md), [references/biz/uk-consumer-statute-anchors.md](../../references/biz/uk-consumer-statute-anchors.md), [references/biz/uk-marketing-statute-anchors.md](../../references/biz/uk-marketing-statute-anchors.md), and [references/biz/ico-duaa-index.md](../../references/biz/ico-duaa-index.md).
+
 ## Modes
 
 You accept exactly four modes. Refuse unknown modes with a clear error.

--- a/skills/slo-marketing/SKILL.md
+++ b/skills/slo-marketing/SKILL.md
@@ -35,9 +35,20 @@ archetype: generator
 skill: slo-marketing
 mode_arg: b2b | b2c
 jurisdiction: uk
+baseline_ref: references/biz/uk-marketing-statute-anchors.md@2026-05-03
 expires_or_review_by: <YYYY-MM-DD + 90 days>
 ---
 ```
+
+## M4 baseline provenance
+
+Marketing legal/routing anchors come from
+[`references/biz/uk-marketing-statute-anchors.md`](../../references/biz/uk-marketing-statute-anchors.md).
+Generated artifacts MUST include `baseline_ref:` when they cite ASA, CAP, PECR,
+DUAA, direct-marketing, or influencer-disclosure constraints. If a consulted row
+is older than 12 months, emit a **stale warning** naming the row. If a consulted
+row is older than 24 months, **refuse at +24 months** and ask for a source
+refresh before producing legal-risk routing guidance.
 
 ## `mode_arg: b2b` body
 

--- a/skills/slo-metrics/SKILL.md
+++ b/skills/slo-metrics/SKILL.md
@@ -57,9 +57,22 @@ archetype: generator
 skill: slo-metrics
 mode_arg: consumer | b2b
 jurisdiction: uk
+baseline_ref: references/biz/saas-kpi-targets-baseline.md@2026-05-03
 expires_or_review_by: <YYYY-MM-DD + 90 days>
 ---
 ```
+
+## M4 baseline provenance
+
+Financial KPI targets come from
+[`references/biz/saas-kpi-targets-baseline.md`](../../references/biz/saas-kpi-targets-baseline.md).
+Generated artifacts MUST include `baseline_ref:` with the retrieval stamp. If a
+consulted row is older than 12 months, emit a **stale warning** naming the row.
+If a consulted row is older than 24 months, **refuse at +24 months** and ask for
+a baseline refresh before producing target numbers.
+
+The target values below are readability mirrors of the cited baseline. If this
+SKILL.md and the baseline disagree, the baseline file wins.
 
 ## `mode_arg: b2b` body
 

--- a/skills/slo-pricing/SKILL.md
+++ b/skills/slo-pricing/SKILL.md
@@ -25,20 +25,56 @@ tier: public
 archetype: generator
 skill: slo-pricing
 jurisdiction: uk
+baseline_ref: references/biz/value-equation-pricing.md@2026-05-03
 expires_or_review_by: <YYYY-MM-DD + 90 days>
 ---
 ```
+
+## M4 baseline provenance
+
+Pricing heuristics come from
+[`references/biz/value-equation-pricing.md`](../../references/biz/value-equation-pricing.md).
+Generated artifacts MUST include `baseline_ref:` with the retrieval stamp. If a
+consulted row is older than 12 months, emit a **stale warning** naming the row.
+If a consulted row is older than 24 months, **refuse at +24 months** and ask for
+a baseline refresh before producing heuristic price bands.
 
 ## Body shape
 
 ### 1. Value-equation calculator
 
 Force the founder to estimate value delivered to the customer in £ per month or per year. Then anchor price as 25-33% of that.
+This 25-33% operating band is cited from `references/biz/value-equation-pricing.md@2026-05-03`; the artifact records the same `baseline_ref:`.
 
 | Customer outcome | Estimated £ value to customer | Confidence (low/med/high) | Price floor (25%) | Price ceiling (33%) | Recommended starting price |
 |---|---|---|---|---|---|
 
 If the founder can't estimate value within an order of magnitude, the skill REDIRECTS to `/slo-talk-to-users post-interview` for value-extraction questions BEFORE pricing.
+
+## M3 numeric verification for value-equation math
+
+Math is computed, not narrated. The value-equation calculator MUST emit a **runnable Python snippet** and perform **reciprocal verification** before writing the artifact. The band remains 25-33%; the recommended price is not a single magic number.
+
+The computation is: `price = round(value × ratio, -2)`. For reciprocal verification, compute `price=value×0.25` and then compute `value=price/0.25`; repeat for 0.33. If the forward and reciprocal calculations disagree outside ±£1 for currency or ±0.01% for percentages, **refuse to write** and surface the mismatch.
+
+```python
+# SPDX-License-Identifier: MIT
+# stdlib-only value-equation verifier
+
+customer_value_gbp = 10000
+ratios = [0.25, 0.33]
+
+for ratio in ratios:
+    price = round(customer_value_gbp * ratio, -2)
+    reciprocal_value = price / ratio
+    delta = abs(reciprocal_value - customer_value_gbp)
+    print({
+        "ratio": ratio,
+        "price_gbp": price,
+        "reciprocal_value_gbp": round(reciprocal_value, 2),
+        "delta_gbp": round(delta, 2),
+    })
+```
 
 ### 2. Tier model (3 tiers max)
 
@@ -65,6 +101,7 @@ Skill prose enforces this canonical correction:
 > - If conversion drops > 60%, the higher price is wrong; revert and investigate why.
 
 The skill records the experiment plan with explicit dates + decision criteria.
+The founder-undercharge framing is opinion-labeled in `references/biz/value-equation-pricing.md`; do not present it as a public market benchmark.
 
 ### 4. SEIS/EIS qualifying-trade interaction (cross-skill)
 

--- a/skills/slo-product/SKILL.md
+++ b/skills/slo-product/SKILL.md
@@ -44,9 +44,19 @@ archetype: generator
 skill: slo-product
 mode_arg: roadmap | metrics | okrs
 jurisdiction: uk
+baseline_ref: references/biz/product-prioritization-frameworks.md@2026-05-03
 expires_or_review_by: <YYYY-MM-DD + 90 days for roadmap and okrs; +180 for metrics>
 ---
 ```
+
+## M4 baseline provenance
+
+Roadmap prioritization frameworks come from
+[`references/biz/product-prioritization-frameworks.md`](../../references/biz/product-prioritization-frameworks.md).
+Generated artifacts that use RICE or Kano MUST include `baseline_ref:` with the
+retrieval stamp. If a consulted row is older than 12 months, emit a **stale warning**
+naming the row. If a consulted row is older than 24 months, **refuse at +24 months**
+and ask for a baseline refresh before producing framework-scored roadmaps.
 
 ## `mode_arg: roadmap` body
 
@@ -67,6 +77,7 @@ The roadmap is 90 days, broken into three 30-day sprints. Each item has a row:
 **RICE** = Reach × Impact × Confidence / Effort. Reach: users / week affected. Impact: 0.25 / 0.5 / 1 / 2 / 3. Confidence: 50% / 80% / 100%. Effort: person-weeks.
 
 **Kano**: must-have / performance / delighter / indifferent / reverse.
+Both definitions cite `references/biz/product-prioritization-frameworks.md@2026-05-03`.
 
 ### 3. "What we're NOT doing this quarter"
 

--- a/skills/slo-sales-funnel/SKILL.md
+++ b/skills/slo-sales-funnel/SKILL.md
@@ -26,9 +26,22 @@ tier: public
 archetype: generator
 skill: slo-sales-funnel
 jurisdiction: uk
+baseline_ref: references/biz/outbound-conversion-baselines.md@2026-05-03
 expires_or_review_by: <YYYY-MM-DD + 90 days>
 ---
 ```
+
+## M4 baseline provenance
+
+Outbound funnel conversion priors come from
+[`references/biz/outbound-conversion-baselines.md`](../../references/biz/outbound-conversion-baselines.md).
+Generated artifacts MUST include `baseline_ref:` with the retrieval stamp. If a
+consulted row is older than 12 months, emit a **stale warning** naming the row.
+If a consulted row is older than 24 months, **refuse at +24 months** and ask for
+a baseline refresh before producing starter conversion rates.
+
+The rates below are starter priors from the baseline file. Replace them with the
+founder's observed funnel rates once there are 20+ opportunities in a stage.
 
 ## Body shape
 
@@ -46,6 +59,7 @@ Force a top-down calculation. The skill demands:
 | **Cold outreach → qualified meetings** | 1-3% on cold; 10-20% on warm referrals | <N / 0.001125 to N / 0.0225> | — |
 
 The 90-day required outreach volume falls out of the math. If it's > 200 cold contacts/week, the founder is signalling either (a) wrong segment (too narrow), (b) wrong channel (cold isn't the right channel — try community-led from `/slo-gtm`), or (c) wrong funnel stage (warm-referral is structurally needed).
+These stage rates cite `references/biz/outbound-conversion-baselines.md@2026-05-03`; do not quote them without the artifact `baseline_ref:`.
 
 ### 2. Cold-email template — seven principles
 

--- a/skills/slo-talk-to-users/SKILL.md
+++ b/skills/slo-talk-to-users/SKILL.md
@@ -40,8 +40,21 @@ archetype: generator
 skill: slo-talk-to-users
 jurisdiction: uk
 mode_arg: pre-interview | post-interview
+baseline_ref: references/biz/mom-test-canonical-questions.md@2026-05-03
 ---
 ```
+
+## M4 baseline provenance
+
+Interview question discipline comes from
+[`references/biz/mom-test-canonical-questions.md`](../../references/biz/mom-test-canonical-questions.md).
+Generated artifacts MUST include `baseline_ref:` with the retrieval stamp. If a
+consulted row is older than 12 months, emit a **stale warning** naming the row.
+If a consulted row is older than 24 months, **refuse at +24 months** and ask for
+a baseline refresh before producing canonical interview-question scaffolding.
+
+The baseline is attribution-only. Paraphrase the question schema and avoid long
+verbatim passages from Rob Fitzpatrick's book.
 
 Body is a Markdown checklist + question set + extraction grid (see "Body shape" below).
 
@@ -80,6 +93,7 @@ The founder fills in 3-5 hypotheses they want to test. The skill produces the co
 ### Mom Test question set (no leading questions)
 
 A canonical 8-12 question set drawn from Rob Fitzpatrick's *The Mom Test* (2013):
+This question set cites `references/biz/mom-test-canonical-questions.md@2026-05-03`; keep it paraphrased and artifact-stamped with `baseline_ref:`.
 
 1. "Tell me about the last time you tried to [achieve outcome X]." — anchored in a SPECIFIC recent event, not hypothetical.
 2. "What was hard about that?" — pain-discovery; the user's words, not the founder's frame.

--- a/tests/e2e_research_m1.rs
+++ b/tests/e2e_research_m1.rs
@@ -6,7 +6,28 @@
 use std::process::Command;
 
 fn binary() -> String {
-    env!("CARGO_MANIFEST_DIR").to_string() + "/target/debug/sldo-research"
+    static RESEARCH_BIN: std::sync::OnceLock<String> = std::sync::OnceLock::new();
+
+    RESEARCH_BIN
+        .get_or_init(|| {
+            let manifest_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+            let bin = manifest_dir
+                .join("target")
+                .join("debug")
+                .join(format!("sldo-research{}", std::env::consts::EXE_SUFFIX));
+
+            if !bin.exists() {
+                let status = Command::new("cargo")
+                    .args(["build", "-p", "sldo-research"])
+                    .current_dir(&manifest_dir)
+                    .status()
+                    .expect("failed to build sldo-research");
+                assert!(status.success(), "cargo build -p sldo-research failed");
+            }
+
+            bin.to_string_lossy().into_owned()
+        })
+        .clone()
 }
 
 #[test]
@@ -90,6 +111,7 @@ fn test_prompt_file_accepted() {
 
     let output = Command::new(binary())
         .arg(prompt_file.to_str().unwrap())
+        .env("PATH", "/sldo_research_nonexistent_path_for_m1")
         .output()
         .expect("failed to execute sldo-research");
 
@@ -114,6 +136,7 @@ fn test_inline_prompt_accepted() {
     let output = Command::new(binary())
         .arg("--prompt")
         .arg("test topic for inline research")
+        .env("PATH", "/sldo_research_nonexistent_path_for_m1")
         .output()
         .expect("failed to execute sldo-research");
 

--- a/tests/e2e_research_m2.rs
+++ b/tests/e2e_research_m2.rs
@@ -8,7 +8,28 @@
 use std::process::Command;
 
 fn binary() -> String {
-    env!("CARGO_MANIFEST_DIR").to_string() + "/target/debug/sldo-research"
+    static RESEARCH_BIN: std::sync::OnceLock<String> = std::sync::OnceLock::new();
+
+    RESEARCH_BIN
+        .get_or_init(|| {
+            let manifest_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+            let bin = manifest_dir
+                .join("target")
+                .join("debug")
+                .join(format!("sldo-research{}", std::env::consts::EXE_SUFFIX));
+
+            if !bin.exists() {
+                let status = Command::new("cargo")
+                    .args(["build", "-p", "sldo-research"])
+                    .current_dir(&manifest_dir)
+                    .status()
+                    .expect("failed to build sldo-research");
+                assert!(status.success(), "cargo build -p sldo-research failed");
+            }
+
+            bin.to_string_lossy().into_owned()
+        })
+        .clone()
 }
 
 #[test]

--- a/tests/e2e_research_m3.rs
+++ b/tests/e2e_research_m3.rs
@@ -15,7 +15,28 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 
 fn binary() -> String {
-    env!("CARGO_MANIFEST_DIR").to_string() + "/target/debug/sldo-research"
+    static RESEARCH_BIN: std::sync::OnceLock<String> = std::sync::OnceLock::new();
+
+    RESEARCH_BIN
+        .get_or_init(|| {
+            let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+            let bin = manifest_dir
+                .join("target")
+                .join("debug")
+                .join(format!("sldo-research{}", std::env::consts::EXE_SUFFIX));
+
+            if !bin.exists() {
+                let status = Command::new("cargo")
+                    .args(["build", "-p", "sldo-research"])
+                    .current_dir(&manifest_dir)
+                    .status()
+                    .expect("failed to build sldo-research");
+                assert!(status.success(), "cargo build -p sldo-research failed");
+            }
+
+            bin.to_string_lossy().into_owned()
+        })
+        .clone()
 }
 
 fn unique_tmp(label: &str) -> PathBuf {

--- a/tests/e2e_research_m4.rs
+++ b/tests/e2e_research_m4.rs
@@ -10,7 +10,28 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 
 fn binary() -> String {
-    env!("CARGO_MANIFEST_DIR").to_string() + "/target/debug/sldo-research"
+    static RESEARCH_BIN: std::sync::OnceLock<String> = std::sync::OnceLock::new();
+
+    RESEARCH_BIN
+        .get_or_init(|| {
+            let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+            let bin = manifest_dir
+                .join("target")
+                .join("debug")
+                .join(format!("sldo-research{}", std::env::consts::EXE_SUFFIX));
+
+            if !bin.exists() {
+                let status = Command::new("cargo")
+                    .args(["build", "-p", "sldo-research"])
+                    .current_dir(&manifest_dir)
+                    .status()
+                    .expect("failed to build sldo-research");
+                assert!(status.success(), "cargo build -p sldo-research failed");
+            }
+
+            bin.to_string_lossy().into_owned()
+        })
+        .clone()
 }
 
 fn unique_tmp(label: &str) -> PathBuf {

--- a/tests/e2e_research_m5.rs
+++ b/tests/e2e_research_m5.rs
@@ -14,7 +14,28 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 
 fn binary() -> String {
-    env!("CARGO_MANIFEST_DIR").to_string() + "/target/debug/sldo-research"
+    static RESEARCH_BIN: std::sync::OnceLock<String> = std::sync::OnceLock::new();
+
+    RESEARCH_BIN
+        .get_or_init(|| {
+            let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+            let bin = manifest_dir
+                .join("target")
+                .join("debug")
+                .join(format!("sldo-research{}", std::env::consts::EXE_SUFFIX));
+
+            if !bin.exists() {
+                let status = Command::new("cargo")
+                    .args(["build", "-p", "sldo-research"])
+                    .current_dir(&manifest_dir)
+                    .status()
+                    .expect("failed to build sldo-research");
+                assert!(status.success(), "cargo build -p sldo-research failed");
+            }
+
+            bin.to_string_lossy().into_owned()
+        })
+        .clone()
 }
 
 fn unique_tmp(label: &str) -> PathBuf {

--- a/tests/e2e_research_m6.rs
+++ b/tests/e2e_research_m6.rs
@@ -24,7 +24,28 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 
 fn binary() -> String {
-    env!("CARGO_MANIFEST_DIR").to_string() + "/target/debug/sldo-research"
+    static RESEARCH_BIN: std::sync::OnceLock<String> = std::sync::OnceLock::new();
+
+    RESEARCH_BIN
+        .get_or_init(|| {
+            let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+            let bin = manifest_dir
+                .join("target")
+                .join("debug")
+                .join(format!("sldo-research{}", std::env::consts::EXE_SUFFIX));
+
+            if !bin.exists() {
+                let status = Command::new("cargo")
+                    .args(["build", "-p", "sldo-research"])
+                    .current_dir(&manifest_dir)
+                    .status()
+                    .expect("failed to build sldo-research");
+                assert!(status.success(), "cargo build -p sldo-research failed");
+            }
+
+            bin.to_string_lossy().into_owned()
+        })
+        .clone()
 }
 
 fn unique_tmp(label: &str) -> PathBuf {

--- a/tests/e2e_research_m7.rs
+++ b/tests/e2e_research_m7.rs
@@ -21,7 +21,28 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 
 fn binary() -> String {
-    env!("CARGO_MANIFEST_DIR").to_string() + "/target/debug/sldo-research"
+    static RESEARCH_BIN: std::sync::OnceLock<String> = std::sync::OnceLock::new();
+
+    RESEARCH_BIN
+        .get_or_init(|| {
+            let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+            let bin = manifest_dir
+                .join("target")
+                .join("debug")
+                .join(format!("sldo-research{}", std::env::consts::EXE_SUFFIX));
+
+            if !bin.exists() {
+                let status = Command::new("cargo")
+                    .args(["build", "-p", "sldo-research"])
+                    .current_dir(&manifest_dir)
+                    .status()
+                    .expect("failed to build sldo-research");
+                assert!(status.success(), "cargo build -p sldo-research failed");
+            }
+
+            bin.to_string_lossy().into_owned()
+        })
+        .clone()
 }
 
 fn fixture_path(rel: &str) -> PathBuf {


### PR DESCRIPTION
## Summary
Hardens the business skill pack against predicate-evaluation drift, stale authority citations, and unsourced numeric heuristics. This runbook moves UK authority/statute references and KPI heuristics into source-verified `references/biz` files, adds advisor intake contracts, adds numeric verification discipline, extends artifact provenance schema, and configures a PR-only annual refresh-loop contract.

## Milestones completed
- M1 — UK regulator enumeration source-verified + statute anchor files — [completion](docs/slo/completion/biz-imp-m1.md)
- M2 — Five conversational intake contracts + advisor SKILL.md updates — [completion](docs/slo/completion/biz-imp-m2.md)
- M3 — Numeric verification for SAFE / cap-table / pricing math — [completion](docs/slo/completion/biz-imp-m3.md)
- M4 — KPI baseline files + generator skill updates — [completion](docs/slo/completion/biz-imp-m4.md)
- M5 — `baseline_ref:` schema field + cross-skill citation tests + annual refresh `/loop` config — [completion](docs/slo/completion/biz-imp-m5.md)

## Test plan
- [x] `cargo test --workspace`
- [x] `cargo test -p sldo-install --test e2e_biz_imp_m1`
- [x] `cargo test -p sldo-install --test e2e_biz_imp_m2`
- [x] `cargo test -p sldo-install --test e2e_biz_imp_m3`
- [x] `cargo test -p sldo-install --test e2e_biz_imp_m4`
- [x] `cargo test -p sldo-install --test e2e_biz_imp_m5`
- [x] Reviewer: read each completion summary and skim the lessons file.
- [x] Reviewer: verify tracker is fully `done`.

## Issue updates
- Implements the runbook coverage for #19 and #20.
- Leaves repo hygiene / branch discipline follow-up tracked via #34.
- Related broader follow-ups #21 and #22 remain open for shared templates, evals, and hard-enforcement hooks beyond this runbook.

## Deferred follow-ups
- Shared `references/templates/` cleanup remains for the engineering-skill-improvements runbook; M2 used inline restate-and-confirm discipline because the shared templates are absent.
- Runtime `/schedule` execution is not present in this repo/session; M5 adds and tests the PR-only `.sldo/refresh-loop.toml` contract, but a future schedule-runtime runbook should define execution and manual dry-run behavior.
- Optional `ARCHITECTURE.md` / `README.md` cross-reference polish can follow separately.
- Track repo-hygiene skill hardening through #34 rather than widening this runbook.

## Security Assessment Summary - Business Skill Improvements

| Field | Value |
|---|---|
| Date | `2026-05-04` |
| Target | `business-skill-improvements` runbook |
| Scope | Advisor and generator skill Markdown contracts, `references/biz/` authority and baseline files, additive artifact-schema fields, structural tests, and PR-only refresh-loop config |
| Out of scope | Live `/schedule` runtime, merging/deploying the PR, broader per-skill eval hooks tracked outside this runbook |
| Skills / tools used | `/slo-execute`, `/slo-ship`, `cargo test --workspace`, GitHub PR flow |

### Executive summary
The highest-risk surfaces were stale legal/numeric authority references and automated refresh drift. This PR reduces those risks with source-verified reference files, stale/refusal discipline, structural tests, and an explicit no-auto-merge refresh config.

### Findings summary
No unresolved security findings were introduced by this runbook. The main residual is that refresh scheduling is a configured contract, not a live scheduler integration, because no `/schedule` skill body exists in this repo/session.

### Coverage gaps

| Gap | Reason | Follow-up |
|---|---|---|
| Live refresh-loop execution | No `/schedule` runtime was available to invoke or test | Future schedule-runtime runbook |
| Repo hygiene / branch discipline in execution skills | Identified as a separate process improvement | #34 |

Generated with `/slo-ship`.