### PR TITLE
ci: enable Dependabot for cargo and github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,45 @@
+# Dependabot keeps cargo and GitHub Actions deps current and surfaces
+# transitive CVEs. Weekly cadence keeps the noise low; security advisories
+# always open PRs immediately regardless of schedule.
+
+version: 2
+updates:
+  - package-ecosystem: cargo
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: Etc/UTC
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - rust
+    commit-message:
+      prefix: chore
+      include: scope
+    groups:
+      cargo-minor-and-patch:
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: Etc/UTC
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - github-actions
+    commit-message:
+      prefix: ci
+      include: scope
+    groups:
+      actions-minor-and-patch:
+        update-types:
+          - minor
+          - patch


### PR DESCRIPTION
## Summary
- Adds `.github/dependabot.yml` covering `cargo` (workspace deps) and `github-actions` (workflow pins).
- Weekly Monday 06:00 UTC cadence; minor/patch updates grouped into a single PR per ecosystem to reduce churn.
- Security advisories still open PRs immediately, independent of the schedule.
- Complements CodeQL (PR #46) on the dependency-CVE axis.

## Test plan
- [ ] Dependabot picks up the config (visible under Insights → Dependency graph → Dependabot)
- [ ] First scheduled run on the next Monday produces grouped PRs (or none, if everything is current)

🤖 Generated with [Claude Code](https://claude.com/claude-code)