### PR TITLE
Add repo hygiene branch gate to execution skills

### DIFF
--- a/crates/sldo-install/tests/e2e_ticket_issue34_repo_hygiene.rs
+++ b/crates/sldo-install/tests/e2e_ticket_issue34_repo_hygiene.rs
@@ -1,0 +1,157 @@
+//! Structural-contract tests for GitHub issue #34.
+//!
+//! These tests pin the repo hygiene and branch discipline expected from
+//! `/slo-execute` and `/slo-ticket-execute`: both skills must inspect git
+//! state before edits, avoid default/protected branch writes, preserve dirty
+//! default-branch work by moving it to a task branch, and record branch
+//! remediation evidence.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("crate dir parent")
+        .parent()
+        .expect("workspace root")
+        .to_path_buf()
+}
+
+fn read(path: impl AsRef<Path>) -> String {
+    let path = path.as_ref();
+    fs::read_to_string(path).unwrap_or_else(|e| panic!("cannot read {}: {e}", path.display()))
+}
+
+fn assert_contains_all(body: &str, path: &str, markers: &[&str]) {
+    for marker in markers {
+        assert!(
+            body.contains(marker),
+            "{path} must document `{marker}` for issue #34"
+        );
+    }
+}
+
+#[test]
+fn slo_execute_has_repo_hygiene_gate_before_file_edits() {
+    let path = "skills/slo-execute/SKILL.md";
+    let body = read(repo_root().join(path));
+
+    assert_contains_all(
+        &body,
+        path,
+        &[
+            "Repo hygiene gate",
+            "before file edits",
+            "git status --short --branch",
+            "git rev-parse --abbrev-ref HEAD",
+            "origin/HEAD",
+            "main",
+            "master",
+            "default/protected branch",
+            "slo/<runbook-prefix>-m<N>",
+        ],
+    );
+}
+
+#[test]
+fn slo_ticket_execute_has_matching_repo_hygiene_gate() {
+    let path = "skills/slo-ticket-execute/SKILL.md";
+    let body = read(repo_root().join(path));
+
+    assert_contains_all(
+        &body,
+        path,
+        &[
+            "Repo hygiene gate",
+            "before file edits",
+            "git status --short --branch",
+            "git rev-parse --abbrev-ref HEAD",
+            "origin/HEAD",
+            "main",
+            "master",
+            "default/protected branch",
+            "ticket/<issue>-<slug>",
+            "issue workpad",
+        ],
+    );
+}
+
+#[test]
+fn both_execution_skills_preserve_dirty_default_branch_work() {
+    let root = repo_root();
+    for path in &[
+        "skills/slo-execute/SKILL.md",
+        "skills/slo-ticket-execute/SKILL.md",
+    ] {
+        let body = read(root.join(path));
+        assert_contains_all(
+            &body,
+            path,
+            &[
+                "uncommitted work",
+                "default branch",
+                "switch",
+                "new branch",
+                "record the remediation",
+            ],
+        );
+    }
+}
+
+#[test]
+fn both_execution_skills_document_repo_hygiene_evidence_fields() {
+    let root = repo_root();
+    for path in &[
+        "skills/slo-execute/SKILL.md",
+        "skills/slo-ticket-execute/SKILL.md",
+    ] {
+        let body = read(root.join(path));
+        assert_contains_all(
+            &body,
+            path,
+            &[
+                "branch before",
+                "branch after",
+                "dirty-tree state",
+                "remediation needed",
+            ],
+        );
+    }
+}
+
+#[test]
+fn branch_names_are_task_scoped_not_agent_scoped() {
+    let root = repo_root();
+    for path in &[
+        "skills/slo-execute/SKILL.md",
+        "skills/slo-ticket-execute/SKILL.md",
+    ] {
+        let body = read(root.join(path));
+        assert_contains_all(
+            &body,
+            path,
+            &["Do not include the agent name", "host name", "model name"],
+        );
+    }
+}
+
+#[test]
+fn execution_skills_keep_commits_and_pushes_out_of_execute_by_default() {
+    let root = repo_root();
+    for path in &[
+        "skills/slo-execute/SKILL.md",
+        "skills/slo-ticket-execute/SKILL.md",
+    ] {
+        let body = read(root.join(path));
+        assert_contains_all(
+            &body,
+            path,
+            &[
+                "Execution may prepare the working tree",
+                "commits and pushes",
+                "explicitly asks",
+            ],
+        );
+    }
+}

