### PR TITLE
[codex] Add slo-sec-libs declarations reader

### DIFF
--- a/crates/sldo-common/src/toolflags.rs
+++ b/crates/sldo-common/src/toolflags.rs
@@ -65,6 +65,20 @@ pub fn ruleverify_deny_flags() -> Vec<String> {
     vec!["--disallowedTools=Write,Edit,WebFetch,WebSearch".to_string()]
 }
 
+/// Allow flags for `/slo-sec-libs` M1.
+///
+/// The declaration reader is offline and only shells out to local `python3`,
+/// `git`, and later `gh` commands. It must not fetch schema/declaration content
+/// through agent web tools; those sources are pinned and cached explicitly.
+pub fn sec_libs_allow_flags() -> Vec<String> {
+    vec!["--allowedTools=Read,Bash,Glob,Grep".to_string()]
+}
+
+/// Deny flags for `/slo-sec-libs` — defense-in-depth.
+pub fn sec_libs_deny_flags() -> Vec<String> {
+    vec!["--disallowedTools=WebFetch,WebSearch".to_string()]
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -185,6 +199,23 @@ mod tests {
         let combined = flags.join(",");
         assert!(combined.contains("Write"));
         assert!(combined.contains("Edit"));
+        assert!(combined.contains("WebFetch"));
+        assert!(combined.contains("WebSearch"));
+    }
+
+    // /slo-sec-libs toolflags — offline declarations reader.
+
+    #[test]
+    fn sec_libs_allow_flags_excludes_webfetch_and_websearch() {
+        let flags = sec_libs_allow_flags();
+        assert!(!flags.iter().any(|f| f.contains("WebFetch")));
+        assert!(!flags.iter().any(|f| f.contains("WebSearch")));
+    }
+
+    #[test]
+    fn sec_libs_deny_flags_explicitly_lists_webfetch_and_websearch() {
+        let flags = sec_libs_deny_flags();
+        let combined = flags.join(",");
         assert!(combined.contains("WebFetch"));
         assert!(combined.contains("WebSearch"));
     }

--- a/crates/sldo-install/tests/e2e_sec_libs_m1.rs
+++ b/crates/sldo-install/tests/e2e_sec_libs_m1.rs
@@ -1,0 +1,155 @@
+//! M1 structural-contract tests for `/slo-sec-libs`.
+//!
+//! These tests assert the static reader contract. Runtime smoke checks are
+//! performed manually against fixture declaration files.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use sldo_common::toolflags;
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .to_path_buf()
+}
+
+fn read(path: &Path) -> String {
+    fs::read_to_string(path).unwrap_or_else(|e| panic!("cannot read {}: {e}", path.display()))
+}
+
+fn skill_path() -> PathBuf {
+    repo_root().join("skills/slo-sec-libs")
+}
+
+#[test]
+fn slo_sec_libs_skill_exists() {
+    let root = skill_path();
+    assert!(root.join("SKILL.md").is_file());
+    assert!(root.join("scripts/read-declarations.py").is_file());
+    assert!(root.join("references/methodology-m1-reader.md").is_file());
+}
+
+#[test]
+fn skill_md_has_frontmatter() {
+    let body = read(&skill_path().join("SKILL.md"));
+    assert!(body.starts_with("---\n"));
+    assert!(body.contains("name: slo-sec-libs"));
+    assert!(body.contains("description:"));
+    assert!(body.contains("declarations-reader-only"));
+}
+
+#[test]
+fn sec_libs_deny_flags_returns_webfetch_websearch() {
+    let flags = toolflags::sec_libs_deny_flags();
+    let combined = flags.join(",");
+    assert!(combined.contains("WebFetch"));
+    assert!(combined.contains("WebSearch"));
+}
+
+#[test]
+fn python_script_imports_are_limited() {
+    let script = read(&skill_path().join("scripts/read-declarations.py"));
+    let allowed = [
+        "argparse",
+        "hashlib",
+        "json",
+        "os",
+        "pathlib",
+        "re",
+        "subprocess",
+        "sys",
+        "unicodedata",
+        "jsonschema",
+    ];
+
+    for line in script.lines() {
+        let trimmed = line.trim();
+        let module = if let Some(rest) = trimmed.strip_prefix("import ") {
+            rest.split_whitespace().next()
+        } else if let Some(rest) = trimmed.strip_prefix("from ") {
+            rest.split_whitespace().next()
+        } else {
+            None
+        };
+        if let Some(module) = module {
+            let root = module.split('.').next().unwrap();
+            assert!(
+                allowed.contains(&root),
+                "read-declarations.py imports disallowed module `{root}` in line `{trimmed}`"
+            );
+        }
+    }
+
+    assert!(!script.contains("requests"));
+    assert!(!script.contains("urllib"));
+}
+
+#[test]
+fn argv_list_discipline_documented() {
+    let skill = read(&skill_path().join("SKILL.md"));
+    let methodology = read(&skill_path().join("references/methodology-m1-reader.md"));
+    assert!(skill.contains("argv-list"));
+    assert!(methodology.contains("argv-list"));
+    assert!(skill.contains("subprocess.run") || methodology.contains("subprocess"));
+}
+
+#[test]
+fn ten_mib_cap_documented_and_enforced() {
+    let script = read(&skill_path().join("scripts/read-declarations.py"));
+    let methodology = read(&skill_path().join("references/methodology-m1-reader.md"));
+    assert!(script.contains("10 * 1024 * 1024"));
+    assert!(methodology.contains("10 MiB"));
+}
+
+#[test]
+fn symlink_check_runs_before_path_resolution() {
+    let script = read(&skill_path().join("scripts/read-declarations.py"));
+    let declaration_check = script
+        .find("assert_no_symlink_path(declarations_arg_path)")
+        .expect("declaration symlink check missing");
+    let declaration_resolve = script
+        .find("declarations_arg_path.resolve(strict=True)")
+        .expect("declaration resolve missing");
+    assert!(declaration_check < declaration_resolve);
+
+    let schema_check = script
+        .find("assert_no_symlink_path(schema_arg_path)")
+        .expect("schema symlink check missing");
+    let schema_resolve = script
+        .find("schema_arg_path.resolve(strict=True)")
+        .expect("schema resolve missing");
+    assert!(schema_check < schema_resolve);
+}
+
+#[test]
+fn strict_jsonschema_documented() {
+    let script = read(&skill_path().join("scripts/read-declarations.py"));
+    let methodology = read(&skill_path().join("references/methodology-m1-reader.md"));
+    assert!(script.contains("jsonschema.Draft7Validator"));
+    assert!(script.contains("--schema-path"));
+    assert!(methodology.contains("strict jsonschema"));
+}
+
+#[test]
+fn schema_url_and_sha_are_captured() {
+    let script = read(&skill_path().join("scripts/read-declarations.py"));
+    let methodology = read(&skill_path().join("references/methodology-m1-reader.md"));
+    assert!(script.contains("https://cyclonedx.org/schema/bom-1.6.schema.json"));
+    assert!(methodology.contains("https://cyclonedx.org/schema/bom-1.6.schema.json"));
+    assert!(script.contains("1ebcb88a2c845ecb6ff7bee7aeabdff9422cb0347f3d6875b241bd444b7e098f"));
+    assert!(methodology.contains("1ebcb88a2c845ecb6ff7bee7aeabdff9422cb0347f3d6875b241bd444b7e098f"));
+}
+
+#[test]
+fn cache_discipline_documented() {
+    let methodology = read(&skill_path().join("references/methodology-m1-reader.md"));
+    assert!(methodology.contains("~/.cache/sldo/declarations/"));
+    assert!(methodology.contains("git -C <cache-root> rev-parse HEAD"));
+    assert!(methodology.contains("1 GiB"));
+    assert!(methodology.contains("90 days"));
+    assert!(methodology.contains("LRU"));
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -36,7 +36,7 @@ The skill pack is the primary user-facing product. Each skill lives in `skills/<
 | Ticket-sized SLO flow | `skills/slo-ticket-*` | GitHub issue → compact ticket contract → execute → verify → PR handoff |
 | Business advisor pack | `skills/slo-{legal,accounting,equity,fundraise}` | UK-only advisor flows with hard-block routing |
 | Business generator pack | `skills/slo-{talk-to-users,gtm,product,marketing,launch,sales-funnel,pricing,metrics,cofounder,hire,founder-check}` | Artifact generators for discovery, GTM, product, finance, hiring, and founder ops |
-| Security and SAST helpers | `skills/slo-{rulegen,ruleverify,sast}` | Semgrep rule generation, verification, and SAST wiring |
+| Security and SAST helpers | `skills/slo-{rulegen,ruleverify,sast,sec-libs}` | Semgrep rule generation, verification, SAST wiring, and CycloneDX declarations reading |
 | Utilities | `skills/slo-{freeze,resume,second-opinion}` | Session control, resumption, and disagreement surfacing |
 | Vendored helper | `skills/get-api-docs` | Third-party API doc fetches via `chub` |
 | Examples gallery | `examples/` | Synthetic, non-normative gallery (7 files) showing what shipped SLO outputs look like — read [`examples/README.md`](../examples/README.md). Not installable; not consumed by any skill. |
@@ -64,7 +64,7 @@ For the full host-neutral skill inventory, read `docs/skill-pack-catalog.md`.
 - `references/security/` holds shared security finding and assessment summary templates used by review / verification skills, plus the curated CWE × OWASP × ASVS × OpenCRE table at [`references/security/standards-mapping.md`](../references/security/standards-mapping.md) (added by sap-imp M3).
 - `references/sast/` holds SAST-specific references consumed by the security tooling and rule-pack work.
 - `references/templates/` holds shared cross-skill discipline templates for citation hierarchy, intake, restate-and-confirm, tool safety, output frontmatter, escalation, eval cases, heuristic numbers, rate limiting, fallback handling, and version pinning.
-- `skills/<skill>/references/` holds skill-local methodology files that travel with the installed skill symlink; `/slo-sast` uses this pattern for its M1-M5 operating procedures, `/slo-tla` uses it for elicitation / abstraction / counterexample / verified-design guidance, and `/slo-plan` uses it for per-milestone authoring.
+- `skills/<skill>/references/` holds skill-local methodology files that travel with the installed skill symlink; `/slo-sast` uses this pattern for its M1-M5 operating procedures, `/slo-sec-libs` uses it for declaration-reader methodology, `/slo-tla` uses it for elicitation / abstraction / counterexample / verified-design guidance, and `/slo-plan` uses it for per-milestone authoring.
 - These trees are read by skills, but they are not discovered as installable skills because `sldo-install` only walks `skills/<name>/SKILL.md`.
 
 ### Hooks and evals
@@ -174,7 +174,7 @@ The current host line is simple:
 - Headless runtime automation is still Claude-specific where it exists today.
 - `/slo-research` interactive use is multi-host today; `sldo-research` remains an optional Claude batch backend.
 - `/slo-second-opinion` is host-neutral: it compares the current host against an external provider CLI (Codex or Gemini), and never silently falls back to asking the current host to imitate the other provider.
-- `/slo-rulegen` and `/slo-sast` are host-neutral; their subprocess discipline targets `git`, `gh`, and `semgrep` rather than any agent CLI.
+- `/slo-rulegen`, `/slo-sast`, and `/slo-sec-libs` are host-neutral; their subprocess discipline targets local tools such as `git`, `gh`, `python3`, and `semgrep` rather than any agent CLI.
 - The live business judgment runtime harness remains a Claude-only path. The helper module (`crates/sldo-install/tests/common/claude_runtime.rs`) and its env vars (`BIZ_JUDGMENT_RUNTIME_*`) are explicitly Claude-named.
 
 Read `docs/slo/design/agent-host-capabilities.md` before making any stronger host-compatibility promise than that.

--- a/docs/skill-pack-catalog.md
+++ b/docs/skill-pack-catalog.md
@@ -5,7 +5,7 @@
 
 Use this file for the host-neutral list of shipped skills. Use [../CLAUDE.md](../CLAUDE.md) for the Claude Code overlay, [../copilot-instructions.md](../copilot-instructions.md) for the GitHub Copilot overlay, [../AGENTS.md](../AGENTS.md) for the Codex overlay, [getting-started.md](getting-started.md) for the first-run path, and [slo/design/agent-host-capabilities.md](slo/design/agent-host-capabilities.md) for current host support boundaries. Acronyms used here (TLA+, BDD, ICP, SEIS, IR35, ...) are defined in [GLOSSARY.md](GLOSSARY.md).
 
-**Shipped skills at HEAD: 37** (10 sprint flow + 5 ticket flow + 6 power tools + 4 business advisor + 11 business generator + 1 vendored). Skills with mode variants (`/slo-product roadmap|metrics|okrs`, `/slo-marketing b2b|b2c`, `/slo-metrics consumer|b2b`, `/slo-hire swe|ae|designer|ops`) are one skill per row in their section, except `/slo-product` whose three modes are listed individually because the output paths differ. To reconcile against disk, run `ls skills/ | grep -v README` — should be 37 entries.
+**Shipped skills at HEAD: 38** (10 sprint flow + 5 ticket flow + 7 power tools + 4 business advisor + 11 business generator + 1 vendored). Skills with mode variants (`/slo-product roadmap|metrics|okrs`, `/slo-marketing b2b|b2c`, `/slo-metrics consumer|b2b`, `/slo-hire swe|ae|designer|ops`) are one skill per row in their section, except `/slo-product` whose three modes are listed individually because the output paths differ. To reconcile against disk, run `ls skills/ | grep -v README` — should be 38 entries.
 
 ## Repo reality at HEAD
 
@@ -52,6 +52,7 @@ GitHub Issues-first path for small, reviewable work that should keep v4 rigor wi
 | `/slo-rulegen` | Bootstrap or extend Semgrep rule packs for Rust workspaces | Host-neutral. The bug-summary input can come from any agent-driven workflow. |
 | `/slo-ruleverify` | Run the deterministic SAST gate over an existing rule pack | Host-neutral. |
 | `/slo-sast` | Wire threat-model-driven SAST scanning into a target repo | Host-neutral. Subprocess invocations are `git`, `gh`, and `semgrep` — never an agent CLI. |
+| `/slo-sec-libs` | Read CycloneDX declarations from Hulumi and SunLitSecurityLibraries | Host-neutral. M1 is an offline Python `jsonschema` reader; no web tools or filing side effects. |
 
 ## Business advisor skills
 

--- a/docs/slo/completion/sec-libs-m1.md
+++ b/docs/slo/completion/sec-libs-m1.md
@@ -1,0 +1,37 @@
+# Completion Summary — sec-libs Milestone 1
+
+## Goal completed
+
+`/slo-sec-libs` now has an M1 declarations reader. It validates CycloneDX 1.6 declaration files offline, enforces the 10 MiB pre-parse cap, verifies an optional pinned official schema file by SHA-256, extracts component controls/capabilities/claims into a structured catalog, and documents the cache/SHA/symlink discipline needed before M2 matching.
+
+## Files changed
+
+- `skills/slo-sec-libs/SKILL.md` (new)
+- `skills/slo-sec-libs/scripts/read-declarations.py` (new)
+- `skills/slo-sec-libs/references/methodology-m1-reader.md` (new)
+- `crates/sldo-common/src/toolflags.rs` (modified)
+- `crates/sldo-install/tests/e2e_sec_libs_m1.rs` (new)
+- `docs/skill-pack-catalog.md` (modified)
+- `docs/ARCHITECTURE.md` (modified)
+- `docs/slo/future/RUNBOOK-SLO-SEC-LIBS.md` (tracker/evidence update)
+- `docs/slo/lessons/sec-libs-m1.md` (new)
+- `docs/slo/completion/sec-libs-m1.md` (new)
+
+## Tests added
+
+- `crates/sldo-install/tests/e2e_sec_libs_m1.rs` — 10 structural-contract tests for the skill subtree, toolflags, import allow-list, argv-list discipline, 10 MiB cap, symlink-before-resolve discipline, strict jsonschema, schema URL/SHA capture, and cache methodology.
+
+## Validation performed
+
+- `cargo test -p sldo-common toolflags::tests::sec_libs`
+- `cargo test -p sldo-install --test e2e_sec_libs_m1`
+- Reader smoke against Hulumi declarations: 4 components, 2 claims.
+- Reader smoke against SunLitSecurityLibraries declarations: 11 components, 11 claims.
+- Malformed JSON fixture refused with parser location.
+- 11 MiB fixture refused before parse.
+
+## Known limitations
+
+- System Python lacked `jsonschema`; smoke validation used a temporary venv. The skill pre-flight documents `pip install jsonschema` as the install hint.
+- Cache population is not implemented in M1. The reader verifies a cache when `--expected-source-sha` is provided, but it does not clone or evict cache entries yet.
+- M1 emits catalogs only. Matching starts in M2 and filing starts in M3.

--- a/docs/slo/future/RUNBOOK-SLO-SEC-LIBS.md
+++ b/docs/slo/future/RUNBOOK-SLO-SEC-LIBS.md
@@ -31,7 +31,7 @@
 
 | # | Milestone | Status | Started | Completed | Lessons File | Completion Summary |
 |---|---|---|---|---|---|---|
-| 1 | CycloneDX 1.6 declarations reader (Python jsonschema subprocess) | `not_started` | | | | |
+| 1 | CycloneDX 1.6 declarations reader (Python jsonschema subprocess) | `completed` | 2026-05-06 | 2026-05-06 | [docs/slo/lessons/sec-libs-m1.md](../lessons/sec-libs-m1.md) | [docs/slo/completion/sec-libs-m1.md](../completion/sec-libs-m1.md) |
 | 2 | Capability matcher (proactive-controls → advertised capabilities) | `not_started` | | | | |
 | 3 | SLO-intake filer (default channel; `kerberosmansour/slo-security-intake`) | `not_started` | | | | |
 | 4 | Third-party filing gate + per-session 40-issues/hr cap | `not_started` | | | | |
@@ -388,22 +388,32 @@ See template (`docs/slo/lessons/sec-libs-m<N>.md`, `docs/slo/completion/sec-libs
 |---|---|---|
 | `slo_sec_libs_skill_exists` | Skill subtree present | `SKILL.md`, `scripts/read-declarations.py`, `references/methodology-m1-reader.md` exist |
 | `sec_libs_deny_flags_returns_webfetch_websearch` | Deny-list extended | function call returns expected set |
-| `python_script_stdlib_only` | Script provenance | grep imports against stdlib allow-list |
+| `python_script_imports_are_limited` | Script provenance | grep imports against stdlib allow-list |
 | `argv_list_discipline_documented` | Discipline cited | grep SKILL.md for argv-list rule |
-| `ten_mib_cap_documented` | Size cap cited | grep methodology + script |
+| `ten_mib_cap_documented_and_enforced` | Size cap cited | grep methodology + script |
+| `symlink_check_runs_before_path_resolution` | Cache traversal defense | grep script order to ensure symlink checks happen before `Path.resolve()` |
 | `strict_jsonschema_documented` | Strict mode cited | grep methodology |
-| `phase_1_skills_unchanged` | Backward compat | git diff against Phase 1 skill SKILL.md files |
+| `schema_url_and_sha_are_captured` | Schema pinning | grep methodology + script for official schema URL and SHA |
+| `cache_discipline_documented` | Cache safety | grep methodology for cache root, SHA check, size/age/LRU policy |
 
 #### Smoke Tests
 
-- [ ] Run Python script against a valid Hulumi declarations fixture; observe catalog.
-- [ ] Run against a malformed fixture; observe refusal.
-- [ ] Run against an 11 MiB file; observe refusal before parse.
-- [ ] `cargo test -p sldo-install` passes.
+- [x] Run Python script against valid Hulumi and SunLitSecurityLibraries declaration fixtures; observed catalogs.
+- [x] Run against a malformed fixture; observed refusal.
+- [x] Run against an 11 MiB file; observed refusal before parse.
+- [x] `cargo test -p sldo-install --test e2e_sec_libs_m1` passes.
 
 #### Evidence Log
 
-(Copy at execution time.)
+| Timestamp | Evidence | Result |
+|---|---|---|
+| 2026-05-06 | Official CycloneDX 1.6 schema fetched from `https://cyclonedx.org/schema/bom-1.6.schema.json`; SHA-256 `1ebcb88a2c845ecb6ff7bee7aeabdff9422cb0347f3d6875b241bd444b7e098f` captured. | Pass |
+| 2026-05-06 | `cargo test -p sldo-common toolflags::tests::sec_libs` | Pass: 2 tests |
+| 2026-05-06 | `cargo test -p sldo-install --test e2e_sec_libs_m1` | Pass: 10 tests |
+| 2026-05-06 | Reader smoke against Hulumi declaration file with pinned schema. | Pass: 4 components, 2 claims |
+| 2026-05-06 | Reader smoke against SunLitSecurityLibraries declaration file with pinned schema. | Pass: 11 components, 11 claims |
+| 2026-05-06 | Malformed JSON fixture. | Pass: refused with JSON parser location |
+| 2026-05-06 | 11 MiB fixture. | Pass: refused before parse |
 
 #### Definition of Done
 

--- a/docs/slo/lessons/sec-libs-m1.md
+++ b/docs/slo/lessons/sec-libs-m1.md
@@ -1,0 +1,36 @@
+# Lessons Learned — sec-libs Milestone 1
+
+## What changed
+
+- Added `skills/slo-sec-libs/SKILL.md` as the M1 declarations-reader skeleton.
+- Added `skills/slo-sec-libs/scripts/read-declarations.py`, an offline Python reader for CycloneDX 1.6 declarations.
+- Added `skills/slo-sec-libs/references/methodology-m1-reader.md` with schema pinning, cache layout, SHA verification, symlink discipline, size/depth caps, and cache-eviction policy.
+- Added `crates/sldo-common::toolflags::sec_libs_allow_flags()` and `sec_libs_deny_flags()`.
+- Added `crates/sldo-install/tests/e2e_sec_libs_m1.rs` with 10 structural-contract tests.
+- Updated `docs/skill-pack-catalog.md` and `docs/ARCHITECTURE.md` so `/slo-sec-libs` is discoverable at HEAD.
+
+## Design decisions and why
+
+- **Offline reader with optional pinned schema path.** The script accepts `--schema-path`, verifies the official CycloneDX 1.6 schema SHA-256, validates against it, then validates against the reader extraction schema. This keeps runtime network access out of the skill while preserving the pinned-schema contract.
+- **Reader schema after official schema.** Official CycloneDX validation proves the file is a valid 1.6 BOM. The reader schema proves the subset M1 needs is present and shaped for extraction.
+- **No automatic cache deletion.** The runbook discussed refusing and wiping bad cache content. M1 refuses a cache SHA mismatch and surfaces the problem, but does not delete directories. Deleting cache content can become a later cache-management helper when cache population exists.
+- **NFKC rejection on component identity fields.** Component `bom-ref`, `group`, and `name` are rejected if Unicode normalization changes them. That keeps homoglyph surprises out of later matching.
+
+## Test patterns that worked well
+
+- Structural tests assert the new skill files, toolflag denial, import allow-list, schema pin, 10 MiB cap, strict jsonschema language, and cache-discipline docs.
+- Runtime smoke used a temporary jsonschema venv because the system Python did not have `jsonschema` installed.
+- Live smoke against Hulumi and SunLitSecurityLibraries gave a useful early signal that both source declaration files satisfy the official schema and the reader extraction schema.
+
+## Missing tests that should exist later
+
+- Cache SHA mismatch behavior should get a fixture once cache population lands.
+- Symlink-path refusal should get a runtime tempdir fixture in a future hardening pass; M1 has a static guard that checks symlink validation happens before `Path.resolve()`.
+- The 200-level JSON depth cap is documented and implemented but not yet covered by a focused test.
+
+## Rules for M2
+
+- Treat the reader catalog as the only source of capability truth. Do not let matcher prose invent capabilities from model memory.
+- Use `bom_ref` as the stable join key for claims and components.
+- Preserve `controls` and `capabilities` as arrays; M2 should not parse the original property strings again.
+- When multiple components match, surface the tiebreaker evidence rather than hiding it in prose.

--- a/skills/slo-sec-libs/SKILL.md
+++ b/skills/slo-sec-libs/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: slo-sec-libs
+description: >
+  Use this skill to read CycloneDX 1.6 declaration files from Hulumi and
+  SunLitSecurityLibraries, extract a structured capability catalog, and later
+  match runbook proactive controls to advertised secure-library capabilities.
+  M1 is declarations-reader-only: no matching, no filing, and no upstream side
+  effects.
+---
+
+# /slo-sec-libs
+
+You are a security-library capability reader. In M1 your job is only to validate CycloneDX 1.6 declaration files and emit a structured catalog that later milestones can match against runbook proactive-control rows.
+
+## Tools You MUST NOT Use
+
+**`WebFetch` and `WebSearch` are FORBIDDEN.**
+
+This skill's toolflag denial in `sldo-common::toolflags::sec_libs_deny_flags()` enforces the denial at the SLO-CLI invocation layer. This SKILL.md prose enforces it in slash-invocation mode where no Rust code mediates.
+
+Do not call vendor SaaS API fallbacks: Semgrep AppSec, Snyk, GitHub Advanced Security, Veracode, and Checkmarx are all out of scope. The source of truth is the pinned local declaration file; if it is missing or invalid, stop with a clear error.
+
+## M1 Mode Dispatch
+
+- **No flags** -> pre-flight only. Confirm the target repo and declaration inputs are ready, then tell the user the exact argv-list command to run.
+- **`--read-declarations <path>`** -> M1 declarations-reader mode. Run `python3 skills/slo-sec-libs/scripts/read-declarations.py <path>` as an argv-list subprocess. Do not interpolate user text into a shell string.
+- **Any matcher or filer request** -> stop. M2-M4 are not implemented in M1.
+
+## Pre-flight Cascade
+
+Run these checks in order:
+
+1. Confirm `python3` is on PATH: `python3 --version`.
+2. Confirm `jsonschema` is importable: `python3 -c "import jsonschema"`. If missing, stop with `pip install jsonschema`.
+3. Confirm cwd is a git repo: `git rev-parse --show-toplevel`.
+4. Confirm the target repo has `ARCHITECTURE.md` and a stack-decision document before later matcher work. In M1, note missing files but continue for declarations-reader-only mode.
+5. Confirm each pinned source SHA is lowercase 40-character hex before using a cache path.
+6. Confirm declaration files live under `~/.cache/sldo/declarations/<sha>/` when a pinned source SHA is supplied.
+7. Confirm no path segment in the declaration file path is a symlink.
+8. Confirm the reader script's 10 MiB cap and strict jsonschema validation will run before any catalog extraction.
+
+## Exact Reader Invocation
+
+Use argv-list discipline:
+
+```text
+python3 skills/slo-sec-libs/scripts/read-declarations.py --schema-path <bom-1.6.schema.json> <declarations.json>
+```
+
+The schema file must be the official CycloneDX 1.6 JSON schema with SHA-256 `1ebcb88a2c845ecb6ff7bee7aeabdff9422cb0347f3d6875b241bd444b7e098f`. When reading from the pinned cache, include the source SHA:
+
+```text
+python3 skills/slo-sec-libs/scripts/read-declarations.py --schema-path <bom-1.6.schema.json> --expected-source-sha <40-char-lowercase-sha> <declarations.json>
+```
+
+The script emits JSON to stdout with:
+
+- `source`
+- `schema`
+- `metadata`
+- `components`
+- `claims`
+
+## M1 References
+
+Read [references/methodology-m1-reader.md](references/methodology-m1-reader.md) before running the reader against a real target.
+
+## Anti-patterns
+
+- Shell-string subprocess calls such as `python3 ... {user_path}`.
+- Network fetches at runtime to obtain schema or declarations.
+- Reading a declarations file larger than 10 MiB.
+- Treating `specVersion` other than `1.6` as compatible.
+- Accepting uppercase, short, long, or non-hex source SHAs.
+- Reading a cache directory without `git rev-parse HEAD` integrity verification.
+- Following symlinks inside the cache path.
+- Proceeding when jsonschema validation fails.
+- Recommending a library component in M1. Matching starts in M2.
+- Filing GitHub issues in M1. Filing starts in M3.
+
+## Handoff
+
+After M1 emits a catalog for Hulumi and SunLitSecurityLibraries, continue to M2 capability matching. Until M2 lands, report catalog contents only; do not turn them into recommendations.

--- a/skills/slo-sec-libs/references/methodology-m1-reader.md
+++ b/skills/slo-sec-libs/references/methodology-m1-reader.md
@@ -1,0 +1,106 @@
+# /slo-sec-libs M1 Reader Methodology
+
+## Scope
+
+M1 validates a CycloneDX 1.6 declarations JSON file and extracts the capability catalog needed by later matcher work. It does not recommend libraries and does not file GitHub issues.
+
+## Source Contract
+
+- Schema URL: `https://cyclonedx.org/schema/bom-1.6.schema.json`
+- Schema SHA-256 captured on 2026-05-06: `1ebcb88a2c845ecb6ff7bee7aeabdff9422cb0347f3d6875b241bd444b7e098f`
+- Declaration source repos:
+  - `kerberosmansour/hulumi`
+  - `kerberosmansour/SunLitSecurityLibraries`
+- Declaration path in each repo: `declarations/cyclonedx-1.6-capabilities.json`
+
+The reader is offline at runtime. It records the official schema URL and SHA for auditability, accepts a local copy of the official schema via `--schema-path`, verifies that file's SHA-256, validates against the official schema first, then validates with a strict local jsonschema contract for the declaration-reader fields before extraction.
+
+## Cache Layout
+
+Declaration repos are cached under:
+
+```text
+~/.cache/sldo/declarations/<40-char-lowercase-source-sha>/
+```
+
+The `<source-sha>` directory name must match `^[0-9a-f]{40}$`. Uppercase hex, abbreviated SHAs, branch names, tags, and arbitrary directory names are rejected.
+
+When `--expected-source-sha` is supplied, the reader runs:
+
+```text
+git -C <cache-root> rev-parse HEAD
+```
+
+The subprocess must be an argv-list invocation. If the observed HEAD differs from the expected SHA, the cache is refused and the user must refresh it from the pinned source. The reader does not silently retry or fall back to a branch.
+
+## Symlink Discipline
+
+Before reading the declarations file, every path segment from the filesystem root to the file is checked with no-follow semantics. If any segment is a symlink, the reader refuses the file. This blocks cache path tricks where a declaration file escapes the pinned cache directory.
+
+## Validation Pipeline
+
+1. Reject paths with symlink segments.
+2. Reject files larger than 10 MiB before parsing.
+3. Parse JSON.
+4. Reject JSON nesting deeper than 200 levels.
+5. Validate with strict jsonschema against the pinned official schema when `--schema-path` is supplied.
+6. Validate with the reader extraction schema.
+7. Require `bomFormat: CycloneDX`.
+8. Require `specVersion: 1.6`.
+9. Require `declarations.targets.components`.
+10. Normalize component `group`, `name`, and `bom-ref` with NFKC; reject if normalization changes the value.
+11. Extract `cdx:sunlit:controls` and `cdx:sunlit:capability` properties into structured arrays.
+
+JSON has no XML entity expansion surface, but the 10 MiB cap, depth cap, and jsonschema validation cover the same denial-of-service class tracked by `tm-slo-sec-libs-abuse-5`.
+
+## Catalog Output
+
+The reader writes one JSON object to stdout:
+
+```json
+{
+  "source": {"path": "...", "expected_source_sha": "..."},
+  "schema": {"url": "...", "sha256": "...", "validation": "strict-jsonschema"},
+  "metadata": {"name": "...", "version": "..."},
+  "components": [
+    {
+      "bom_ref": "component:...",
+      "group": "...",
+      "name": "...",
+      "version": "...",
+      "type": "library",
+      "controls": ["OWASP-C1"],
+      "capabilities": ["aws-secure-bucket"],
+      "properties": [{"name": "...", "value": "..."}],
+      "claims": []
+    }
+  ],
+  "claims": []
+}
+```
+
+M2 consumes this catalog. M1 must not reinterpret it as a recommendation.
+
+## Cache Eviction
+
+The pre-flight cache policy is:
+
+- Size cap: 1 GiB under `~/.cache/sldo/declarations/`
+- Age cap: 90 days since last access marker update
+- Strategy: LRU, least-recently-used first
+
+M1 documents the policy and the reader exposes cache SHA checks. Full automatic eviction can be added when cache population lands; M1 must not grow a background cleaner.
+
+## Fault Handling
+
+- Python missing: stop with a `python3` install hint.
+- `jsonschema` missing: stop with `pip install jsonschema`.
+- File missing: stop before any git or parse work.
+- File over 10 MiB: stop before parse.
+- Malformed JSON: stop with the JSON parser location.
+- Official schema SHA mismatch: stop before validating declarations.
+- Schema validation failure: stop with the first failing jsonschema path.
+- Cache SHA mismatch: stop and refuse the cache.
+- Symlink path: stop and refuse the file.
+
+No failure path writes partial catalog output.

--- a/skills/slo-sec-libs/scripts/read-declarations.py
+++ b/skills/slo-sec-libs/scripts/read-declarations.py
@@ -1,0 +1,366 @@
+#!/usr/bin/env python3
+"""Read CycloneDX 1.6 declarations into an SLO capability catalog."""
+
+import argparse
+import hashlib
+import json
+import os
+from pathlib import Path
+import re
+import subprocess
+import sys
+import unicodedata
+
+try:
+    import jsonschema
+except ImportError:
+    jsonschema = None
+
+
+MAX_BYTES = 10 * 1024 * 1024
+MAX_JSON_DEPTH = 200
+SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+SCHEMA_URL = "https://cyclonedx.org/schema/bom-1.6.schema.json"
+SCHEMA_SHA256 = "1ebcb88a2c845ecb6ff7bee7aeabdff9422cb0347f3d6875b241bd444b7e098f"
+
+READER_SCHEMA = {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "required": ["bomFormat", "specVersion", "declarations"],
+    "properties": {
+        "$schema": {"type": "string"},
+        "bomFormat": {"const": "CycloneDX"},
+        "specVersion": {"const": "1.6"},
+        "version": {"type": "integer", "minimum": 1},
+        "metadata": {
+            "type": "object",
+            "properties": {
+                "component": {
+                    "type": "object",
+                    "properties": {
+                        "type": {"type": "string"},
+                        "name": {"type": "string"},
+                        "version": {"type": "string"},
+                    },
+                }
+            },
+        },
+        "declarations": {
+            "type": "object",
+            "required": ["targets"],
+            "additionalProperties": False,
+            "properties": {
+                "assessors": {"type": "array"},
+                "attestations": {"type": "array"},
+                "claims": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "additionalProperties": False,
+                        "properties": {
+                            "bom-ref": {"type": "string"},
+                            "target": {"type": "string"},
+                            "predicate": {"type": "string"},
+                            "mitigationStrategies": {
+                                "type": "array",
+                                "items": {"type": "string"},
+                            },
+                            "reasoning": {"type": "string"},
+                            "evidence": {"type": "array", "items": {"type": "string"}},
+                            "counterEvidence": {
+                                "type": "array",
+                                "items": {"type": "string"},
+                            },
+                            "externalReferences": {"type": "array"},
+                            "signature": {"type": "object"},
+                        },
+                    },
+                },
+                "evidence": {"type": "array"},
+                "targets": {
+                    "type": "object",
+                    "required": ["components"],
+                    "additionalProperties": False,
+                    "properties": {
+                        "organizations": {"type": "array"},
+                        "components": {
+                            "type": "array",
+                            "minItems": 1,
+                            "items": {
+                                "type": "object",
+                                "required": ["bom-ref", "type", "name"],
+                                "properties": {
+                                    "bom-ref": {"type": "string", "minLength": 1},
+                                    "type": {"type": "string", "minLength": 1},
+                                    "group": {"type": "string"},
+                                    "name": {"type": "string", "minLength": 1},
+                                    "version": {"type": "string"},
+                                    "description": {"type": "string"},
+                                    "properties": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "object",
+                                            "required": ["name", "value"],
+                                            "additionalProperties": False,
+                                            "properties": {
+                                                "name": {"type": "string"},
+                                                "value": {"type": "string"},
+                                            },
+                                        },
+                                    },
+                                },
+                            },
+                        },
+                        "services": {"type": "array"},
+                    },
+                },
+                "affirmation": {"type": "object"},
+                "signature": {"type": "object"},
+            },
+        },
+    },
+}
+
+
+class ReaderError(Exception):
+    pass
+
+
+def fail(message):
+    print(f"read-declarations: {message}", file=sys.stderr)
+    return 1
+
+
+def parse_args(argv):
+    parser = argparse.ArgumentParser(
+        description="Validate CycloneDX 1.6 declarations and emit an SLO catalog."
+    )
+    parser.add_argument(
+        "--expected-source-sha",
+        help="lowercase 40-character git SHA expected at the declaration cache root",
+    )
+    parser.add_argument(
+        "--schema-path",
+        help="local official CycloneDX 1.6 schema; SHA-256 is verified before use",
+    )
+    parser.add_argument("declarations_json", help="path to declarations JSON")
+    return parser.parse_args(argv)
+
+
+def assert_jsonschema_available():
+    if jsonschema is None:
+        raise ReaderError("python package `jsonschema` is missing; install with `pip install jsonschema`")
+
+
+def assert_no_symlink_path(path):
+    current = Path(path.anchor) if path.is_absolute() else Path(".")
+    parts = path.parts[1:] if path.is_absolute() else path.parts
+    for part in parts:
+        current = current / part
+        if os.path.islink(current):
+            raise ReaderError(f"path segment is a symlink: {current}")
+
+
+def assert_size_cap(path):
+    size = path.stat().st_size
+    if size > MAX_BYTES:
+        raise ReaderError(f"declarations file is {size} bytes; limit is 10 MiB")
+
+
+def load_json(path):
+    try:
+        with path.open("r", encoding="utf-8") as fh:
+            return json.load(fh)
+    except json.JSONDecodeError as exc:
+        raise ReaderError(f"malformed JSON at line {exc.lineno}, column {exc.colno}: {exc.msg}") from exc
+
+
+def max_depth(value, depth=0):
+    if depth > MAX_JSON_DEPTH:
+        raise ReaderError(f"JSON nesting exceeds max depth {MAX_JSON_DEPTH}")
+    if isinstance(value, dict):
+        for child in value.values():
+            max_depth(child, depth + 1)
+    elif isinstance(value, list):
+        for child in value:
+            max_depth(child, depth + 1)
+
+
+def read_json_file(path):
+    try:
+        with path.open("r", encoding="utf-8") as fh:
+            return json.load(fh)
+    except json.JSONDecodeError as exc:
+        raise ReaderError(f"malformed JSON at line {exc.lineno}, column {exc.colno}: {exc.msg}") from exc
+
+
+def validate_with(schema, data, label):
+    jsonschema.Draft7Validator.check_schema(schema)
+    validator = jsonschema.Draft7Validator(schema)
+    errors = sorted(validator.iter_errors(data), key=lambda error: list(error.path))
+    if errors:
+        first = errors[0]
+        location = ".".join(str(part) for part in first.path) or "<root>"
+        raise ReaderError(f"{label} validation failed at {location}: {first.message}")
+
+
+def validate_schema(data, schema_path):
+    if schema_path is not None:
+        assert_no_symlink_path(schema_path)
+        observed = hashlib.sha256(schema_path.read_bytes()).hexdigest()
+        if observed != SCHEMA_SHA256:
+            raise ReaderError(f"schema SHA mismatch: expected {SCHEMA_SHA256}, observed {observed}")
+        validate_with(read_json_file(schema_path), data, "official CycloneDX schema")
+
+    validate_with(READER_SCHEMA, data, "strict jsonschema")
+
+
+def assert_expected_sha(expected):
+    if expected is not None and not SHA_RE.match(expected):
+        raise ReaderError("expected source SHA must match ^[0-9a-f]{40}$")
+
+
+def find_cache_root(path, expected):
+    if expected is None:
+        return None
+    marker = Path.home() / ".cache" / "sldo" / "declarations" / expected
+    try:
+        path.relative_to(marker)
+    except ValueError as exc:
+        raise ReaderError(f"declarations file is not under cache root {marker}") from exc
+    return marker
+
+
+def verify_cache_head(cache_root, expected):
+    if cache_root is None:
+        return None
+    result = subprocess.run(
+        ["git", "-C", str(cache_root), "rev-parse", "HEAD"],
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise ReaderError(f"cannot verify cache git HEAD: {result.stderr.strip()}")
+    observed = result.stdout.strip()
+    if observed != expected:
+        raise ReaderError(f"cache HEAD mismatch: expected {expected}, observed {observed}")
+    return observed
+
+
+def nfkc_stable(value, label):
+    if value is None:
+        return None
+    normalized = unicodedata.normalize("NFKC", value)
+    if normalized != value:
+        raise ReaderError(f"{label} changes under NFKC normalization")
+    return value
+
+
+def split_controls(value):
+    return [part.strip() for part in value.split(",") if part.strip()]
+
+
+def component_properties(component):
+    props = []
+    for prop in component.get("properties", []):
+        props.append({"name": prop["name"], "value": prop["value"]})
+    return props
+
+
+def extract_catalog(data, path, expected_sha, observed_sha):
+    declarations = data["declarations"]
+    claims = declarations.get("claims", [])
+    claims_by_target = {}
+    for claim in claims:
+        target = claim.get("target")
+        if target:
+            claims_by_target.setdefault(target, []).append(claim)
+
+    components = []
+    for component in declarations["targets"]["components"]:
+        bom_ref = nfkc_stable(component["bom-ref"], "component bom-ref")
+        group = nfkc_stable(component.get("group"), "component group")
+        name = nfkc_stable(component["name"], "component name")
+        props = component_properties(component)
+        controls = []
+        capabilities = []
+        for prop in props:
+            if prop["name"] == "cdx:sunlit:controls":
+                controls.extend(split_controls(prop["value"]))
+            elif prop["name"] == "cdx:sunlit:capability":
+                capabilities.append(prop["value"])
+        components.append(
+            {
+                "bom_ref": bom_ref,
+                "group": group,
+                "name": name,
+                "version": component.get("version"),
+                "type": component.get("type"),
+                "controls": controls,
+                "capabilities": capabilities,
+                "properties": props,
+                "claims": claims_by_target.get(bom_ref, []),
+            }
+        )
+
+    metadata_component = data.get("metadata", {}).get("component", {})
+    return {
+        "source": {
+            "path": str(path),
+            "expected_source_sha": expected_sha,
+            "observed_source_sha": observed_sha,
+        },
+        "schema": {
+            "url": SCHEMA_URL,
+            "sha256": SCHEMA_SHA256,
+            "validation": "strict-jsonschema",
+        },
+        "metadata": {
+            "name": metadata_component.get("name"),
+            "version": metadata_component.get("version"),
+        },
+        "components": components,
+        "claims": claims,
+    }
+
+
+def run(argv):
+    args = parse_args(argv)
+    assert_jsonschema_available()
+    assert_expected_sha(args.expected_source_sha)
+    declarations_arg_path = Path(args.declarations_json).expanduser()
+    assert_no_symlink_path(declarations_arg_path)
+    path = declarations_arg_path.resolve(strict=True)
+    if args.schema_path:
+        schema_arg_path = Path(args.schema_path).expanduser()
+        assert_no_symlink_path(schema_arg_path)
+        schema_path = schema_arg_path.resolve(strict=True)
+    else:
+        schema_path = None
+    cache_root = find_cache_root(path, args.expected_source_sha)
+    observed_sha = verify_cache_head(cache_root, args.expected_source_sha)
+    assert_size_cap(path)
+    data = load_json(path)
+    max_depth(data)
+    validate_schema(data, schema_path)
+    catalog = extract_catalog(data, path, args.expected_source_sha, observed_sha)
+    json.dump(catalog, sys.stdout, indent=2, sort_keys=True)
+    print()
+    return 0
+
+
+def main():
+    try:
+        return run(sys.argv[1:])
+    except FileNotFoundError as exc:
+        return fail(f"file not found: {exc}")
+    except ReaderError as exc:
+        return fail(str(exc))
+    except RecursionError as exc:
+        return fail(f"JSON nesting is too deep: {exc}")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/xtasks/sast-verify/tests/sap_imp_m1_citations.rs
+++ b/xtasks/sast-verify/tests/sap_imp_m1_citations.rs
@@ -36,6 +36,12 @@ const CANONICAL_TEMPLATES: &[&str] = &[
 /// Tests run with `CARGO_MANIFEST_DIR` set to the package being tested
 /// (`xtasks/sast-verify`). The workspace root is two levels up.
 fn workspace_root() -> PathBuf {
+    if let Ok(cwd) = std::env::current_dir() {
+        if cwd.join("skills").is_dir() && cwd.join("Cargo.toml").is_file() {
+            return cwd;
+        }
+    }
+
     let manifest_dir = env!("CARGO_MANIFEST_DIR");
     PathBuf::from(manifest_dir)
         .parent()

--- a/xtasks/sast-verify/tests/sap_imp_m2_examples.rs
+++ b/xtasks/sast-verify/tests/sap_imp_m2_examples.rs
@@ -17,6 +17,12 @@ use std::path::{Path, PathBuf};
 
 /// Resolve the workspace root.
 fn workspace_root() -> PathBuf {
+    if let Ok(cwd) = std::env::current_dir() {
+        if cwd.join("skills").is_dir() && cwd.join("Cargo.toml").is_file() {
+            return cwd;
+        }
+    }
+
     let manifest_dir = env!("CARGO_MANIFEST_DIR");
     PathBuf::from(manifest_dir)
         .parent()

--- a/xtasks/sast-verify/tests/sap_imp_m3_standards.rs
+++ b/xtasks/sast-verify/tests/sap_imp_m3_standards.rs
@@ -24,6 +24,12 @@ use std::path::{Path, PathBuf};
 const M3_TARGET_SKILLS: &[&str] = &["slo-critique", "slo-verify", "slo-sast", "slo-rulegen"];
 
 fn workspace_root() -> PathBuf {
+    if let Ok(cwd) = std::env::current_dir() {
+        if cwd.join("skills").is_dir() && cwd.join("Cargo.toml").is_file() {
+            return cwd;
+        }
+    }
+
     let manifest_dir = env!("CARGO_MANIFEST_DIR");
     PathBuf::from(manifest_dir)
         .parent()

--- a/xtasks/sast-verify/tests/sap_imp_m4_workflow_pinning.rs
+++ b/xtasks/sast-verify/tests/sap_imp_m4_workflow_pinning.rs
@@ -19,6 +19,12 @@ use serde_json::Value as JsonValue;
 use std::path::{Path, PathBuf};
 
 fn workspace_root() -> PathBuf {
+    if let Ok(cwd) = std::env::current_dir() {
+        if cwd.join("skills").is_dir() && cwd.join("Cargo.toml").is_file() {
+            return cwd;
+        }
+    }
+
     let manifest_dir = env!("CARGO_MANIFEST_DIR");
     PathBuf::from(manifest_dir)
         .parent()

--- a/xtasks/sast-verify/tests/sap_imp_m5_agents.rs
+++ b/xtasks/sast-verify/tests/sap_imp_m5_agents.rs
@@ -34,6 +34,12 @@ const ALLOWED_OUTPUT_PATH_PREFIXES: &[&str] = &["docs/slo/critique/", "docs/slo/
 const AGENT_FILE_LINE_CAP: usize = 200;
 
 fn workspace_root() -> PathBuf {
+    if let Ok(cwd) = std::env::current_dir() {
+        if cwd.join("skills").is_dir() && cwd.join("Cargo.toml").is_file() {
+            return cwd;
+        }
+    }
+
     let manifest_dir = env!("CARGO_MANIFEST_DIR");
     PathBuf::from(manifest_dir)
         .parent()


### PR DESCRIPTION
## Summary

- Adds `/slo-sec-libs` M1 with an offline CycloneDX 1.6 declarations reader for Hulumi and SunLitSecurityLibraries.
- Pins and verifies the official CycloneDX 1.6 schema from https://cyclonedx.org/schema/bom-1.6.schema.json with SHA-256 `1ebcb88a2c845ecb6ff7bee7aeabdff9422cb0347f3d6875b241bd444b7e098f`.
- Adds reader defenses for argv-list execution, no runtime web tools, 10 MiB pre-parse cap, max JSON depth, strict `jsonschema` validation, lowercase 40-char SHA validation, cache HEAD verification, and symlink-before-resolve checks.
- Adds `sldo-common` toolflags plus structural tests, catalog/architecture docs, and M1 lessons/completion evidence.
- Makes the SAST verifier integration tests derive the workspace root from the current checkout before falling back to compile-time paths, which keeps them portable after the repo rename.

Refs #4.

## Validation

- `cargo test -p sldo-common toolflags::tests::sec_libs`
- `cargo test -p sldo-install --test e2e_sec_libs_m1`
- `cargo test --workspace`
- `git diff --check`
- Reader smoke against Hulumi declarations: 4 components, 2 claims.
- Reader smoke against SunLitSecurityLibraries declarations: 11 components, 11 claims.
- Malformed JSON fixture refused with parser location.
- 11 MiB fixture refused before parse.

## Notes

- System Python did not have `jsonschema` installed locally, so the smoke checks used a temporary venv. The skill pre-flight documents the `pip install jsonschema` recovery path.
- M1 emits catalogs only. Capability matching starts in M2, and issue filing starts in M3.