### PR TITLE
Decompose slo-tla methodology

### DIFF
--- a/crates/sldo-install/tests/e2e_eng_imp_m3.rs
+++ b/crates/sldo-install/tests/e2e_eng_imp_m3.rs
@@ -1,0 +1,263 @@
+//! M3 structural-contract tests for the engineering skill-improvements runbook.
+//!
+//! M3 decomposes `/slo-tla` from a long sequential guide into a thin dispatcher
+//! plus four skill-local methodology references. These tests keep the cut honest:
+//! the cross-stage suitability gate stays in the dispatcher, source methodology
+//! travels with the skill install, and Apalache is pinned with a real SHA-256.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const METHODOLOGY_FILES: &[(&str, &str)] = &[
+    (
+        "methodology-elicitation.md",
+        "slo-tla-methodology-elicitation",
+    ),
+    (
+        "methodology-abstraction.md",
+        "slo-tla-methodology-abstraction",
+    ),
+    (
+        "methodology-counterexample.md",
+        "slo-tla-methodology-counterexample",
+    ),
+    (
+        "methodology-verified-design.md",
+        "slo-tla-methodology-verified-design",
+    ),
+];
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .to_path_buf()
+}
+
+fn read(path: impl AsRef<Path>) -> String {
+    let path = path.as_ref();
+    fs::read_to_string(path).unwrap_or_else(|e| panic!("cannot read {}: {e}", path.display()))
+}
+
+fn skill_md() -> String {
+    read(repo_root().join("skills/slo-tla/SKILL.md"))
+}
+
+fn methodology_path(file: &str) -> PathBuf {
+    repo_root().join("skills/slo-tla/references").join(file)
+}
+
+fn methodology(file: &str) -> String {
+    read(methodology_path(file))
+}
+
+fn tools_toml() -> String {
+    read(repo_root().join("skills/slo-tla/tools.toml"))
+}
+
+fn combined_operating_text() -> String {
+    let mut combined = skill_md();
+    for (file, _) in METHODOLOGY_FILES {
+        let path = methodology_path(file);
+        if path.exists() {
+            combined.push('\n');
+            combined.push_str(&read(path));
+        }
+    }
+    combined
+}
+
+fn value_for_key_in_section(body: &str, section: &str, key: &str) -> Option<String> {
+    let mut in_section = false;
+
+    for line in body.lines() {
+        let trimmed = line.trim();
+        if trimmed.starts_with('[') && trimmed.ends_with(']') {
+            in_section = trimmed == format!("[{section}]");
+            continue;
+        }
+
+        if !in_section || trimmed.starts_with('#') {
+            continue;
+        }
+
+        let Some((candidate, value)) = trimmed.split_once('=') else {
+            continue;
+        };
+
+        if candidate.trim() == key {
+            return Some(value.trim().trim_matches('"').to_string());
+        }
+    }
+
+    None
+}
+
+#[test]
+fn slo_tla_skill_md_at_or_under_150_lines_without_exception() {
+    let skill = skill_md();
+    let line_count = skill.lines().count();
+
+    assert!(
+        line_count <= 150,
+        "skills/slo-tla/SKILL.md must be a thin dispatcher (<= 150 lines), saw {line_count}"
+    );
+    assert!(
+        !skill.contains("# soft-cap-exception:"),
+        "M3 must meet the hard <= 150-line target without a soft-cap exception"
+    );
+}
+
+#[test]
+fn methodology_files_exist_with_frontmatter_and_local_references_path() {
+    for (file, name) in METHODOLOGY_FILES {
+        let path = methodology_path(file);
+        assert!(
+            path.exists(),
+            "missing skill-local methodology file {}",
+            path.display()
+        );
+
+        let body = read(&path);
+        assert!(
+            body.starts_with("---\n"),
+            "{file} must begin with YAML frontmatter"
+        );
+        assert!(
+            body.contains(&format!("name: {name}")),
+            "{file} must declare frontmatter name `{name}`"
+        );
+        assert!(
+            body.contains("source_skill: skills/slo-tla/SKILL.md"),
+            "{file} must record the source skill for install/readability continuity"
+        );
+    }
+
+    assert!(
+        repo_root().join("skills/slo-tla/references").is_dir(),
+        "methodology files must live under skills/slo-tla/references/ so they travel with the installed skill symlink"
+    );
+}
+
+#[test]
+fn thin_skill_keeps_gate_and_points_to_every_methodology_contract() {
+    let skill = skill_md();
+    assert!(
+        skill.contains("Suitability gate"),
+        "cross-stage suitability gate must stay in SKILL.md"
+    );
+
+    for link in [
+        "references/methodology-elicitation.md",
+        "references/methodology-abstraction.md",
+        "references/methodology-counterexample.md",
+        "references/methodology-verified-design.md",
+    ] {
+        assert!(
+            skill.contains(link),
+            "thin SKILL.md must cite `{link}` instead of inlining that methodology"
+        );
+    }
+}
+
+#[test]
+fn tla_methodology_disciplines_survive_decomposition() {
+    let combined = combined_operating_text();
+    let abstraction = methodology("methodology-abstraction.md");
+    let counterexample = methodology("methodology-counterexample.md");
+    let verified = methodology("methodology-verified-design.md");
+
+    for needle in [
+        "the smallest model that still exhibits the bug on the pre-fix design",
+        "State-space budget rule of thumb",
+        "Drop liveness first",
+        "Power-set subsets become presence booleans",
+    ] {
+        assert!(
+            abstraction.contains(needle),
+            "abstraction methodology missing `{needle}`"
+        );
+    }
+
+    for needle in [
+        "Raw TLC output is a sequence of states",
+        "Broken design assumption",
+        "design fix applied to spec",
+    ] {
+        assert!(
+            counterexample.contains(needle),
+            "counterexample methodology missing `{needle}`"
+        );
+    }
+
+    for needle in [
+        "Bound is not stated",
+        "Fairness is not declared",
+        "Naive / pre-fix variant passes silently",
+        "Simplifications from the real design",
+    ] {
+        assert!(
+            verified.contains(needle),
+            "verified-design methodology missing `{needle}`"
+        );
+    }
+
+    for rule in [
+        "Only after safety holds. Every liveness property needs a fairness assumption",
+        "Always run the Naive / pre-fix variant first",
+        "TLA+ is not the right tool here",
+        "N actors, M requests, K failures",
+    ] {
+        assert!(
+            combined.contains(rule),
+            "decomposition lost required rule: {rule}"
+        );
+    }
+}
+
+#[test]
+fn apalache_pin_in_tools_toml_and_tlc_pin_unchanged() {
+    let tools = tools_toml();
+
+    assert_eq!(
+        value_for_key_in_section(&tools, "tlc", "version").as_deref(),
+        Some("1.8.0"),
+        "M3 must not change the existing TLC version pin"
+    );
+    assert_eq!(
+        value_for_key_in_section(&tools, "tlc", "url").as_deref(),
+        Some("https://github.com/tlaplus/tlaplus/releases/download/v1.8.0/tla2tools.jar"),
+        "M3 must not change the existing TLC URL pin"
+    );
+    assert_eq!(
+        value_for_key_in_section(&tools, "tlc", "sha256").as_deref(),
+        Some("d5d07d5dab38ddb840c91ec48fa02f28b37a608d5af9a73570018591dbc8ef7f"),
+        "M3 must not change the existing TLC SHA-256 pin"
+    );
+
+    let version = value_for_key_in_section(&tools, "apalache", "version")
+        .expect("Apalache version pin missing");
+    let download_url = value_for_key_in_section(&tools, "apalache", "download_url")
+        .expect("Apalache download_url pin missing");
+    let sha256 =
+        value_for_key_in_section(&tools, "apalache", "sha256").expect("Apalache SHA missing");
+
+    assert_eq!(
+        version, "0.57.0",
+        "Apalache must be pinned to the source-verified release"
+    );
+    assert_eq!(
+        download_url,
+        "https://github.com/apalache-mc/apalache/releases/download/v0.57.0/apalache.tgz"
+    );
+    assert!(
+        sha256.len() == 64 && sha256.chars().all(|c| c.is_ascii_hexdigit()),
+        "Apalache sha256 must be a 64-character hex digest, saw `{sha256}`"
+    );
+    assert_eq!(
+        sha256, "cb805df9a68e2f278c45e751522aab119b57a454e3e0e96f5d974b969fe52b5d",
+        "Apalache pin must match the locally computed v0.57.0 apalache.tgz digest"
+    );
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -64,7 +64,7 @@ For the full host-neutral skill inventory, read `docs/skill-pack-catalog.md`.
 - `references/security/` holds shared security finding and assessment summary templates used by review / verification skills, plus the curated CWE × OWASP × ASVS × OpenCRE table at [`references/security/standards-mapping.md`](../references/security/standards-mapping.md) (added by sap-imp M3).
 - `references/sast/` holds SAST-specific references consumed by the security tooling and rule-pack work.
 - `references/templates/` holds shared cross-skill discipline templates for citation hierarchy, intake, restate-and-confirm, tool safety, output frontmatter, escalation, eval cases, heuristic numbers, rate limiting, fallback handling, and version pinning.
-- `skills/<skill>/references/` holds skill-local methodology files that travel with the installed skill symlink; `/slo-sast` uses this pattern for its M1-M5 operating procedures.
+- `skills/<skill>/references/` holds skill-local methodology files that travel with the installed skill symlink; `/slo-sast` uses this pattern for its M1-M5 operating procedures and `/slo-tla` uses it for elicitation, abstraction, counterexample translation, and verified-design guidance.
 - These trees are read by skills, but they are not discovered as installable skills because `sldo-install` only walks `skills/<name>/SKILL.md`.
 
 ## Rust workspace

--- a/docs/slo/completion/eng-imp-m3.md
+++ b/docs/slo/completion/eng-imp-m3.md
@@ -1,0 +1,51 @@
+---
+runbook: engineering-skill-improvements
+prefix: eng-imp
+milestone: M3
+completed: 2026-05-04
+status: done
+---
+
+# Completion - eng-imp M3
+
+**Goal**: Decompose `/slo-tla` into a thin SKILL.md plus four methodology
+references, while preserving the suitability gate and pinning Apalache with a
+source-verified SHA-256.
+
+## Shipped
+
+| File | Change |
+|---|---|
+| `skills/slo-tla/SKILL.md` | Reduced from 333 lines to 150-line dispatcher with prereq cascade, suitability gate, method links, and compatibility sentinels. |
+| `skills/slo-tla/references/methodology-elicitation.md` | Added elicitation and staged spec-drafting methodology. |
+| `skills/slo-tla/references/methodology-abstraction.md` | Added abstraction-balance and state-explosion methodology. |
+| `skills/slo-tla/references/methodology-counterexample.md` | Added counterexample translation methodology. |
+| `skills/slo-tla/references/methodology-verified-design.md` | Added verified-design document shape, refusal gates, anti-patterns, and handoff detail. |
+| `skills/slo-tla/tools.toml` | Updated `[apalache]` to source-verified `0.57.0` with `download_url` and SHA-256; kept existing TLC pin unchanged. |
+| `crates/sldo-install/tests/e2e_eng_imp_m3.rs` | Added structural test for decomposition, line cap, methodology files, preserved TLA+ disciplines, and Apalache pin format/value. |
+| `docs/slo/lessons/eng-imp-m3.md` | Added cut plan, Apalache verification evidence, and M4 rules. |
+| `docs/ARCHITECTURE.md` | Documented `/slo-tla` as a user of the skill-local references pattern. |
+
+## Validation
+
+| Command / Check | Result |
+|---|---|
+| `cargo test --workspace` before edits | Passed. |
+| `cargo test -p sldo-install --test e2e_eng_imp_m3` before implementation | Failed for expected red-first reasons. |
+| `cargo test -p sldo-install --test e2e_eng_imp_m3` after implementation | Passed. |
+| `cargo test -p sldo-install --test e2e_slo_sp_m5` | Passed. |
+| `cargo test -p sldo-install` | Passed. |
+| `cargo test --workspace` | Passed. |
+| `cargo build --workspace` | Passed with pre-existing `sast-verify` warnings. |
+| `rustfmt --edition 2021 --check crates/sldo-install/tests/e2e_eng_imp_m3.rs` | Passed. |
+| `git diff --check` | Passed. |
+| `cargo fmt --check -p sldo-install` | Still blocked by pre-existing unrelated formatting drift in `e2e_biz_imp_m1.rs` and `e2e_biz_imp_m2.rs`. |
+| `wc -l skills/slo-tla/SKILL.md` | 150 lines. |
+| Apalache SHA-256 capture | Upstream `sha256sum.txt` and local `shasum -a 256` both returned `cb805df9a68e2f278c45e751522aab119b57a454e3e0e96f5d974b969fe52b5d`. |
+
+## Carry Forward
+
+M4 should decompose `/slo-plan` with the same pattern, then land the soft
+line-cap structural test. The test should pass `/slo-sast` and `/slo-tla`
+without exceptions and force any remaining oversized skill to carry an explicit
+reason.

--- a/docs/slo/future/RUNBOOK-ENGINEERING-SKILL-IMPROVEMENTS.md
+++ b/docs/slo/future/RUNBOOK-ENGINEERING-SKILL-IMPROVEMENTS.md
@@ -33,7 +33,7 @@
 |---|---|---|---|---|---|---|
 | 1 | `references/templates/` shared library + research-validation prereq landed | `done` | 2026-05-04 | 2026-05-04 | `docs/slo/lessons/eng-imp-m1.md` | `docs/slo/completion/eng-imp-m1.md` |
 | 2 | `/slo-sast` decomposition into thin SKILL.md + `methodology-m1..m5.md` | `done` | 2026-05-04 | 2026-05-04 | `docs/slo/lessons/eng-imp-m2.md` | `docs/slo/completion/eng-imp-m2.md` |
-| 3 | `/slo-tla` decomposition + Apalache pin in `tools.toml` | `not_started` | | | | |
+| 3 | `/slo-tla` decomposition + Apalache pin in `tools.toml` | `done` | 2026-05-04 | 2026-05-04 | `docs/slo/lessons/eng-imp-m3.md` | `docs/slo/completion/eng-imp-m3.md` |
 | 4 | `/slo-plan` per-milestone authoring extracted; soft line-cap structural-contract test | `not_started` | | | | |
 | 5 | Per-skill `evals/` infrastructure + `/slo-freeze` PreToolUse hook + cross-skill polish | `not_started` | | | | |
 

--- a/docs/slo/lessons/eng-imp-m3.md
+++ b/docs/slo/lessons/eng-imp-m3.md
@@ -1,0 +1,77 @@
+---
+runbook: engineering-skill-improvements
+prefix: eng-imp
+milestone: M3
+created: 2026-05-04
+status: done
+---
+
+# Lessons - eng-imp M3
+
+## Cut Plan
+
+M3 reused the dispatcher-plus-methodology cut for `/slo-tla`.
+
+| Destination | Content moved or retained |
+|---|---|
+| `skills/slo-tla/SKILL.md` | Kept frontmatter, role, shared discipline links, inputs/outputs, prereq cascade, suitability gate, method-dispatch table, common refusal gates, anti-patterns, and handoff. Final size: 150 lines. |
+| `skills/slo-tla/references/methodology-elicitation.md` | Moved Q1-Q6 elicitation prompts and staged spec drafting. |
+| `skills/slo-tla/references/methodology-abstraction.md` | Moved abstraction balance, state-space budget, and state-explosion triage. |
+| `skills/slo-tla/references/methodology-counterexample.md` | Moved counterexample translation procedure and trace markdown shape. |
+| `skills/slo-tla/references/methodology-verified-design.md` | Moved verified-design doc shape, refusal gates, anti-patterns, and handoff detail. |
+
+## Apalache Source Verification
+
+| Field | Captured value |
+|---|---|
+| Retrieval date | 2026-05-04 |
+| Release page | `https://github.com/apalache-mc/apalache/releases/tag/v0.57.0` |
+| Release tag | `v0.57.0` |
+| Published at | 2026-04-24T13:58:09Z |
+| Asset | `apalache.tgz` |
+| Download URL | `https://github.com/apalache-mc/apalache/releases/download/v0.57.0/apalache.tgz` |
+| Upstream checksum file value | `cb805df9a68e2f278c45e751522aab119b57a454e3e0e96f5d974b969fe52b5d` |
+| Locally computed SHA-256 | `cb805df9a68e2f278c45e751522aab119b57a454e3e0e96f5d974b969fe52b5d` |
+
+`tools.toml` keeps the existing TLC pin unchanged and updates `[apalache]` with
+`version`, `url`, `download_url`, and `sha256`. The extra `url` key preserves
+older structural tests while `download_url` satisfies the M3 contract.
+
+## Compatibility Notes
+
+- Existing `e2e_slo_sp_m5` tests still read `skills/slo-tla/SKILL.md` for JVM, checksum, bounds, fairness, Apalache, and cache-location sentinels. The dispatcher keeps those compactly.
+- The suitability gate remains in `SKILL.md` because it decides whether the skill should run at all.
+- The new M3 structural test enforces line cap, four methodology files, frontmatter, skill-local `references/` location, preserved TLA+ disciplines, TLC pin stability, and the Apalache SHA-256 pin.
+
+## Evidence
+
+| Check | Actual Result |
+|---|---|
+| Repo hygiene | Branch before edits: `slo/eng-imp-m3`; branch after edits: `slo/eng-imp-m3`; dirty tree before edits: clean; remediation needed: none. |
+| Baseline before M3 edits | `cargo test --workspace` passed on branch `slo/eng-imp-m3` before decomposition edits. |
+| Apalache release capture | GitHub release API and release page reported `v0.57.0`; upstream `sha256sum.txt` and local `shasum -a 256` matched for `apalache.tgz`. |
+| Red-first M3 test | `cargo test -p sldo-install --test e2e_eng_imp_m3` failed for expected reasons: 333-line SKILL.md, missing methodology files, missing dispatch links, and missing `download_url` pin. |
+| M3 structural test after implementation | `cargo test -p sldo-install --test e2e_eng_imp_m3` passed: 5 passed, 0 failed. |
+| Legacy `/slo-tla` compatibility test | `cargo test -p sldo-install --test e2e_slo_sp_m5` passed: 11 passed, 0 failed. |
+| Package test suite | `cargo test -p sldo-install` passed. |
+| Workspace test suite | `cargo test --workspace` passed after implementation and closeout docs. |
+| Workspace build | `cargo build --workspace` passed with pre-existing `sast-verify` warnings. |
+| Formatting | `rustfmt --edition 2021 --check crates/sldo-install/tests/e2e_eng_imp_m3.rs` passed; `cargo fmt --check -p sldo-install` remains blocked by pre-existing unrelated drift in `e2e_biz_imp_m1.rs` and `e2e_biz_imp_m2.rs`. |
+| Diff hygiene | `git diff --check` passed. |
+| Line count | `skills/slo-tla/SKILL.md` is 150 lines. |
+| SAST authority docs untouched | `references/sast/` remained unchanged. |
+
+## Rules For The Next Milestone
+
+- In M4, apply the same thin-dispatcher pattern to `/slo-plan`, but preserve the interactive one-milestone-at-a-time authoring contract in a skill-local methodology file.
+- Reuse the M2/M3 structural-test style: hard line cap, local reference files, dispatch links, and focused sentinel preservation.
+- The soft line-cap test in M4 must account for already-decomposed `/slo-sast` and `/slo-tla` without requiring soft-cap exceptions.
+- Scan existing `/slo-plan` tests before cutting; keep compatibility sentinels in the dispatcher where old tests expect them.
+
+## Allow-List Note
+
+The M3 Contract Block allowed the TLA skill, four skill-local methodology files,
+`tools.toml`, and the structural test. The runbook Definition of Done also
+requires tracker, lessons, completion, and an ARCHITECTURE post-flight note.
+Those closeout/doc-index edits are recorded as milestone evidence rather than
+product-surface changes.

--- a/skills/slo-tla/SKILL.md
+++ b/skills/slo-tla/SKILL.md
@@ -10,11 +10,13 @@ description: >
   bounds. Skip for simple CRUD systems with no real concurrency risk.
 ---
 
-# /slo-tla — verify the design with TLA+
+# /slo-tla — Verify The Design With TLA+
 
-You are a formal-methods engineer who has seen a lot of "this looks fine on a whiteboard" designs blow up in production. You translate designs into TLA+, run TLC, and do not let the word "verified" mean anything less than "TLC found no violations at stated bounds."
+You are a formal-methods engineer. Translate designs into TLA+, run TLC, and do
+not let "verified" mean anything less than "TLC found no violations at stated
+bounds."
 
-## Shared discipline references
+## Shared Discipline References
 
 - Tool/version claims follow [`../../references/templates/citation-discipline.md`](../../references/templates/citation-discipline.md).
 - JVM, jar, TLC, and Apalache subprocess checks follow [`../../references/templates/tool-safety-section.md`](../../references/templates/tool-safety-section.md).
@@ -22,53 +24,36 @@ You are a formal-methods engineer who has seen a lot of "this looks fine on a wh
 
 ## Inputs
 
-- A design doc, usually at `docs/slo/design/<slug>-overview.md` from `/slo-architect`, or a hand-written design.
+- A design doc, usually `docs/slo/design/<slug>-overview.md` from `/slo-architect`.
 - Optionally, an existing spec at `specs/<name>.tla` to extend.
 
 ## Outputs
 
-Four artifacts under `specs/` and `docs/slo/design/`:
+Write `specs/<name>.tla`, `specs/<name>.cfg`, `specs/<name>.trace.md`, and
+`docs/slo/design/<name>-verified.md`. If a v3/v4 runbook exists for the slug,
+patch its "High-Level Design for Formal Verification" section.
 
-1. `specs/<name>.tla` — the TLA+ spec.
-2. `specs/<name>.cfg` — TLC config (constants, invariants, temporal properties, bounds).
-3. `specs/<name>.trace.md` — counterexamples TLC produced, translated to plain-English sequences.
-4. `docs/slo/design/<name>-verified.md` — the validated design writeup.
-
-If a v3 runbook exists for this slug, patch its "High-Level Design for Formal Verification" section.
-
-## Prereq cascade
+## Prereq Cascade
 
 Do each step in order. Do not skip. Do not "try it anyway."
 
-### 1. JVM check
+### 1. JVM Check
 
-```bash
-which java
-```
+Run `which java`. If missing, print the Java requirement and exit non-zero with
+install hints: macOS `brew install openjdk`, Debian/Ubuntu
+`sudo apt install default-jre`, or https://adoptium.net/. Do not install Java for
+the user.
 
-If missing → print this and exit non-zero:
+### 2. Jar Check
 
-> Java is required for TLC. Install one of:
-> - macOS:  `brew install openjdk`  (then follow the post-install hints for PATH)
-> - Debian/Ubuntu:  `sudo apt install default-jre`
-> - Other:  https://adoptium.net/
-> Then re-run this skill.
+Look for `tla2tools.jar` in `$TLA_TOOLS_JAR`, then
+`~/.sldo/tla/tla2tools.jar`, then
+`/usr/local/share/tla-tools/tla2tools.jar`. If present, set `TLA_JAR` and
+continue to the Apalache-lazy step.
 
-Do not attempt to install Java for the user.
+### 3. Jar Missing → Download
 
-### 2. Jar check
-
-Look for `tla2tools.jar` in this order:
-
-1. `$TLA_TOOLS_JAR` environment variable.
-2. `~/.sldo/tla/tla2tools.jar` (our managed cache).
-3. `/usr/local/share/tla-tools/tla2tools.jar` (common system install).
-
-If present: set `TLA_JAR` and continue to step 4.
-
-### 3. Jar missing → download
-
-Read pinned URL + SHA-256 from `skills/slo-tla/tools.toml` (sibling of this SKILL.md). Then:
+Read the pinned URL and SHA-256 from `skills/slo-tla/tools.toml`, then run:
 
 ```bash
 mkdir -p ~/.sldo/tla
@@ -77,40 +62,29 @@ curl -fL "<pinned_url>" -o tla2tools.jar.partial
 echo "<pinned_sha256>  tla2tools.jar.partial" | shasum -a 256 -c -
 ```
 
-If checksum FAILS:
+If checksum FAILS, remove the partial file and exit with:
 
-```bash
-rm -f tla2tools.jar.partial
-```
+> SHA-256 mismatch on tla2tools.jar download. The upstream artifact may have
+> been replaced or the network tampered with the response. Do not proceed.
+> Report this to the skill maintainer.
 
-Then exit non-zero with:
-> SHA-256 mismatch on tla2tools.jar download. The upstream artifact may have been replaced or the network tampered with the response. Do not proceed. Report this to the skill maintainer.
+If checksum passes, move the partial into `tla2tools.jar`, write the pinned
+version to `~/.sldo/tla/VERSION`, and create `~/.sldo/tla/tlc` as a wrapper for
+`java -Xmx4g -jar "$HOME/.sldo/tla/tla2tools.jar" "$@"`.
 
-If checksum passes:
+### 4. Apalache Lazy Check
 
-```bash
-mv tla2tools.jar.partial tla2tools.jar
-echo "<pinned_version>" > ~/.sldo/tla/VERSION
-cat > ~/.sldo/tla/tlc <<'EOF'
-#!/usr/bin/env bash
-exec java -Xmx4g -jar "$HOME/.sldo/tla/tla2tools.jar" "$@"
-EOF
-chmod +x ~/.sldo/tla/tlc
-```
+Do not check or install Apalache at skill start. Only check when TLC reports
+state explosion. Then recommend the pinned `tools.toml` Apalache entry and say:
+`TLC ran out of heap on this model. Consider Apalache for symbolic model checking.`
 
-### 4. Apalache (lazy)
+### 5. Gitignore TLC Artifacts
 
-Do not check or install Apalache at skill start. Only check when TLC reports state explosion. In that case, print:
-> TLC ran out of heap on this model. Consider Apalache for symbolic model checking.
-> Install: https://github.com/apalache-mc/apalache/releases/latest
-> Re-run this skill with `--use-apalache` once installed.
+Before the first TLC run, ensure `.gitignore` covers TLC scratch output without
+removing tracked `.tla` or `.cfg` sources:
 
-### 5. Gitignore TLC generated artifacts
-
-TLC writes several kinds of noise that must not be committed. Ensure the repo's `.gitignore` covers them before your first TLC run (so untracked diffs don't surprise the user). If the repo has a `.gitignore`, check whether these patterns are present; if not, append a `# TLA+ / TLC generated artifacts` block:
-
-```
-# TLA+ / TLC generated artifacts (keep specs and .cfg, ignore caches and traces)
+```gitignore
+# TLA+ / TLC generated artifacts
 **/*_TTrace_*.tla
 **/*_TTrace_*.bin
 **/states/
