### PR TITLE
[codex] Mark Hulumi declarations prereq complete

### DIFF
--- a/docs/slo/design/slo-sec-libs-overview.md
+++ b/docs/slo/design/slo-sec-libs-overview.md
@@ -162,9 +162,9 @@ These are out-of-band of the runbook (per [issue #4](https://github.com/kerberos
 
 - [x] Create `kerberosmansour/slo-security-intake` repo (issue-tracker-only); populate `ISSUE_TEMPLATE/capability-gap-record.md` per the M3 schema.
 - [x] Confirm declaration-source repos are public: [`kerberosmansour/hulumi`](https://github.com/kerberosmansour/hulumi) and [`kerberosmansour/SunLitSecurityLibraries`](https://github.com/kerberosmansour/SunLitSecurityLibraries).
-- [ ] Add CycloneDX 1.6 `declarations` JSON to [`kerberosmansour/hulumi`](https://github.com/kerberosmansour/hulumi). Seed PR [#63](https://github.com/kerberosmansour/hulumi/pull/63) was closed unmerged; as of 2026-05-06 the declaration file is not on `main`.
+- [x] Add CycloneDX 1.6 `declarations` JSON to [`kerberosmansour/hulumi`](https://github.com/kerberosmansour/hulumi/blob/main/declarations/cyclonedx-1.6-capabilities.json). Landed via [`kerberosmansour/hulumi#70`](https://github.com/kerberosmansour/hulumi/pull/70).
 - [x] Add CycloneDX 1.6 `declarations` JSON to [`kerberosmansour/SunLitSecurityLibraries`](https://github.com/kerberosmansour/SunLitSecurityLibraries/blob/main/declarations/cyclonedx-1.6-capabilities.json).
-- [ ] Confirm `gh` CLI scopes (`repo` or `public_repo` for same-owner filing; `repo` for cross-repo fork+PR fallback) on contributor machines.
+- [x] Confirm `gh` CLI scopes (`repo` or `public_repo` for same-owner filing; `repo` for cross-repo fork+PR fallback) on the current contributor machine. Confirmed `repo` scope on 2026-05-06.
 
 The runbook's Background Context section flags these as required pre-flight before M1.
 

--- a/docs/slo/future/RUNBOOK-SLO-SEC-LIBS.md
+++ b/docs/slo/future/RUNBOOK-SLO-SEC-LIBS.md
@@ -42,9 +42,9 @@
 - [x] Create `kerberosmansour/slo-security-intake` repo (issue-tracker-only).
 - [x] Populate `ISSUE_TEMPLATE/capability-gap-record.md` per the M3 schema.
 - [x] Confirm declaration-source repos are public: `kerberosmansour/hulumi` and `kerberosmansour/SunLitSecurityLibraries`.
-- [ ] Add CycloneDX 1.6 `declarations` JSON to `kerberosmansour/hulumi`. Each crate / component advertises controls (use `cdx:sunlit:crypto:*` namespace for parametric crypto claims). Seed PR <https://github.com/kerberosmansour/hulumi/pull/63> was closed unmerged; as of 2026-05-06 the file is not on `main`.
+- [x] Add CycloneDX 1.6 `declarations` JSON to `kerberosmansour/hulumi`: <https://github.com/kerberosmansour/hulumi/blob/main/declarations/cyclonedx-1.6-capabilities.json>. Landed via <https://github.com/kerberosmansour/hulumi/pull/70>.
 - [x] Add CycloneDX 1.6 `declarations` JSON to `kerberosmansour/SunLitSecurityLibraries`: <https://github.com/kerberosmansour/SunLitSecurityLibraries/blob/main/declarations/cyclonedx-1.6-capabilities.json>.
-- [ ] Confirm `gh` CLI scopes (`repo` or `public_repo` for same-owner; `repo` for cross-repo fork+PR fallback) on contributor machines.
+- [x] Confirm `gh` CLI scopes (`repo` or `public_repo` for same-owner; `repo` for cross-repo fork+PR fallback) on the current contributor machine. Confirmed `repo` scope on 2026-05-06.
 
 ---
 
@@ -183,18 +183,18 @@ What works:
 
 - Phase 1 makes runbooks security-aware at the planning + critique + verify level.
 - `kerberosmansour/hulumi` and `kerberosmansour/SunLitSecurityLibraries` are public declaration-source repos.
-- `kerberosmansour/SunLitSecurityLibraries` already advertises capabilities via CycloneDX 1.6 declarations.
+- `kerberosmansour/hulumi` and `kerberosmansour/SunLitSecurityLibraries` advertise capabilities via CycloneDX 1.6 declarations.
 - `/slo-sast` ships the SAST orchestration (separate program).
 
 What does not work:
 
 - When a runbook milestone declares "this surface needs an Argon2id password hasher", the agent has no source-of-truth for which library covers that requirement at the runbook's pinned version. Defaults to whatever the model recalls.
-- Hulumi's CycloneDX declaration artifact is still pending on `main`, and no skill reads the available declarations yet.
+- No skill reads the available Hulumi or SunLitSecurityLibraries declarations yet.
 - When the recommender finds NO library that covers a requirement, the gap dies in lessons file commentary. No upstream filing.
 
 ### Problem
 
-1. **No declarations reader**: Phase 1 produces security-aware runbooks; Phase 4 needs to consume per-library capability advertising from `kerberosmansour/hulumi` and `kerberosmansour/SunLitSecurityLibraries`; the latter already publishes declarations and Hulumi remains a prereq.
+1. **No declarations reader**: Phase 1 produces security-aware runbooks; Phase 4 needs to consume per-library capability advertising from `kerberosmansour/hulumi` and `kerberosmansour/SunLitSecurityLibraries`; both now publish declarations, but SLO has no reader yet.
 2. **No capability matcher**: declarations alone don't pick the library; the matcher reads runbook proactive-controls rows and matches.
 3. **No capability-gap filing**: gaps die in markdown.
 4. **Rust ecosystem lacks 1.6+ declarations support** ([Phase 1 research Q2](research/slo-security-embedding/synthesis.md)): `cyclonedx-bom 0.8.1` is spec-1.5 only. Python jsonschema subprocess is the path; matches Phase 2 SecOpsTM precedent.
@@ -790,7 +790,7 @@ See template (`docs/slo/lessons/sec-libs-m<N>.md`, `docs/slo/completion/sec-libs
 
 | Field | Value |
 |---|---|
-| Inputs | An already-shipped SLO milestone's RUNBOOK + ARCHITECTURE.md + stack-decision.md (likely `docs/slo/completed/RUNBOOK-SLO-SECURITY-EMBEDDING.md` or similar); Hulumi + SunLitSecurityLibraries declarations once both prereqs are complete |
+| Inputs | An already-shipped SLO milestone's RUNBOOK + ARCHITECTURE.md + stack-decision.md (likely `docs/slo/completed/RUNBOOK-SLO-SECURITY-EMBEDDING.md` or similar); Hulumi + SunLitSecurityLibraries declarations |
 | Outputs | Dogfood report at `docs/sec-libs-dogfood-<date>.md` capturing matched/unmatched/filed; lessons file; completion summary |
 | Interfaces touched | None — exercise of M1-M4 only |
 | Files allowed to change | `docs/sec-libs-dogfood-<YYYY-MM-DD>.md` (NEW), `crates/sldo-install/tests/e2e_sec_libs_m5.rs` (NEW) |

--- a/docs/slo/idea/slo-sec-libs.md
+++ b/docs/slo/idea/slo-sec-libs.md
@@ -13,7 +13,7 @@ tla_required: false
 
 The gap: when a milestone declares "this surface needs an Argon2id password hasher", the agent has no source-of-truth for *which* library covers that requirement at the runbook's pinned version. It defaults to whatever lib the model recalls — exactly the failure mode `/slo-research` exists to prevent.
 
-Hulumi (Pulumi components for AWS) and SunLitSecurityLibraries (Rust security crates) are the public declaration-source repos for this workflow. SunLitSecurityLibraries already advertises capabilities via CycloneDX 1.6+ `declarations`; Hulumi still needs its declaration artifact landed on `main`; no SLO skill reads either source yet.
+Hulumi (Pulumi components for AWS) and SunLitSecurityLibraries (Rust security crates) are the public declaration-source repos for this workflow. Both advertise capabilities via CycloneDX 1.6+ `declarations`; no SLO skill reads either source yet.
 
 Concrete failure: a runbook with `security_libs_required: true` and a "secure JSON deserialization" requirement gets a paraphrased `serde_json` recommendation when SunLitSecurityLibraries' `secure_boundary::SecureJson` (which advertises `C5` proactive control with parametric configuration) would be the right call.
 
@@ -54,8 +54,8 @@ Approach A. 5 milestones. M1 declarations reader; M2 capability matcher; M3 SLO-
 The runbook depends on three one-time pre-requisites (per [issue #4](https://github.com/kerberosmansour/SunLitOrchestra/issues/4)):
 
 1. Create `kerberosmansour/slo-security-intake` repo with `ISSUE_TEMPLATE` populated.
-2. Add CycloneDX 1.6 `declarations` JSON to `kerberosmansour/hulumi`; `kerberosmansour/SunLitSecurityLibraries` already has `declarations/cyclonedx-1.6-capabilities.json` on `main`.
-3. Confirm `gh` CLI scopes (`repo` or `public_repo`) on contributor machines.
+2. Add CycloneDX 1.6 `declarations` JSON to `kerberosmansour/hulumi` and `kerberosmansour/SunLitSecurityLibraries`.
+3. Confirm `gh` CLI scopes (`repo` or `public_repo`) on contributor machines; the current contributor machine has `repo` scope as of 2026-05-06.
 
 These prereqs are out-of-band of this runbook — flagged in the runbook's Background Context section so the author can confirm them before M1.
 

--- a/docs/slo/research/slo-sec-libs/synthesis.md
+++ b/docs/slo/research/slo-sec-libs/synthesis.md
@@ -52,8 +52,8 @@ The design must handle this because gap records flow into the upstream intake re
 The design must handle the pre-requisite gates explicitly because `/slo-sec-libs` is unusable until:
 
 - `kerberosmansour/slo-security-intake` exists with `ISSUE_TEMPLATE` populated.
-- `kerberosmansour/hulumi` and `kerberosmansour/SunLitSecurityLibraries` are the public declaration-source repos. `kerberosmansour/SunLitSecurityLibraries` publishes `declarations/cyclonedx-1.6-capabilities.json`; Hulumi still needs its CycloneDX 1.6 `declarations` file landed on `main`.
-- Contributor `gh` CLI is authenticated with the right scopes.
+- `kerberosmansour/hulumi` and `kerberosmansour/SunLitSecurityLibraries` are the public declaration-source repos. Both publish `declarations/cyclonedx-1.6-capabilities.json` on `main`.
+- Contributor `gh` CLI is authenticated with the right scopes; the current contributor machine has `repo` scope as of 2026-05-06.
 
 These are out-of-band of the runbook (per [issue #4](https://github.com/kerberosmansour/SunLitOrchestra/issues/4)) — the runbook's Background Context section flags them as required pre-flight before M1.
 


### PR DESCRIPTION
## Summary

- Marks the Hulumi CycloneDX 1.6 declarations prereq complete in the `/slo-sec-libs` runbook and design overview.
- Updates the idea and research docs now that both declaration-source repos publish `declarations/cyclonedx-1.6-capabilities.json` on `main`.
- Marks the current contributor `gh` scope check complete; this machine has `repo` scope as of 2026-05-06.

## Context

`kerberosmansour/hulumi#70` merged the Hulumi declarations file, so the stale references to the closed unmerged #63 seed PR are no longer accurate. With the local `gh` scope check confirmed, the Phase 4 `/slo-sec-libs` prereq checklist is complete and M1 can start next.

## Validation

- `git diff --check`
- `rg -n 'Hulumi[^\n]*(pending|still needs|missing|closed unmerged|not on `main`)|hulumi[^\n]*(pending|still needs|missing|closed unmerged|not on `main`)|#63' docs/slo/future docs/slo/idea docs/slo/research docs/slo/design README.md SECURITY.md skills crates`