--- a/docs/slo/tickets/ticket-34-repo-hygiene-branch-discipline.md
+++ b/docs/slo/tickets/ticket-34-repo-hygiene-branch-discipline.md
@@ -1,0 +1,223 @@
+# Repo Hygiene And Branch Discipline - SLO Ticket Contract v1
+
+> **Purpose**: Execute one issue-sized change with v4 SLO rigor, without requiring a full multi-milestone runbook.
+> **Audience**: AI coding agents first, humans second.
+> **Source template**: Derived from `docs/slo/templates/runbook-template_v_4_template.md`. Use the full v4 runbook when this contract cannot stay issue-sized.
+
+---
+
+## 1. Ticket Metadata
+
+| Field | Value |
+|---|---|
+| Ticket Contract ID | `ticket-34-repo-hygiene-branch-discipline` |
+| Source tracker | `GitHub Issues` |
+| Source issue | [#34](https://github.com/kerberosmansour/SunLitOrchestrate/issues/34) |
+| Issue title | `Add repo hygiene and branch discipline to SLO execution skills` |
+| Labels | `enhancement`, `retro-derived` |
+| Assignee / owner | `unassigned` |
+| Target branch | `ticket/34-repo-hygiene-branch-discipline` |
+| Primary stack | Markdown skill contracts + Rust structural tests |
+| Default formatter command | `cargo fmt --check -p sldo-install` |
+| Default typecheck / build command | `cargo test -p sldo-install --test e2e_ticket_issue34_repo_hygiene --no-run` |
+| Default static analysis / lint command | `cargo clippy -p sldo-install --tests -- -D warnings` |
+| Default unit / BDD command | `cargo test -p sldo-install --test e2e_ticket_issue34_repo_hygiene` |
+| Default runtime validation command | `N/A - docs-only skill-contract change` |
+| Default dependency / security audit command | `N/A - no dependency changes` |
+| Default debugger or state-inspection tool | `N/A - structural Markdown assertions are enough for this ticket` |
+| Public interfaces stable by default | `yes` |
+| Allowed new dependencies by default | `none` |
+| Schema/config migration allowed by default | `no` |
+
+### Public interfaces that must remain stable unless explicitly listed otherwise
+
+- `/slo-execute`
+- `/slo-ticket-execute`
+
+---
+
+## 2. Sizing Gate
+
+| Check | Answer |
+|---|---|
+| User-visible outcome fits in one sentence | `yes - execution skills now block or remediate unsafe default-branch work before edits` |
+| Expected changed files <= 8 | `yes - 4 files` |
+| New public surfaces <= 1 | `yes - no new command surface; existing skill contract text only` |
+| No schema migration unless explicitly approved | `yes` |
+| No cross-subsystem rewrite | `yes` |
+| Can be reviewed as one PR | `yes` |
+| Requires full v4 runbook instead | `no - issue-sized process hardening` |
+
+---
+
+## 3. Issue Context
+
+### Problem
+
+The execution skills already enforce BDD and allow-list discipline, but they do not consistently stop work that starts on `main` or another default/protected branch. They also do not record branch remediation evidence clearly enough for later review.
+
+Quoted issue context:
+
+~~~text
+Add a pre-flight repo hygiene gate to both execution paths:
+
+1. Run and record `git status --short --branch` before edits.
+2. Detect the current branch and default branch, including `main`, `master`, and `origin/HEAD` where available.
+3. If execution is on the default/protected branch, stop before file edits and create/switch to a task branch, unless the user explicitly instructed otherwise.
+4. If uncommitted work already exists on the default branch, preserve it by switching to a new branch immediately and record the remediation.
+5. Use predictable branch names for runbooks and tickets, e.g. `slo/<runbook-prefix>-m<N>` or `ticket/<issue>-<slug>` when no branch is specified.
+6. Add an evidence row for repo hygiene: branch before, branch after, dirty-tree state, and whether any remediation was needed.
+7. Clarify commit discipline: execution may prepare the working tree, but commits/pushes happen only when the active workflow or user explicitly asks for them.
+8. Ensure `/slo-ticket-execute` updates the issue workpad with the branch name once selected.
+~~~
+
+### Acceptance Criteria From Issue
+
+- [ ] `/slo-execute` refuses to continue on `main`/default branch until a feature branch exists.
+- [ ] `/slo-ticket-execute` has the same branch and dirty-tree guardrails as `/slo-execute`.
+- [ ] Both skills document how to preserve already-started work that accidentally began on `main`.
+- [ ] Both skills document evidence-log/workpad fields for repo hygiene.
+- [ ] Tests or docs validation cover the new pre-flight expectations if the repo has a suitable skill validation harness.
+
+### Non-Goals
+
+- No runtime hook implementation.
+- No branch creation, commit, or PR automation changes beyond skill contract prose.
+- No changes to the full runbook or ticket contract templates.
+
+### Reproduction / Current Signal
+
+| Signal | Evidence |
+|---|---|
+| Current `/slo-execute` pre-flight | Does not require `git status --short --branch`, default-branch detection, or branch remediation before file edits |
+| Current `/slo-ticket-execute` pre-flight | Only says to create or switch to the target branch |
+| Expected result | Both skills document a repo hygiene gate before edits, branch naming, dirty-tree preservation, evidence/workpad fields, and commit discipline |
+
+---
+
+## 4. Compact Architecture Delta
+
+N/A - no architecture delta. This ticket hardens Markdown skill contracts and structural tests only.
+
+### Data Flow Delta
+
+```text
+agent invokes execution skill
+  -> repo hygiene pre-flight checks git state before edits
+  -> branch remediation is recorded in evidence/workpad
+  -> implementation proceeds only on a task branch unless user explicitly overrides
+```
+
+---
+
+## 5. Contract Block
+
+| Contract Row | Value |
+|---|---|
+| Inputs | GitHub issue #34, existing skill prose, structural-test conventions |
+| Outputs | Updated skill contracts, new structural-contract test, filled ticket evidence |
+| Interfaces touched | `/slo-execute`, `/slo-ticket-execute` prose contracts |
+| Files allowed to change | `skills/slo-execute/SKILL.md`, `skills/slo-ticket-execute/SKILL.md`, `crates/sldo-install/tests/e2e_ticket_issue34_repo_hygiene.rs`, `docs/slo/tickets/ticket-34-repo-hygiene-branch-discipline.md` |
+| Files to read before changing | `skills/slo-execute/SKILL.md`, `skills/slo-ticket-execute/SKILL.md`, `crates/sldo-install/tests/e2e_ticket_flow.rs`, `docs/slo/design/ticket-sized-slo-workflow.md`, `docs/ARCHITECTURE.md` |
+| New files allowed | `crates/sldo-install/tests/e2e_ticket_issue34_repo_hygiene.rs`, `docs/slo/tickets/ticket-34-repo-hygiene-branch-discipline.md` |
+| New dependencies allowed | `none` |
+| Migration allowed | `no` |
+| Compatibility commitments | Existing execution skill flows, allow-list rule, ticket-loop contract, and no auto-commit behavior remain stable |
+| Data classification | `Public` |
+| Proactive controls in play | N/A - process/documentation control, no product security surface |
+| Abuse acceptance scenarios | Branch names must be deterministic and not include an agent name; default-branch writes are blocked unless explicitly overridden |
+| Resource bounds introduced/changed | N/A - no runtime resource growth |
+| Invariants/assertions required | Structural tests assert repo hygiene markers, branch naming, evidence/workpad fields, preservation of dirty default-branch work, and commit discipline |
+| Debugger / inspection expectation | N/A - failing structural tests provide direct evidence |
+| Static analysis gates | `cargo fmt --check -p sldo-install`, `cargo clippy -p sldo-install --tests -- -D warnings`, targeted integration test |
+| Forbidden shortcuts | Do not only update one execution skill; do not use agent-named branch examples; do not imply commits/pushes happen during execution without explicit user/workflow request |
+
+---
+
+## 6. Implementation Plan
+
+1. Add a failing structural-contract test for #34.
+2. Run the targeted test and record the expected failure.
+3. Add repo hygiene pre-flight prose to `/slo-execute`.
+4. Add matching branch/dirty-tree/workpad prose to `/slo-ticket-execute`.
+5. Run formatter, targeted test, and build/static gates as practical.
+6. Fill validation evidence in this ticket contract and update the issue workpad.
+
+---
+
+## 7. BDD Acceptance Scenarios
+
+| Scenario | Category | Given | When | Then | Evidence |
+|---|---|---|---|---|---|
+| Sprint execution blocks default branch | `happy path` | `/slo-execute` is invoked on `main`, `master`, or `origin/HEAD` default | Pre-flight runs before edits | The skill requires a task branch such as `slo/<runbook-prefix>-m<N>` before continuing | Structural test |
+| Ticket execution uses issue branch | `happy path` | `/slo-ticket-execute` has no existing target branch | Pre-flight chooses a branch | The skill documents `ticket/<issue>-<slug>` and updates the issue workpad | Structural test |
+| Dirty default branch is preserved | `empty / degraded state` | Uncommitted work exists on the default branch | Pre-flight detects it | The skill says to switch/create a task branch immediately and record remediation | Structural test |
+| Agent-named branches are avoided | `abuse case` | A coding agent is tempted to create a branch with host or agent branding | Pre-flight derives a branch name | Branch examples remain task-scoped and omit agent names | Structural test |
+
+---
+
+## 8. Validation Plan
+
+| Check | Command / Action | Expected Result | Actual Result | Status | Notes |
+|---|---|---|---|---|---|
+| Baseline before change | `cargo test -p sldo-install --test e2e_ticket_flow` | passes | Passed: 5 tests | `pass` | Existing ticket-flow baseline |
+| New tests fail first | `cargo test -p sldo-install --test e2e_ticket_issue34_repo_hygiene` | fails for missing repo hygiene prose before implementation | Failed as expected before skill edits: 0 passed, 6 failed, missing repo hygiene markers | `pass` | BDD-first structural test |
+| Formatter | `cargo fmt --check -p sldo-install` | passes | Package-level check blocked by pre-existing unrelated formatting drift in `e2e_biz_imp_m1.rs` and `e2e_biz_imp_m2.rs`; targeted `rustfmt --edition 2021 --check crates/sldo-install/tests/e2e_ticket_issue34_repo_hygiene.rs` passed | `pass-with-note` | Did not reformat unrelated files outside the ticket allow-list |
+| Typecheck / build | `cargo test -p sldo-install --test e2e_ticket_issue34_repo_hygiene --no-run` | passes | Passed | `pass` | |
+| Static analysis / lint | `cargo clippy -p sldo-install --tests -- -D warnings` | passes or documented existing warnings | Package-level clippy blocked by pre-existing unrelated `doc_lazy_continuation` warnings in `tests/common/claude_runtime.rs`; targeted `cargo clippy -p sldo-install --test e2e_ticket_issue34_repo_hygiene -- -D warnings` passed | `pass-with-note` | Did not edit unrelated test helper outside the allow-list |
+| Unit / BDD tests | `cargo test -p sldo-install --test e2e_ticket_issue34_repo_hygiene` | passes | Passed: 6 tests | `pass` | |
+| Runtime validation | `N/A` | docs-only skill-contract change | N/A - no runtime surface | `pass` | |
+| Dependency / security audit | `N/A` | no dependency changes | N/A - no dependency changes | `pass` | |
+| Resource bound / invariant check | Structural test branch-name and evidence-field assertions | passes | Passed in `e2e_ticket_issue34_repo_hygiene` | `pass` | |
+| Compatibility check | Review `skills/slo-execute/SKILL.md` and `skills/slo-ticket-execute/SKILL.md` allow-list sections remain intact | passes | Passed: allow-list and anti-placeholder markers still present in both skills | `pass` | |
+| `.gitignore` / artifact cleanup | `git status --short` | no stray artifacts | Clean except intended changes on `ticket/34-repo-hygiene-branch-discipline` | `pass` | |
+
+---
+
+## 9. Workpad / Tracker Updates
+
+Use one persistent issue comment marked `<!-- slo-ticket-workpad:v1 -->`.
+
+---
+
+## 10. Self-Review Gate
+
+- [x] Did I stay inside the file allow-list?
+- [x] Did I write or update BDD tests before production code?
+- [x] Did I confirm new tests failed for the right reason before implementing?
+- [x] Did I preserve public interfaces unless explicitly allowed to change them?
+- [x] Did I add or strengthen assertions/invariants where the contract required them?
+- [x] Did I bound new resource growth or document why no bound applies?
+- [x] Did I run formatter, typecheck/build, and static analysis?
+- [x] Did I use a debugger or state-inspection tool when failure evidence was ambiguous?
+- [x] Did I remove temporary proof edits, debug output, and placeholder logic?
+- [x] Did I record evidence rather than claims?
+- [x] Did I update the issue workpad and PR handoff notes?
+
+---
+
+## 11. Closure Summary
+
+### Completed
+
+- Added a repo hygiene pre-flight gate to `/slo-execute`.
+- Added matching branch, dirty-tree, workpad, and commit-discipline guidance to `/slo-ticket-execute`.
+- Added structural-contract tests for issue #34.
+
+### Tests And Validation
+
+- `cargo test -p sldo-install --test e2e_ticket_flow` - passed.
+- `cargo test -p sldo-install --test e2e_ticket_issue34_repo_hygiene` - failed first for missing markers, then passed after implementation.
+- `cargo test -p sldo-install --test e2e_ticket_issue34_repo_hygiene --no-run` - passed.
+- `rustfmt --edition 2021 --check crates/sldo-install/tests/e2e_ticket_issue34_repo_hygiene.rs` - passed.
+- `cargo clippy -p sldo-install --test e2e_ticket_issue34_repo_hygiene -- -D warnings` - passed.
+- Package-level `cargo fmt --check -p sldo-install` and `cargo clippy -p sldo-install --tests -- -D warnings` are blocked by unrelated pre-existing drift outside this ticket allow-list, documented above.
+
+### Lessons / Follow-Ups
+
+- Follow-up candidate: fix existing `cargo fmt` drift in `e2e_biz_imp_m1.rs` / `e2e_biz_imp_m2.rs` and clippy `doc_lazy_continuation` warnings in `tests/common/claude_runtime.rs` in a separate cleanup ticket.
+
+### PR / Issue Links
+
+- PR: pending
+- Issue: https://github.com/kerberosmansour/SunLitOrchestrate/issues/34

--- a/docs/slo/tickets/ticket-34-repo-hygiene-branch-discipline.md
+++ b/docs/slo/tickets/ticket-34-repo-hygiene-branch-discipline.md
@@ -219,5 +219,5 @@ Use one persistent issue comment marked `<!-- slo-ticket-workpad:v1 -->`.
 
 ### PR / Issue Links
 
-- PR: pending
+- PR: https://github.com/kerberosmansour/SunLitOrchestrate/pull/36
 - Issue: https://github.com/kerberosmansour/SunLitOrchestrate/issues/34

--- a/skills/slo-execute/SKILL.md
+++ b/skills/slo-execute/SKILL.md
@@ -30,6 +30,7 @@ You are a disciplined implementer. You just got handed one milestone of a runboo
 1. **Read the lessons file from the previous milestone.** Apply its "Rules for the next milestone" literally.
 1.5. **Read open prior-retro issues filtered by this runbook's prefix.** Surface them as scope candidates with a suggested lane (`micro | milestone | fresh-runbook`) — do NOT auto-extend the allow-list. The user decides each milestone's bounds. See "Pre-flight: prior-retro carry-forward" below for the full procedure.
 2. **Read the current milestone top to bottom.** Goal, context, contract block, out-of-scope, file allow-list, files-to-read, BDD scenarios, regression tests, E2E validation, smoke tests, compatibility, Definition of Done.
+2.5. **Run the Repo hygiene gate before file edits.** Record git state, confirm the current branch is not the default/protected branch, and create/switch to a task branch when needed. See "Pre-flight: Repo hygiene gate" below.
 3. **Run the baseline test command from the runbook metadata.** If it's red, stop and fix the baseline first — do not begin on a red baseline.
 4. **Read the files listed in "Files To Read Before Changing Anything".** Understand the current shape.
 5. **Update the Milestone Tracker** — current milestone to `in_progress`, record Started date.
@@ -81,6 +82,46 @@ If a runbook has a "Carry-forward from prior retros" section, prefer rows from t
 - First milestone of a runbook (M1): output `no carry-forward from prior retros (this is M1)`.
 - `gh` not on PATH or unauthenticated: warn + proceed. This pre-flight read is informational; missing `gh` does not block.
 - Multi-runbook prefix collision: surface BOTH and recommend renaming.
+
+## Pre-flight: Repo hygiene gate
+
+This gate runs before file edits. It is allowed to switch branches, but it must not edit project files until branch state is safe.
+
+### Commands to record
+
+Run and record:
+
+```
+git status --short --branch
+git rev-parse --abbrev-ref HEAD
+git symbolic-ref --short refs/remotes/origin/HEAD
+```
+
+If `origin/HEAD` is unavailable, detect the default branch from local context and fall back to checking both `main` and `master`. Treat the current branch as unsafe when it is the default/protected branch or when local policy marks it protected.
+
+### Branch rule
+
+If execution is on the default/protected branch, stop before file edits and create or switch to a task branch unless the user explicitly instructed execution to remain there. The default runbook branch shape is:
+
+```
+slo/<runbook-prefix>-m<N>
+```
+
+Do not include the agent name, host name, or model name in the branch. Branch names are task-scoped, not agent-scoped.
+
+If uncommitted work already exists on the default branch, preserve it by switching to a new branch immediately, then record the remediation. Do not stash, discard, or reset user work unless the user explicitly asks.
+
+### Evidence row
+
+Add or fill a Repo hygiene row in the Evidence Log with:
+
+- branch before
+- branch after
+- dirty-tree state
+- remediation needed
+- remediation taken
+
+Execution may prepare the working tree; commits and pushes happen only when the active workflow or the user explicitly asks for them.
 
 ## The allow-list rule — never bend
 

--- a/skills/slo-ticket-execute/SKILL.md
+++ b/skills/slo-ticket-execute/SKILL.md
@@ -38,7 +38,47 @@ You are the implementer for one issue-sized SLO contract. Your job is to satisfy
    - invariants/assertions
    - static-analysis gates
    - validation commands
-6. Create or switch to the target branch.
+6. Run the Repo hygiene gate before file edits. Record git state, confirm the current branch is not the default/protected branch, create/switch to the target task branch when needed, and update the issue workpad with the branch name once selected.
+
+## Pre-flight: Repo hygiene gate
+
+This gate runs before file edits. It is allowed to switch branches, but it must not edit project files until branch state is safe.
+
+### Commands to record
+
+Run and record:
+
+```
+git status --short --branch
+git rev-parse --abbrev-ref HEAD
+git symbolic-ref --short refs/remotes/origin/HEAD
+```
+
+If `origin/HEAD` is unavailable, detect the default branch from local context and fall back to checking both `main` and `master`. Treat the current branch as unsafe when it is the default/protected branch or when local policy marks it protected.
+
+### Branch rule
+
+Use the ticket contract's target branch when it is present. If the contract does not name one, derive:
+
+```
+ticket/<issue>-<slug>
+```
+
+Do not include the agent name, host name, or model name in the branch. Branch names are task-scoped, not agent-scoped.
+
+If execution is on the default/protected branch, stop before file edits and create or switch to the task branch unless the user explicitly instructed execution to remain there. If uncommitted work already exists on the default branch, preserve it by switching to a new branch immediately, then record the remediation. Do not stash, discard, or reset user work unless the user explicitly asks.
+
+### Evidence and workpad row
+
+Add or fill a Repo hygiene row in the ticket Validation Plan and issue workpad with:
+
+- branch before
+- branch after
+- dirty-tree state
+- remediation needed
+- remediation taken
+
+The issue workpad must include the selected branch name. Execution may prepare the working tree; commits and pushes happen only when the active workflow or the user explicitly asks for them.
 
 ## Allow-list rule
 


### PR DESCRIPTION
## Summary
Adds a repo hygiene pre-flight gate to both `/slo-execute` and `/slo-ticket-execute` so execution records git state, avoids default/protected branch edits, preserves dirty default-branch work by moving it to a task branch, and records branch remediation evidence.

## Issue
Closes #34

## SLO ticket contract
- `docs/slo/tickets/ticket-34-repo-hygiene-branch-discipline.md`

## Validation
- `cargo test -p sldo-install --test e2e_ticket_flow` - passed
- `cargo test -p sldo-install --test e2e_ticket_issue34_repo_hygiene` - failed first as expected, then passed: 6 tests
- `cargo test -p sldo-install --test e2e_ticket_issue34_repo_hygiene --no-run` - passed
- `rustfmt --edition 2021 --check crates/sldo-install/tests/e2e_ticket_issue34_repo_hygiene.rs` - passed
- `cargo clippy -p sldo-install --test e2e_ticket_issue34_repo_hygiene -- -D warnings` - passed
- `git diff --check` - passed

Package-level checks noted in the ticket contract:
- `cargo fmt --check -p sldo-install` is currently blocked by unrelated pre-existing formatting drift in `e2e_biz_imp_m1.rs` and `e2e_biz_imp_m2.rs`.
- `cargo clippy -p sldo-install --tests -- -D warnings` is currently blocked by unrelated pre-existing `doc_lazy_continuation` warnings in `tests/common/claude_runtime.rs`.

## Risk and compatibility
- Data classification: Public
- Public surfaces touched: `/slo-execute`, `/slo-ticket-execute` prose contracts only
- Compatibility: existing allow-list and BDD-first execution discipline remains intact
- Branch examples are task-scoped (`slo/<runbook-prefix>-m<N>`, `ticket/<issue>-<slug>`) and avoid agent, host, or model names

## Follow-ups
- Suggested separate cleanup ticket: fix the pre-existing package-level fmt/clippy drift outside this ticket allow-list.

Generated with /slo-ticket-close