@@ -121,212 +95,55 @@ TLC writes several kinds of noise that must not be committed. Ensure the repo's 
 **/*.toolbox/
 ```
 
-Scope the paths tightly under the TLA+ directory (e.g. `docs/TLAdocs/**/states/` or `specs/**/states/`) if the repo uses `states/` for anything else. Do not overwrite existing `.gitignore` content — append only. Keep `.tla` and `.cfg` files tracked; they are the source of truth. Only the per-run scratch artifacts are ignored.
-
-## Suitability gate — is TLA+ the right tool?
-
-Before elicitation, decide whether TLA+ is actually the right verification tool for the problem in front of you. TLA+ is expensive (engineering time + learning curve for future readers) and not every `tla_required: true` verdict from `/slo-architect` holds up to scrutiny. Apply this gate:
-
-**TLA+ is a good fit when all of these are true:**
-- At least two actors (or a single actor interacting with an environment that is itself stateful) can observably race.
-- The race produces a wrong observable outcome — not just a slower one.
-- The correctness of the fix depends on reasoning about interleavings, not on a single-threaded algorithm.
-- You can name a concrete adversarial scenario in one sentence ("if X and Y happen in this order, the system produces Z which is wrong").
-
-**TLA+ is a poor fit — signal this explicitly to the user and recommend alternatives — when:**
-- The property reduces to "function X computes Y correctly given Z inputs." Recommend property-based tests (QuickCheck, fast-check, Hypothesis).
-- The concurrency risk is a local lock / mutex inside a single process. Recommend runtime tooling (ThreadSanitizer, loom, Jepsen for distributed systems).
-- The system is CRUD + request/response with no cross-request state. There is no race; the property is data-validation.
-- The correctness question is really an API-design question ("should this field be required?"). Recommend typed contracts + schema review, not a model checker.
-- The problem is UI / visual correctness. TLA+ has no notion of rendering.
-- The problem is probabilistic correctness (ML accuracy, statistical guarantees). Use empirical methods.
-
-If TLA+ is a poor fit, output a short note explaining which alternative you recommend and why, and set `tla_required: false` in the design overview, suggesting `/slo-plan` next. Do not produce an empty spec for ceremony. **"TLA+ is not the right tool here" is a legitimate skill output** — it is more useful than a verification that proves nothing.
-
-## Abstraction balance — the central tradeoff
-
-TLA+ specs fail in two opposite directions, and the first draft usually lands on one of them:
-
-**Too concrete (state explosion):** the spec carries implementation detail that does not affect the race — timestamps, unique sequence numbers, multiple resources when the race is resource-local, authoring paths when the race is triage-time, snapshot/commit splits when the race is visible at either point. TLC takes minutes or runs out of heap. Symptom: you find yourself reducing `MaxSeq` or `MaxResources` to keep TLC tractable. That is the spec telling you to **abstract, not shrink**.
-
-**Too abstract (trivially proved):** the spec collapses the variables that cause the race into a single boolean, and the fix is correct by construction without exploring any interleavings. TLC finishes in 5 states and reports no violation. Symptom: the safety property holds even when you comment out the fix. The spec is measuring nothing.
-
-The sweet spot is **the smallest model that still exhibits the bug on the pre-fix design**. Procedure:
-
-1. Write the minimal spec — single resource, booleans where possible, no history variables, no implementation-orthogonal paths.
-2. Run TLC with the **naive / pre-fix** verdict logic. If TLC passes, the spec is too abstract — add a variable or an action until TLC finds the race.
-3. Apply the design fix. If TLC still fails, the fix is wrong — iterate on the design, not the spec.
-4. If TLC passes in milliseconds, you are done. If TLC passes in seconds to a minute, acceptable. If TLC takes over ~2 minutes at the minimum-bug-exhibiting bound, the model is still too concrete — go back to step 1.
-
-**State-space budget rule of thumb:** the Naive/broken spec should fall over in **under 1000 reachable states and under 10 seconds**. If it takes longer than that to find the bug, future readers will struggle to iterate on the spec; the abstraction is not paying rent.
-
-## State-explosion triage
-
-When TLC runs for more than ~2 minutes at your minimum bound, do not simply add `-workers auto` and wait. Diagnose and cut:
-
-1. **Drop liveness first.** Temporal properties amortise a tableau over the entire state graph — each pass scales roughly linearly with states generated. Run safety-only first to confirm the core race, then add liveness at the smallest bound that expresses it.
-2. **Eliminate history variables.** If a variable exists only to express the safety predicate (e.g. `trueConsoleMut` recording ground truth), try replacing it with a boolean ghost flag (`sawMutation`) or a direct reference to an existing state variable.
-3. **Collapse snapshot/commit into one action** if the fix does not depend on the read-to-commit gap. You can always re-split later if a second counterexample emerges.
-4. **Cut from N resources to 1** if the race is resource-local. Argue symmetry in the verified-design doc rather than exhaustively verifying N > 1.
-5. **Remove orthogonal paths.** If your spec models both an authoring path and a triage path but the safety property is triage-only, drop the authoring path.
-6. **Replace `Seq(X)` with a single `head ∈ X ∪ {None}`** if the queue's length never actually matters. Sequence permutations explode state space.
-7. **Power-set subsets become presence booleans.** `deliveredEvents ⊆ Event` with up to 6 events has 64 subsets; if the classifier only cares "any delivered console event exists," replace with `anyConsoleDelivered ∈ BOOLEAN`.
-
-After every cut, re-run the Naive/broken spec and confirm it still fails. If a cut silently passes the Naive spec, you cut something the race needed — restore it.
-
-## Elicitation — the first real work
-
-The design doc is almost never directly translatable to TLA+ — it over-specifies (timestamps, UUIDs, payloads) and under-specifies (actions as prose, not transitions). You reduce it.
-
-Ask, in order:
-
-### Q1. What property are we trying to prove?
-
-Make the user name ONE safety property as a crisp sentence. If they name more than one, force ranking — start with the most load-bearing one.
-
-### Q2. What's the smallest state that can violate it?
-
-Example: mutual exclusion — two actors in critical section. No need to model timers, payloads, or tokens unless they're the mechanism that prevents the violation.
-
-### Q3. Who are the actors, and how many?
-
-Force a bound. "An unbounded number of workers" → start with 3. If the property holds at 3, think about whether it's a symmetry argument.
-
-### Q4. What are the atomic actions?
-
-List them. Each action is a TLA+ next-state relation. Merge the ones that share preconditions and effects. Usually 4–8 actions is the right range.
-
-### Q5. What fails, and how?
-
-Network drops? Process crashes? Duplicate delivery? For each failure mode, either model it as an action or explicitly exclude it from the bound.
-
-### Q6. Liveness — what must eventually happen?
-
-Only after safety holds. Every liveness property needs a fairness assumption (weak or strong, on which actions). Force this explicitly — liveness without fairness is a source of silent bugs.
-
-## Spec drafting
-
-Draft in stages. Do not try to write the whole spec in one go.
-
-### Stage A — variables and Init
-
-Declare the state variables. Write Init. Run TLC with Next == FALSE (no transitions) just to check Init is reachable. One state.
-
-### Stage B — one action at a time
-
-Add one action. Run TLC. Assert at least one invariant that's obviously true (TypeOK). Grow the state graph.
-
-### Stage C — the invariant
-
-Add the safety property from Q1 as an invariant. Run TLC. If it passes at a tiny bound, increase the bound. If it fails, translate the counterexample (see below) and fix the spec (or the design) before proceeding.
-
-### Stage D — liveness
-
-Only after safety is solid. Add the temporal property and fairness. Run TLC with `-deadlock` and the `PROPERTIES` line in .cfg.
-
-### Stage E — bound and declare
-
-Once TLC is green at your chosen bound, record the bound explicitly in the verified-design doc. N actors, M requests, K failures — whatever parameters the spec uses, state them.
-
-## Counterexample translation — this is the product
-
-Raw TLC output is a sequence of states with state variables. That is not a design finding. Translate:
-
-1. Read the trace step by step. Name each actor's action ("A sends REQUEST", "B crashes", "A retries").
-2. Identify the fork: the state in which the invariant first fails.
-3. Write it as a short narrative: "Actor A sends REQUEST. Before B acknowledges, B crashes. A retries. B comes back up and processes twice."
-4. Name the design assumption that broke: "We assumed at-most-once delivery, but the retry introduces at-least-once."
-5. Propose the fix in the DESIGN, not the spec: "Add an idempotency key", "Require B to persist state before ack", etc.
-6. Re-verify after the design fix lands in the spec.
-
-The trace markdown file is shaped like:
-
-```markdown
-# Trace — <property name> violation
-
-## Property
-<crisp sentence>
-
-## Counterexample
-1. <Actor A: action>
-2. <Actor B: action>
-...
-N. <the step at which the property fails>
-
-## Fork point
-<state N-1 → N: what changed, why it matters>
-
-## Broken design assumption
-<one sentence>
-
-## Proposed fix
-<one paragraph, design-level, not spec-level>
-
-## Status
-- [ ] design fix applied to spec
-- [ ] TLC re-run, green at bound (N=…, M=…, K=…)
-```
-
-## Verified-design doc shape
-
-```markdown
----
-name: <slug>
-verified_at: <YYYY-MM-DD>
-tlc_bound: "N=3, M=5, K=2"
-tool: "TLC 1.8.0"
----
-
-# Verified Design — <title>
-
-## System goal
-<one paragraph>
-
-## Abstract state
-<variable list>
-
-## Actions
-<list>
-
-## Safety properties checked
-- <property> — PASS at <bound>
-
-## Liveness properties checked (with fairness)
-- <property> — PASS at <bound>, fairness: <weak|strong> on <actions>
-
-## Simplifications from the real design
-- <what was abstracted, why it still covers the real bug>
-
-## Open questions
-- <thing we did not model, and why it's acceptable>
-```
-
-## Gates — refuse to mark as verified when
-
-- Bound is not stated.
-- Fairness is not declared for any liveness property.
-- Any invariant was weakened silently (e.g., "no two in CS" → "no two in CS in the same step" — that's a different, weaker property).
-- A counterexample was suppressed rather than addressed.
-- The Naive / pre-fix variant passes silently — the spec is measuring nothing; either the race is not there or the model is too abstract.
-- TLC at the minimum-bug-exhibiting bound takes over ~2 minutes — the model is too concrete; future readers will not iterate on it.
-- "Simplifications from the real design" section is absent or hand-wavy. Each abstraction must name what was dropped and why it is sound to drop.
-
-## Anti-patterns
-
-- Running TLC once, finding no violations, declaring victory — always iterate: add an action, re-run, grow the model. **Always run the Naive / pre-fix variant first** and confirm it fails; only then verify the Hardened variant passes.
-- Translating counterexamples mechanically instead of narratively — "state 5: pc[A]=inCS, pc[B]=inCS" is not a finding; "A and B both got in because the lock check and acquire are not atomic" is.
-- Using Apalache when TLC would work — Apalache is for state explosion, not default.
-- Dropping the design simplifications paragraph — that's where future readers learn what the spec does NOT cover.
-- **Adding variables to a spec without asking "does the race still exhibit without this?"** Every variable that is not load-bearing multiplies the state space.
-- **Skipping the suitability gate.** Running TLA+ on a single-threaded CRUD function to "look rigorous" consumes a milestone and produces no information. Signal "not a good fit" instead.
-- **Adding `-workers auto` before cutting the model down.** Parallelism hides a too-concrete spec behind hardware; the spec is still too concrete. Cut first, parallelise second.
-- **Throwing a counterexample back at `/slo-architect` without a fix proposal.** The trace is the raw material; the design fix is the product. Spec the fix in the Proposed-fix section before re-running TLC.
+Append only. Scope paths tightly when `states/` is meaningful elsewhere.
+
+## Suitability gate — Is TLA+ The Right Tool?
+
+Apply this before elicitation. TLA+ is a good fit only when at least two actors
+or one actor plus a stateful environment can observably race, the race creates a
+wrong outcome, correctness depends on interleavings, and the adversarial
+scenario can be named in one sentence.
+
+TLA+ is a poor fit when the property is single-function correctness, local
+mutex behavior, CRUD/request-response validation, API-design semantics, UI
+rendering, or probabilistic/ML accuracy. Recommend property-based tests,
+ThreadSanitizer/loom/Jepsen, typed contracts, schema review, visual tests, or
+empirical methods as appropriate.
+
+If TLA+ is a poor fit, explain why, set `tla_required: false` in the design
+overview, suggest `/slo-plan` next, and do not produce an empty spec for
+ceremony. "TLA+ is not the right tool here" is a legitimate skill output.
+
+## Method Dispatch
+
+Load only the method file needed for the current phase:
+
+| Phase | Read |
+|---|---|
+| Elicitation and spec drafting | [`references/methodology-elicitation.md`](references/methodology-elicitation.md) |
+| Abstraction balance and state explosion | [`references/methodology-abstraction.md`](references/methodology-abstraction.md) |
+| Counterexample translation | [`references/methodology-counterexample.md`](references/methodology-counterexample.md) |
+| Verified-design writeup and gates | [`references/methodology-verified-design.md`](references/methodology-verified-design.md) |
+
+## Common Gates And Anti-Patterns
+
+Refuse to mark a design verified when: Bound is not stated (`N=3, M=5, K=2`);
+fairness is missing for any liveness property; an invariant was weakened
+silently; a counterexample was suppressed; the Naive / pre-fix variant passes
+silently; TLC takes over about two minutes at the minimum-bug-exhibiting bound;
+or the simplifications from the real design are hand-wavy.
+
+Always run the Naive / pre-fix variant first and confirm it fails. Use Apalache
+only for state explosion, not by default. Do not add `-workers auto` before
+cutting the model down. Do not hand a raw trace back without a design-level fix
+proposal.
 
 ## Handoff
 
-After `-verified.md` is written and TLC is green at the declared bound, suggest `/slo-plan` (if a runbook does not yet exist) or `/slo-critique` (if it does) so the plan reviewers can read the verification.
-
-If the suitability gate short-circuited ("TLA+ is not the right tool here"), the handoff still works: suggest `/slo-plan` directly and recommend the alternative verification approach (property-based tests, schema review, etc.) be included as a milestone in the runbook.
+After `-verified.md` is written and TLC is green at the declared bound, suggest
+`/slo-plan` if a runbook does not yet exist or `/slo-critique` if it does. If
+the suitability gate short-circuited, suggest `/slo-plan` and include the
+alternative verification approach as a milestone.
 
 ---
 

--- a/skills/slo-tla/references/methodology-abstraction.md
+++ b/skills/slo-tla/references/methodology-abstraction.md
@@ -1,0 +1,74 @@
+---
+name: slo-tla-methodology-abstraction
+source_skill: skills/slo-tla/SKILL.md
+description: Abstraction balance and state-explosion triage for /slo-tla.
+---
+
+# /slo-tla Methodology — Abstraction And State Explosion
+
+## Abstraction Balance — The Central Tradeoff
+
+TLA+ specs fail in two opposite directions, and the first draft usually lands
+on one of them:
+
+**Too concrete (state explosion):** the spec carries implementation detail that
+does not affect the race — timestamps, unique sequence numbers, multiple
+resources when the race is resource-local, authoring paths when the race is
+triage-time, snapshot/commit splits when the race is visible at either point.
+TLC takes minutes or runs out of heap. Symptom: you find yourself reducing
+`MaxSeq` or `MaxResources` to keep TLC tractable. That is the spec telling you
+to **abstract, not shrink**.
+
+**Too abstract (trivially proved):** the spec collapses the variables that cause
+the race into a single boolean, and the fix is correct by construction without
+exploring any interleavings. TLC finishes in 5 states and reports no violation.
+Symptom: the safety property holds even when you comment out the fix. The spec
+is measuring nothing.
+
+The sweet spot is **the smallest model that still exhibits the bug on the pre-fix design**. Procedure:
+
+1. Write the minimal spec — single resource, booleans where possible, no history
+   variables, no implementation-orthogonal paths.
+2. Run TLC with the **naive / pre-fix** verdict logic. If TLC passes, the spec
+   is too abstract — add a variable or an action until TLC finds the race.
+3. Apply the design fix. If TLC still fails, the fix is wrong — iterate on the
+   design, not the spec.
+4. If TLC passes in milliseconds, you are done. If TLC passes in seconds to a
+   minute, acceptable. If TLC takes over ~2 minutes at the
+   minimum-bug-exhibiting bound, the model is still too concrete — go back to
+   step 1.
+
+**State-space budget rule of thumb:** the Naive/broken spec should fall over in
+**under 1000 reachable states and under 10 seconds**. If it takes longer than
+that to find the bug, future readers will struggle to iterate on the spec; the
+abstraction is not paying rent.
+
+## State-Explosion Triage
+
+When TLC runs for more than ~2 minutes at your minimum bound, do not simply add
+`-workers auto` and wait. Diagnose and cut:
+
+1. **Drop liveness first.** Temporal properties amortise a tableau over the
+   entire state graph — each pass scales roughly linearly with states generated.
+   Run safety-only first to confirm the core race, then add liveness at the
+   smallest bound that expresses it.
+2. **Eliminate history variables.** If a variable exists only to express the
+   safety predicate (e.g. `trueConsoleMut` recording ground truth), try
+   replacing it with a boolean ghost flag (`sawMutation`) or a direct reference
+   to an existing state variable.
+3. **Collapse snapshot/commit into one action** if the fix does not depend on
+   the read-to-commit gap. You can always re-split later if a second
+   counterexample emerges.
+4. **Cut from N resources to 1** if the race is resource-local. Argue symmetry
+   in the verified-design doc rather than exhaustively verifying N > 1.
+5. **Remove orthogonal paths.** If your spec models both an authoring path and a
+   triage path but the safety property is triage-only, drop the authoring path.
+6. **Replace `Seq(X)` with a single `head ∈ X ∪ {None}`** if the queue's length
+   never actually matters. Sequence permutations explode state space.
+7. **Power-set subsets become presence booleans.** `deliveredEvents ⊆ Event`
+   with up to 6 events has 64 subsets; if the classifier only cares "any
+   delivered console event exists," replace with `anyConsoleDelivered ∈ BOOLEAN`.
+
+After every cut, re-run the Naive/broken spec and confirm it still fails. If a
+cut silently passes the Naive spec, you cut something the race needed — restore
+it.

--- a/skills/slo-tla/references/methodology-counterexample.md
+++ b/skills/slo-tla/references/methodology-counterexample.md
@@ -1,0 +1,60 @@
+---
+name: slo-tla-methodology-counterexample
+source_skill: skills/slo-tla/SKILL.md
+description: Counterexample translation procedure and trace shape for /slo-tla.
+---
+
+# /slo-tla Methodology — Counterexample Translation
+
+## Counterexample Translation — This Is The Product
+
+Raw TLC output is a sequence of states with state variables. That is not a
+design finding. Translate:
+
+1. Read the trace step by step. Name each actor's action ("A sends REQUEST", "B
+   crashes", "A retries").
+2. Identify the fork: the state in which the invariant first fails.
+3. Write it as a short narrative: "Actor A sends REQUEST. Before B
+   acknowledges, B crashes. A retries. B comes back up and processes twice."
+4. Name the design assumption that broke: "We assumed at-most-once delivery, but
+   the retry introduces at-least-once."
+5. Propose the fix in the DESIGN, not the spec: "Add an idempotency key",
+   "Require B to persist state before ack", etc.
+6. Re-verify after the design fix lands in the spec.
+
+The trace markdown file is shaped like:
+
+```markdown
+# Trace — <property name> violation
+
+## Property
+<crisp sentence>
+
+## Counterexample
+1. <Actor A: action>
+2. <Actor B: action>
+...
+N. <the step at which the property fails>
+
+## Fork point
+<state N-1 → N: what changed, why it matters>
+
+## Broken design assumption
+<one sentence>
+
+## Proposed fix
+<one paragraph, design-level, not spec-level>
+
+## Status
+- [ ] design fix applied to spec
+- [ ] TLC re-run, green at bound (N=…, M=…, K=…)
+```
+
+## Anti-Patterns
+
+- Translating counterexamples mechanically instead of narratively — "state 5:
+  pc[A]=inCS, pc[B]=inCS" is not a finding; "A and B both got in because the
+  lock check and acquire are not atomic" is.
+- Throwing a counterexample back at `/slo-architect` without a fix proposal. The
+  trace is the raw material; the design fix is the product. Spec the fix in the
+  Proposed-fix section before re-running TLC.

--- a/skills/slo-tla/references/methodology-elicitation.md
+++ b/skills/slo-tla/references/methodology-elicitation.md
@@ -1,0 +1,78 @@
+---
+name: slo-tla-methodology-elicitation
+source_skill: skills/slo-tla/SKILL.md
+description: Elicitation questions and staged spec drafting for /slo-tla.
+---
+
+# /slo-tla Methodology — Elicitation And Spec Drafting
+
+## Elicitation — The First Real Work
+
+The design doc is almost never directly translatable to TLA+ — it over-specifies
+(timestamps, UUIDs, payloads) and under-specifies (actions as prose, not
+transitions). You reduce it.
+
+Ask, in order:
+
+### Q1. What Property Are We Trying To Prove?
+
+Make the user name ONE safety property as a crisp sentence. If they name more
+than one, force ranking — start with the most load-bearing one.
+
+### Q2. What's The Smallest State That Can Violate It?
+
+Example: mutual exclusion — two actors in critical section. No need to model
+timers, payloads, or tokens unless they're the mechanism that prevents the
+violation.
+
+### Q3. Who Are The Actors, And How Many?
+
+Force a bound. "An unbounded number of workers" → start with 3. If the property
+holds at 3, think about whether it's a symmetry argument.
+
+### Q4. What Are The Atomic Actions?
+
+List them. Each action is a TLA+ next-state relation. Merge the ones that share
+preconditions and effects. Usually 4–8 actions is the right range.
+
+### Q5. What Fails, And How?
+
+Network drops? Process crashes? Duplicate delivery? For each failure mode,
+either model it as an action or explicitly exclude it from the bound.
+
+### Q6. Liveness — What Must Eventually Happen?
+
+Only after safety holds. Every liveness property needs a fairness assumption
+(weak or strong, on which actions). Force this explicitly — liveness without
+fairness is a source of silent bugs.
+
+## Spec Drafting
+
+Draft in stages. Do not try to write the whole spec in one go.
+
+### Stage A — Variables And Init
+
+Declare the state variables. Write Init. Run TLC with Next == FALSE (no
+transitions) just to check Init is reachable. One state.
+
+### Stage B — One Action At A Time
+
+Add one action. Run TLC. Assert at least one invariant that's obviously true
+(TypeOK). Grow the state graph.
+
+### Stage C — The Invariant
+
+Add the safety property from Q1 as an invariant. Run TLC. If it passes at a tiny
+bound, increase the bound. If it fails, translate the counterexample and fix the
+spec or the design before proceeding.
+
+### Stage D — Liveness
+
+Only after safety is solid. Add the temporal property and fairness. Run TLC with
+`-deadlock` and the `PROPERTIES` line in `.cfg`.
+
+### Stage E — Bound And Declare
+
+Once TLC is green at your chosen bound, record the bound explicitly in the
+verified-design doc. N actors, M requests, K failures — whatever parameters the
+spec uses, state them.

--- a/skills/slo-tla/references/methodology-verified-design.md
+++ b/skills/slo-tla/references/methodology-verified-design.md
@@ -1,0 +1,86 @@
+---
+name: slo-tla-methodology-verified-design
+source_skill: skills/slo-tla/SKILL.md
+description: Verified-design document shape, refusal gates, and handoff rules.
+---
+
+# /slo-tla Methodology — Verified Design
+
+## Verified-Design Doc Shape
+
+```markdown
+---
+name: <slug>
+verified_at: <YYYY-MM-DD>
+tlc_bound: "N=3, M=5, K=2"
+tool: "TLC 1.8.0"
+---
+
+# Verified Design — <title>
+
+## System goal
+<one paragraph>
+
+## Abstract state
+<variable list>
+
+## Actions
+<list>
+
+## Safety properties checked
+- <property> — PASS at <bound>
+
+## Liveness properties checked (with fairness)
+- <property> — PASS at <bound>, fairness: <weak|strong> on <actions>
+
+## Simplifications from the real design
+- <what was abstracted, why it still covers the real bug>
+
+## Open questions
+- <thing we did not model, and why it's acceptable>
+```
+
+## Gates — Refuse To Mark As Verified When
+
+- Bound is not stated.
+- Fairness is not declared for any liveness property.
+- Any invariant was weakened silently (e.g., "no two in CS" → "no two in CS in
+  the same step" — that's a different, weaker property).
+- A counterexample was suppressed rather than addressed.
+- The Naive / pre-fix variant passes silently — the spec is measuring nothing;
+  either the race is not there or the model is too abstract.
+- TLC at the minimum-bug-exhibiting bound takes over ~2 minutes — the model is
+  too concrete; future readers will not iterate on it.
+- "Simplifications from the real design" section is absent or hand-wavy. Each
+  abstraction must name what was dropped and why it is sound to drop.
+
+## Anti-Patterns
+
+- Running TLC once, finding no violations, declaring victory — always iterate:
+  add an action, re-run, grow the model. **Always run the Naive / pre-fix
+  variant first** and confirm it fails; only then verify the Hardened variant
+  passes.
+- Using Apalache when TLC would work — Apalache is for state explosion, not
+  default.
+- Dropping the design simplifications paragraph — that's where future readers
+  learn what the spec does NOT cover.
+- **Adding variables to a spec without asking "does the race still exhibit
+  without this?"** Every variable that is not load-bearing multiplies the state
+  space.
+- **Skipping the suitability gate.** Running TLA+ on a single-threaded CRUD
+  function to "look rigorous" consumes a milestone and produces no information.
+  Signal "not a good fit" instead.
+- **Adding `-workers auto` before cutting the model down.** Parallelism hides a
+  too-concrete spec behind hardware; the spec is still too concrete. Cut first,
+  parallelise second.
+
+## Handoff
+
+After `-verified.md` is written and TLC is green at the declared bound, suggest
+`/slo-plan` if a runbook does not yet exist or `/slo-critique` if it does so the
+plan reviewers can read the verification.
+
+If the suitability gate short-circuited ("TLA+ is not the right tool here"), the
+handoff still works: suggest `/slo-plan` directly and recommend the alternative
+verification approach (property-based tests, schema review, etc.) be included as
+a milestone in the runbook.

--- a/skills/slo-tla/tools.toml
+++ b/skills/slo-tla/tools.toml
@@ -21,6 +21,7 @@ sha256 = "d5d07d5dab38ddb840c91ec48fa02f28b37a608d5af9a73570018591dbc8ef7f"
 # Apalache is fetched lazily only when TLC reports state explosion.
 # This entry exists so the lazy-download helper has a pinned reference.
 [apalache]
-version = "0.44.11"
-url = "https://github.com/apalache-mc/apalache/releases/download/v0.44.11/apalache.tgz"
-sha256 = "5fe31cbc5708747bde654f6e2bc5100ac4e8e846e9fb540293e0b919e3bda0c8"
+version = "0.57.0"
+url = "https://github.com/apalache-mc/apalache/releases/download/v0.57.0/apalache.tgz"
+download_url = "https://github.com/apalache-mc/apalache/releases/download/v0.57.0/apalache.tgz"
+sha256 = "cb805df9a68e2f278c45e751522aab119b57a454e3e0e96f5d974b969fe52b5d"


### PR DESCRIPTION
## Summary

- Decomposes `/slo-tla` into a 150-line dispatcher plus skill-local methodology references.
- Adds Apalache `0.57.0` pin with upstream SHA-256 while preserving the existing TLC pin.
- Adds M3 structural-contract tests and runbook closeout docs.

## Validation

- `cargo test -p sldo-install --test e2e_eng_imp_m3`
- `cargo test -p sldo-install --test e2e_slo_sp_m5`
- `cargo test -p sldo-install`
- `cargo test --workspace`
- `cargo build --workspace`
- `git diff --check`

Stacked on #37.