### PR TITLE
SLO: Add slo-sec-libs upstream filing gate

### DIFF
--- a/crates/sldo-install/tests/e2e_sec_libs_m4.rs
+++ b/crates/sldo-install/tests/e2e_sec_libs_m4.rs
@@ -1,0 +1,187 @@
+//! M4 structural-contract tests for `/slo-sec-libs`.
+//!
+//! These tests assert the explicit upstream filing gate and per-session cap.
+//! Live upstream issue creation remains manually gated by user confirmation.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use sldo_common::toolflags;
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .to_path_buf()
+}
+
+fn read(path: &Path) -> String {
+    fs::read_to_string(path).unwrap_or_else(|e| panic!("cannot read {}: {e}", path.display()))
+}
+
+fn skill_path() -> PathBuf {
+    repo_root().join("skills/slo-sec-libs")
+}
+
+fn skill() -> String {
+    read(&skill_path().join("SKILL.md"))
+}
+
+fn discipline() -> String {
+    read(&skill_path().join("references/upstream-filing-discipline.md"))
+}
+
+fn cap_decision(filed_this_session: u8) -> &'static str {
+    if filed_this_session < 40 {
+        "allow-upstream"
+    } else {
+        "spilled-cap"
+    }
+}
+
+#[test]
+fn file_upstream_flag_documented() {
+    let skill = skill();
+    let discipline = discipline();
+    assert!(skill.contains("--file-upstream --upstream-dir <path>"));
+    assert!(skill.contains("M4 upstream filing mode"));
+    assert!(discipline.contains("`--file-upstream` is an explicit opt-in gate"));
+    assert!(discipline.contains("Without it, every valid gap follows the default SLO-intake path"));
+}
+
+#[test]
+fn default_destination_unchanged_without_file_upstream() {
+    let skill = skill();
+    let discipline = discipline();
+    assert!(skill.contains("--file-gaps <m2-output.json> --intake-dir <path>"));
+    assert!(skill.contains("M3 default filing mode"));
+    assert!(discipline.contains("Default destination: `kerberosmansour/slo-security-intake`"));
+    assert!(discipline.contains("default SLO-intake path"));
+}
+
+#[test]
+fn upstream_owner_mapping_locked() {
+    let discipline = discipline();
+    for expected in [
+        "`hulumi`",
+        "`kerberosmansour/hulumi`",
+        "`SunLitSecurityLibraries`",
+        "`kerberosmansour/SunLitSecurityLibraries`",
+        "`unknown` | none | upstream filing refused",
+    ] {
+        assert!(
+            discipline.contains(expected),
+            "missing mapping `{expected}`"
+        );
+    }
+    assert!(discipline
+        .contains("Ambiguous, unknown, legacy, or mismatched owner values MUST NOT file upstream"));
+}
+
+#[test]
+fn upstream_confirmation_and_fallback_documented() {
+    let skill = skill();
+    let discipline = discipline();
+    assert!(skill.contains("require a yes/no confirmation for upstream filing"));
+    assert!(skill.contains("separate confirmation before any intake fallback"));
+    assert!(discipline.contains(
+        "If the user declines upstream filing, offer the SLO-intake fallback and ask again"
+    ));
+    assert!(discipline.contains("Resolved intake origin URL"));
+    assert!(discipline.contains("Cap counter (`filed_this_session` / 40)"));
+}
+
+#[test]
+fn forty_per_hour_cap_documented() {
+    let skill = skill();
+    let discipline = discipline();
+    assert!(skill.contains("40 issues per session per hour cap"));
+    assert!(skill.contains("filed_this_session"));
+    assert!(discipline.contains("40 issues per session per hour"));
+    assert!(discipline.contains("filed_this_session = 0"));
+    assert!(discipline.contains("Allow upstream filings while `filed_this_session < 40`"));
+    assert!(
+        discipline.contains("41st and later upstream candidates MUST NOT call `gh issue create`")
+    );
+}
+
+#[test]
+fn cap_simulation_allows_first_40_and_spills_41st() {
+    for filed in 0..40 {
+        assert_eq!(cap_decision(filed), "allow-upstream");
+    }
+    assert_eq!(cap_decision(40), "spilled-cap");
+    assert_eq!(cap_decision(41), "spilled-cap");
+}
+
+#[test]
+fn cross_session_state_not_persisted() {
+    let skill = skill();
+    let discipline = discipline();
+    let combined = format!("{skill}\n{discipline}");
+    assert!(combined.contains("never persist cap state across sessions"));
+    assert!(discipline.contains("MUST NOT persist cap state to disk, environment variables, git config, temp files, or any global cache"));
+    assert!(discipline.contains("The cap resets when the invocation/session ends"));
+    assert!(!combined.to_lowercase().contains("saved counter"));
+    assert!(!combined.to_lowercase().contains("global counter"));
+}
+
+#[test]
+fn lessons_backlog_spillover() {
+    let skill = skill();
+    let discipline = discipline();
+    assert!(skill.contains("spill the 41st and later candidates to `LESSONS-BACKLOG.md` with `disposition: spilled-cap`"));
+    assert!(discipline.contains("LESSONS-BACKLOG.md"));
+    assert!(discipline.contains("capability-gap-schema.md"));
+    assert!(discipline.contains("disposition` | `spilled-cap`"));
+    assert!(discipline.contains("spillover_reason` | `upstream-cap-40-per-session`"));
+}
+
+#[test]
+fn no_repo_and_no_merge_flags_still_forbidden() {
+    let skill = skill();
+    let discipline = discipline();
+    assert!(skill.contains("Do not use `--repo`"));
+    assert!(discipline.contains("NO `--repo` flag"));
+    assert!(!discipline.contains("gh issue create --repo"));
+    assert!(!discipline.contains("gh issue list --repo"));
+    assert!(discipline.contains("Running `gh pr merge`"));
+    for flag in ["--auto", "--merge", "--squash", "--rebase", "--admin"] {
+        assert!(
+            discipline.contains(flag),
+            "missing forbidden merge flag `{flag}`"
+        );
+    }
+}
+
+#[test]
+fn no_gh_auth_login_from_skill() {
+    let skill = skill();
+    let discipline = discipline();
+    assert!(skill.contains("never run `gh auth login`"));
+    assert!(discipline.contains("Never run `gh auth login` from this skill"));
+    assert!(discipline.contains("gh auth status"));
+}
+
+#[test]
+fn m1_m2_m3_contracts_still_present() {
+    let root = skill_path();
+    let skill = skill();
+    assert!(skill.contains("--read-declarations <path>"));
+    assert!(skill.contains("--match <runbook.md> --catalog <catalog.json>"));
+    assert!(skill.contains("--file-gaps <m2-output.json> --intake-dir <path>"));
+    assert!(root.join("scripts/read-declarations.py").is_file());
+    assert!(root.join("references/methodology-m1-reader.md").is_file());
+    assert!(root.join("references/methodology-m2-matcher.md").is_file());
+    assert!(root.join("references/capability-gap-schema.md").is_file());
+}
+
+#[test]
+fn sec_libs_tool_deny_flags_unchanged() {
+    let flags = toolflags::sec_libs_deny_flags();
+    let combined = flags.join(",");
+    assert!(combined.contains("WebFetch"));
+    assert!(combined.contains("WebSearch"));
+}

--- a/docs/skill-pack-catalog.md
+++ b/docs/skill-pack-catalog.md
@@ -52,7 +52,7 @@ GitHub Issues-first path for small, reviewable work that should keep v4 rigor wi
 | `/slo-rulegen` | Bootstrap or extend Semgrep rule packs for Rust workspaces | Host-neutral. The bug-summary input can come from any agent-driven workflow. |
 | `/slo-ruleverify` | Run the deterministic SAST gate over an existing rule pack | Host-neutral. |
 | `/slo-sast` | Wire threat-model-driven SAST scanning into a target repo | Host-neutral. Subprocess invocations are `git`, `gh`, and `semgrep` — never an agent CLI. |
-| `/slo-sec-libs` | Read CycloneDX declarations, match proactive controls to advertised capabilities, and file confirmed intake gaps | Host-neutral. M1-M2 are read-only: offline Python `jsonschema` reader plus catalog-grounded matcher. M3 files only regex-validated, user-confirmed SLO-intake issues; no upstream filing until M4. |
+| `/slo-sec-libs` | Read CycloneDX declarations, match proactive controls to advertised capabilities, and file confirmed capability gaps | Host-neutral. M1-M2 are read-only: offline Python `jsonschema` reader plus catalog-grounded matcher. M3 files regex-validated SLO-intake issues; M4 adds explicit upstream filing with per-issue confirmation and a 40-issues/hr session cap. |
 
 ## Business advisor skills
 

--- a/docs/slo/completion/sec-libs-m4.md
+++ b/docs/slo/completion/sec-libs-m4.md
@@ -1,0 +1,37 @@
+# Completion Summary - sec-libs Milestone 4
+
+## Goal completed
+
+`/slo-sec-libs` now has an explicit M4 upstream filing gate. The default filing path remains `kerberosmansour/slo-security-intake`, while `--file-upstream --upstream-dir <path>` can file confirmed gaps to the mapped Hulumi or SunLitSecurityLibraries checkout. M4 also documents the 40 issues per session per hour cap and `LESSONS-BACKLOG.md` spillover path.
+
+## Files changed
+
+- `skills/slo-sec-libs/SKILL.md` (extended)
+- `skills/slo-sec-libs/references/upstream-filing-discipline.md` (extended)
+- `crates/sldo-install/tests/e2e_sec_libs_m4.rs` (new)
+- `docs/skill-pack-catalog.md` (modified)
+- `docs/slo/future/RUNBOOK-SLO-SEC-LIBS.md` (tracker/evidence update)
+- `docs/slo/lessons/sec-libs-m4.md` (new)
+- `docs/slo/completion/sec-libs-m4.md` (new)
+
+## Tests added
+
+- `crates/sldo-install/tests/e2e_sec_libs_m4.rs` - 12 structural-contract tests for `--file-upstream`, default destination preservation, owner mapping, confirmation/fallback behavior, 40/hr cap, cap-boundary simulation, no persisted state, spillover, no `--repo`, auth discipline, M1-M3 compatibility, and deny-list compatibility.
+
+## Validation performed
+
+- `git diff --check`
+- `rustfmt --check crates/sldo-install/tests/e2e_sec_libs_m4.rs`
+- `cargo test -p sldo-install --test e2e_sec_libs_m1`
+- `cargo test -p sldo-install --test e2e_sec_libs_m2`
+- `cargo test -p sldo-install --test e2e_sec_libs_m3`
+- `cargo test -p sldo-install --test e2e_sec_libs_m4`
+- `cargo test -p sldo-install --test e2e_agent_host_m2`
+- `cargo test -p sldo-install`
+- `cargo test --workspace`
+
+## Known limitations
+
+- No live upstream issue was filed during implementation because M4 still requires explicit per-issue confirmation.
+- M4 remains a host-driven filing contract, not a standalone Rust or Python filer executable.
+- The only upstream owner mappings are `hulumi` and `SunLitSecurityLibraries`.

--- a/docs/slo/future/RUNBOOK-SLO-SEC-LIBS.md
+++ b/docs/slo/future/RUNBOOK-SLO-SEC-LIBS.md
@@ -34,7 +34,7 @@
 | 1 | CycloneDX 1.6 declarations reader (Python jsonschema subprocess) | `completed` | 2026-05-06 | 2026-05-06 | [docs/slo/lessons/sec-libs-m1.md](../lessons/sec-libs-m1.md) | [docs/slo/completion/sec-libs-m1.md](../completion/sec-libs-m1.md) |
 | 2 | Capability matcher (proactive-controls → advertised capabilities) | `completed` | 2026-05-06 | 2026-05-06 | [docs/slo/lessons/sec-libs-m2.md](../lessons/sec-libs-m2.md) | [docs/slo/completion/sec-libs-m2.md](../completion/sec-libs-m2.md) |
 | 3 | SLO-intake filer (default channel; `kerberosmansour/slo-security-intake`) | `completed` | 2026-05-06 | 2026-05-06 | [docs/slo/lessons/sec-libs-m3.md](../lessons/sec-libs-m3.md) | [docs/slo/completion/sec-libs-m3.md](../completion/sec-libs-m3.md) |
-| 4 | Third-party filing gate + per-session 40-issues/hr cap | `not_started` | | | | |
+| 4 | Third-party filing gate + per-session 40-issues/hr cap | `completed` | 2026-05-06 | 2026-05-06 | [docs/slo/lessons/sec-libs-m4.md](../lessons/sec-libs-m4.md) | [docs/slo/completion/sec-libs-m4.md](../completion/sec-libs-m4.md) |
 | 5 | Dogfood: re-critique an SLO milestone using `/slo-sec-libs` | `not_started` | | | | |
 
 ### Pre-requisites (one-time, BEFORE M1)
@@ -715,7 +715,7 @@ See template (`docs/slo/lessons/sec-libs-m<N>.md`, `docs/slo/completion/sec-libs
 | Inputs | M3's filer; `--file-upstream` flag; per-session counter |
 | Outputs | Filings to library-owner repos when `--file-upstream` is passed; spillover to `LESSONS-BACKLOG.md` on cap |
 | Interfaces touched | SKILL.md mode dispatch; `upstream-filing-discipline.md` extended |
-| Files allowed to change | `skills/slo-sec-libs/SKILL.md` (extend), `skills/slo-sec-libs/references/upstream-filing-discipline.md` (extend), `crates/sldo-install/tests/e2e_sec_libs_m4.rs` (NEW) |
+| Files allowed to change | `skills/slo-sec-libs/SKILL.md` (extend), `skills/slo-sec-libs/references/upstream-filing-discipline.md` (extend), `crates/sldo-install/tests/e2e_sec_libs_m4.rs` (NEW), tracker/lessons/completion/catalog docs |
 | Files to read before changing anything | M3 lessons; R1 M3's rate-limit pattern (if shipped) |
 | New files allowed | test file |
 | New dependencies allowed | `none` |
@@ -772,8 +772,8 @@ See template (`docs/slo/lessons/sec-libs-m<N>.md`, `docs/slo/completion/sec-libs
 
 #### Compatibility Checklist
 
-- [ ] M1, M2, M3 unchanged.
-- [ ] Default destination still `slo-security-intake`.
+- [x] M1, M2, M3 unchanged.
+- [x] Default destination still `slo-security-intake`.
 
 #### E2E Runtime Validation
 
@@ -785,16 +785,28 @@ See template (`docs/slo/lessons/sec-libs-m<N>.md`, `docs/slo/completion/sec-libs
 | `forty_per_hour_cap_documented` | Cap cited | grep |
 | `cross_session_state_not_persisted` | Per-session discipline | grep refuses any "saved counter" pattern |
 | `lessons_backlog_spillover` | Spillover documented | grep |
+| `cap_simulation_allows_first_40_and_spills_41st` | Cap boundary | executable helper allows 0-39 and spills 40+ |
+| `default_destination_unchanged_without_file_upstream` | M3 default preserved | grep SKILL.md + discipline |
+| `upstream_owner_mapping_locked` | Owner mapping bounded | grep Hulumi, SunLitSecurityLibraries, unknown refusal |
+| `upstream_confirmation_and_fallback_documented` | Consent gate preserved | grep confirmation + fallback |
+| `no_repo_and_no_merge_flags_still_forbidden` | Existing safety preserved | grep forbidden flags |
+| `m1_m2_m3_contracts_still_present` | Backward compatibility | grep prior mode refs |
+| `sec_libs_tool_deny_flags_unchanged` | Toolflag compatibility | deny flags still include WebFetch/WebSearch |
 
 #### Smoke Tests
 
-- [ ] Mock-invoke 40 fillings; observe all proceed; 41st triggers cap + spillover.
-- [ ] End session, restart, attempt filing — observe counter reset.
-- [ ] `cargo test -p sldo-install` passes.
+- [x] Simulated 40 upstream filings in `e2e_sec_libs_m4`; 41st triggers `spilled-cap`.
+- [x] Verified the discipline says cap state is memory-only and resets when the invocation/session ends.
+- [x] Confirmed no live upstream issue was filed during implementation because upstream filing still requires explicit per-issue confirmation.
+- [x] `cargo test -p sldo-install --test e2e_sec_libs_m4` passes.
 
 #### Evidence Log
 
-(Copy at execution time.)
+- 2026-05-06: `cargo test -p sldo-install --test e2e_sec_libs_m4` passed with 12 tests.
+- 2026-05-06: M4 cap boundary simulated in test: filings 1-40 allowed; 41st and later spill to `LESSONS-BACKLOG.md`.
+- 2026-05-06: `cargo test -p sldo-install` passed.
+- 2026-05-06: `cargo test --workspace` passed.
+- 2026-05-06: No live upstream issue was filed in this implementation pass because M4 still requires explicit per-issue confirmation.
 
 #### Definition of Done
 

--- a/docs/slo/lessons/sec-libs-m4.md
+++ b/docs/slo/lessons/sec-libs-m4.md
@@ -1,0 +1,34 @@
+# Lessons Learned - sec-libs Milestone 4
+
+## What changed
+
+- Extended `skills/slo-sec-libs/SKILL.md` with the explicit `--file-upstream --upstream-dir <path>` gate.
+- Extended `skills/slo-sec-libs/references/upstream-filing-discipline.md` with upstream owner mapping, cap rules, spillover format, and fallback behavior.
+- Added `crates/sldo-install/tests/e2e_sec_libs_m4.rs` with 12 structural-contract tests, including an executable cap-boundary helper.
+- Updated the runbook tracker/evidence and the skill catalog.
+
+## Design decisions and why
+
+- **Default destination remains SLO intake.** Owner names alone do not trigger upstream filing; `--file-upstream` is the opt-in gate.
+- **No `--repo` exception for upstream filing.** Direct upstream filing uses a local checkout whose origin matches the mapped owner repo, so the user can inspect the destination before confirming.
+- **The cap is memory-only.** M4 tracks `filed_this_session` in the current invocation and refuses to persist state across sessions. Cross-session rate discipline remains the user's responsibility.
+- **Declining upstream does not lose the gap.** The flow offers a separately confirmed SLO-intake fallback when the user says no to upstream filing.
+
+## Test patterns that worked well
+
+- The cap-boundary helper makes the 40/41 behavior executable without creating live issues.
+- Tests pin the two allowed upstream mappings and the `unknown` refusal path.
+- M1-M3 compatibility remains in the M4 suite so the new upstream path cannot erase default intake behavior.
+
+## Missing tests that should exist later
+
+- M5 dogfood should run the full read -> match -> file flow against real target data and record actual issue URLs after explicit confirmation.
+- A future standalone filer executable should add fixture tests for owner mapping, decline fallback, cap spillover, and secondary-rate-limit responses.
+- If more library owners are added, the mapping table should get a fixture for each owner.
+
+## Rules for M5
+
+- Dogfood must exercise the default intake path before relying on upstream filing.
+- Any live filing still needs per-issue confirmation.
+- Record whether each filed issue went to SLO intake or a direct upstream repo.
+- Keep canonical `SunLitSecurityLibraries` spelling.

--- a/skills/slo-sec-libs/SKILL.md
+++ b/skills/slo-sec-libs/SKILL.md
@@ -4,12 +4,13 @@ description: >
   Use this skill to read CycloneDX 1.6 declaration files from Hulumi and
   SunLitSecurityLibraries, extract a structured capability catalog, and match
   runbook proactive controls to advertised secure-library capabilities. M1-M2
-  are read-only; M3 files only user-confirmed SLO-intake capability gaps.
+  are read-only; M3 files user-confirmed SLO-intake capability gaps; M4 adds
+  explicit upstream filing with a per-session cap.
 ---
 
 # /slo-sec-libs
 
-You are a security-library capability reader, matcher, and intake filer. In M1 you validate CycloneDX 1.6 declaration files and emit a structured catalog. In M2 you match target runbook proactive-control rows against that catalog. In M3 you turn unmatched rows into regex-validated capability-gap records and file them only after user confirmation.
+You are a security-library capability reader, matcher, and intake filer. In M1 you validate CycloneDX 1.6 declaration files and emit a structured catalog. In M2 you match target runbook proactive-control rows against that catalog. In M3 you turn unmatched rows into regex-validated capability-gap records and file them to SLO intake only after user confirmation. In M4 you may file upstream only when the user explicitly passes `--file-upstream`.
 
 ## Tools You MUST NOT Use
 
@@ -25,7 +26,8 @@ Do not call vendor SaaS API fallbacks: Semgrep AppSec, Snyk, GitHub Advanced Sec
 - **`--read-declarations <path>`** -> M1 declarations-reader mode. Run `python3 skills/slo-sec-libs/scripts/read-declarations.py <path>` as an argv-list subprocess. Do not interpolate user text into a shell string.
 - **`--match <runbook.md> --catalog <catalog.json>`** -> M2 matcher mode. Read [references/methodology-m2-matcher.md](references/methodology-m2-matcher.md), then emit one JSON object with `matched`, `unmatched`, and `diagnostics`. Multiple `--catalog` inputs are allowed. Do not write files and do not file issues.
 - **`--file-gaps <m2-output.json> --intake-dir <path>`** -> M3 default filing mode. Read [references/capability-gap-schema.md](references/capability-gap-schema.md) and [references/upstream-filing-discipline.md](references/upstream-filing-discipline.md), validate every unmatched record, ask for per-issue confirmation, then run `gh issue create` from the local `slo-security-intake` checkout. Do not use `--repo`.
-- **`--file-upstream` or any third-party filing request** -> stop. M4 is not implemented yet.
+- **`--file-gaps <m2-output.json> --intake-dir <path> --file-upstream --upstream-dir <path>`** -> M4 upstream filing mode. Keep the M3 intake fallback available, but when the validated record maps to `hulumi` or `SunLitSecurityLibraries`, confirm the resolved upstream checkout and file there only after per-issue confirmation. Enforce the 40 issues per session per hour cap and spill overflow to `LESSONS-BACKLOG.md`.
+- **Any third-party filing request without `--file-upstream`** -> use the M3 intake path and explain that direct upstream filing is explicit opt-in only.
 
 ## Pre-flight Cascade
 
@@ -41,6 +43,7 @@ Run these checks in order:
 8. Confirm the reader script's 10 MiB cap and strict jsonschema validation will run before any catalog extraction.
 9. For M2, confirm the target runbook exists, the catalog JSON was produced by M1, and every candidate match can cite a catalog `bom_ref`.
 10. For M3, confirm `gh --version`, `gh auth status`, the intake checkout's origin URL, and `.github/ISSUE_TEMPLATE/capability-gap-record.md`.
+11. For M4, confirm the upstream checkout origin matches the mapped owner repo, the per-session counter starts at 0, and no cap state will be persisted.
 
 ## Exact Reader Invocation
 
@@ -91,6 +94,18 @@ Read [references/capability-gap-schema.md](references/capability-gap-schema.md) 
 - run `gh issue create --title <title> --body-file <tmpfile> --label capability-gap` from the intake checkout as an argv-list subprocess;
 - never run `gh auth login`; if `gh auth status` fails, stop with a login hint.
 
+## M4 Upstream Filing Gate
+
+Read [references/upstream-filing-discipline.md](references/upstream-filing-discipline.md) before using `--file-upstream`. The gate must:
+
+- preserve `kerberosmansour/slo-security-intake` as the default destination when `--file-upstream` is absent;
+- map only `expected_library_owner: hulumi` to `kerberosmansour/hulumi` and `expected_library_owner: SunLitSecurityLibraries` to `kerberosmansour/SunLitSecurityLibraries`;
+- refuse upstream filing for `expected_library_owner: unknown`, ambiguous mappings, or mismatched checkout origins, then offer the SLO-intake fallback;
+- show the user the resolved upstream origin URL, title, body preview, validation result, dedupe disposition, and cap counter before each upstream filing;
+- require a yes/no confirmation for upstream filing and a separate confirmation before any intake fallback;
+- track `filed_this_session` in memory only, allow filings 1 through 40, and spill the 41st and later candidates to `LESSONS-BACKLOG.md` with `disposition: spilled-cap`;
+- never persist cap state across sessions and never bypass the cap with `--repo`.
+
 ## Anti-patterns
 
 - Shell-string subprocess calls such as `python3 ... {user_path}`.
@@ -110,7 +125,10 @@ Read [references/capability-gap-schema.md](references/capability-gap-schema.md) 
 - Running `gh auth login` from the skill.
 - Copying free-text target prose into a capability-gap issue body.
 - Using merge flags, auto-merge flags, or `gh pr merge` anywhere in this skill.
+- Inferring upstream filing from owner names without `--file-upstream`.
+- Persisting the 40-issues/hr cap counter across sessions.
+- Filing the 41st issue in a session instead of spilling it to `LESSONS-BACKLOG.md`.
 
 ## Handoff
 
-After M3 files default intake issues, continue to M4 for the explicit `--file-upstream` gate and per-session cap. Until M4 lands, do not file directly to Hulumi or SunLitSecurityLibraries.
+After M4, continue to M5 dogfood. Direct upstream filing is available only through the explicit `--file-upstream` gate; otherwise keep filing confirmed gaps to SLO intake.

--- a/skills/slo-sec-libs/references/upstream-filing-discipline.md
+++ b/skills/slo-sec-libs/references/upstream-filing-discipline.md
@@ -2,15 +2,16 @@
 name: slo-sec-libs-upstream-filing-discipline
 description: >
   Filing discipline for /slo-sec-libs M3 and M4. M3 uses the SLO-owned intake
-  repository only; M4 may extend this file for direct upstream filing.
+  repository by default; M4 adds explicit direct upstream filing with a
+  per-session cap and spillover path.
 applies_to: [slo-sec-libs]
-milestone: M3
+milestone: M3-M4
 inherits_from: [slo-sast M5 argv-list discipline, slo-retro issue-filing confirmation gate]
 ---
 
 # /slo-sec-libs Filing Discipline
 
-M3 is the default SLO-intake filer. It creates capability-gap issues only in `kerberosmansour/slo-security-intake`, only after regex validation, and only after the user confirms each issue. Direct filing to Hulumi, SunLitSecurityLibraries, or any third-party repository is M4 work and is not enabled in M3.
+M3 is the default SLO-intake filer. It creates capability-gap issues in `kerberosmansour/slo-security-intake`, only after regex validation, and only after the user confirms each issue. M4 keeps that default unchanged and adds direct upstream filing only when the user passes `--file-upstream`.
 
 ## Destination Discipline
 
@@ -19,6 +20,26 @@ M3 is the default SLO-intake filer. It creates capability-gap issues only in `ke
 - Template dependency: `.github/ISSUE_TEMPLATE/capability-gap-record.md` SHOULD exist in the intake checkout. If it is missing, warn the user and fall back to the plain Markdown body from `capability-gap-schema.md`.
 - NO `--repo` flag: `gh issue create`, `gh issue list`, and dedupe/search commands MUST NOT pass `--repo`. Destination comes from the local intake checkout origin that the user can inspect.
 - If the current working directory is not the intake checkout and the runner cannot set the subprocess working directory directly, stop and tell the user to rerun with `--intake-dir <path>`.
+
+## Upstream Destination Gate
+
+`--file-upstream` is an explicit opt-in gate. Without it, every valid gap follows the default SLO-intake path even when `expected_library_owner` names a known library.
+
+Allowed upstream mappings:
+
+| `expected_library_owner` | Upstream repository | Accepted checkout origins |
+|---|---|---|
+| `hulumi` | `kerberosmansour/hulumi` | `https://github.com/kerberosmansour/hulumi.git`, `git@github.com:kerberosmansour/hulumi.git`, `https://github.com/kerberosmansour/hulumi` |
+| `SunLitSecurityLibraries` | `kerberosmansour/SunLitSecurityLibraries` | `https://github.com/kerberosmansour/SunLitSecurityLibraries.git`, `git@github.com:kerberosmansour/SunLitSecurityLibraries.git`, `https://github.com/kerberosmansour/SunLitSecurityLibraries` |
+| `unknown` | none | upstream filing refused |
+
+Rules:
+
+- The upstream checkout MUST be supplied by `--upstream-dir <path>`.
+- The upstream checkout origin MUST match the mapped repository before any issue body is previewed for upstream filing.
+- Ambiguous, unknown, legacy, or mismatched owner values MUST NOT file upstream. Offer the SLO-intake fallback with a note instead.
+- If the user declines upstream filing, offer the SLO-intake fallback and require a separate confirmation before filing there.
+- Do not infer upstream filing from owner names, component names, package names, or repository prose.
 
 ## Pre-Flight
 
@@ -37,6 +58,8 @@ Never run `gh auth login` from this skill. If `gh auth status` fails, stop with 
 GitHub CLI is not authenticated. Run `gh auth login`, then rerun /slo-sec-libs --file-gaps.
 ```
 
+When `--file-upstream` is present, additionally run `git remote get-url origin` from `--upstream-dir` and compare the normalized URL to the mapping above. Still do not use `--repo`.
+
 ## Confirmation Gate
 
 Every candidate filing MUST surface a per-issue confirmation prompt. The prompt shows:
@@ -47,9 +70,10 @@ Every candidate filing MUST surface a per-issue confirmation prompt. The prompt 
 4. Body preview built from validated fields.
 5. Validation result.
 6. Dedupe disposition when available (`none`, `match-id`, or `ambiguous`).
-7. A yes/no prompt.
+7. Cap counter (`filed_this_session` / 40) when `--file-upstream` is active.
+8. A yes/no prompt.
 
-Never auto-file. If the user declines, skip that gap and continue to the next unmatched record. If validation fails, do not prompt for filing; report the invalid field and skip.
+Never auto-file. If the user declines the default intake filing, skip that gap and continue to the next unmatched record. If the user declines upstream filing, offer the SLO-intake fallback and ask again. If validation fails, do not prompt for filing; report the invalid field and skip.
 
 ## Dedupe Check
 
@@ -61,9 +85,11 @@ gh issue list --label capability-gap --search "<desired_capability>"
 
 The command must be invoked as an argv-list subprocess from the intake checkout. A dedupe failure is not a reason to bypass confirmation; surface the failure and ask whether to proceed.
 
+When `--file-upstream` is active, run the same command from the upstream checkout for upstream candidates, then run it from the intake checkout only if the flow falls back to intake.
+
 ## Issue Creation Command
 
-Only this issue creation shape is allowed in M3:
+Only this issue creation shape is allowed in M3-M4:
 
 ```text
 gh issue create --title "<title>" --body-file "<tmpfile>" --label capability-gap
@@ -77,17 +103,49 @@ Invocation rules:
 - Write the body to a local temporary file, pass the path as one argv item, then delete the temporary file after the command returns.
 - Capture stdout/stderr and surface the issue URL to the user when creation succeeds.
 
+For M4, the subprocess current directory is:
+
+- the intake checkout when filing the default SLO-intake issue;
+- the mapped upstream checkout when `--file-upstream` is active, mapping succeeds, the cap allows the filing, and the user confirms upstream filing.
+
+## Rate-Limit Cap and Spillover
+
+M4 enforces a defensive cap of **40 issues per session per hour** for direct upstream filing. The counter is named `filed_this_session`.
+
+Counter rules:
+
+- Initialize `filed_this_session = 0` at the start of each `/slo-sec-libs` invocation.
+- Increment only after `gh issue create` succeeds for an upstream issue.
+- Allow upstream filings while `filed_this_session < 40`.
+- The 41st and later upstream candidates MUST NOT call `gh issue create`.
+- Spill capped candidates to `LESSONS-BACKLOG.md` in the original invocation repo root with `disposition: spilled-cap`.
+- MUST NOT persist cap state to disk, environment variables, git config, temp files, or any global cache.
+- The cap resets when the invocation/session ends.
+
+Spillover records append a Markdown table row with every `capability-gap-schema.md` field plus these M4 fields:
+
+| Field | Validation |
+|---|---|
+| `filed_to` | `kerberosmansour/hulumi`, `kerberosmansour/SunLitSecurityLibraries`, or `kerberosmansour/slo-security-intake` |
+| `disposition` | `spilled-cap` |
+| `spillover_reason` | `upstream-cap-40-per-session` |
+
+If `gh issue create` returns a GitHub secondary rate-limit response before the local cap fires, do not retry blindly. Surface the response to the user and either wait with a fresh confirmation or spill to `LESSONS-BACKLOG.md` with `disposition: spilled-cap`.
+
 ## Forbidden Shortcuts
 
 - Passing `--repo` to `gh issue create`, `gh issue list`, or any M3 dedupe/search command.
 - Running `gh auth login`.
 - Running `gh pr merge` or using merge flags: `--auto`, `--merge`, `--squash`, `--rebase`, `--admin`.
 - Filing without per-issue user confirmation.
-- Filing to Hulumi, SunLitSecurityLibraries, or any third-party repository in M3.
+- Filing to Hulumi, SunLitSecurityLibraries, or any third-party repository without `--file-upstream`.
+- Inferring upstream filing from owner names without explicit user opt-in.
+- Persisting the `filed_this_session` cap counter across sessions.
+- Filing the 41st upstream issue in a session instead of spilling to `LESSONS-BACKLOG.md`.
 - Building a shell string, using `sh -c`, or interpolating record fields into a shell command.
 - Copying free-text target prose into a capability-gap issue body.
 - Silently repairing a rejected field and filing anyway.
 
-## M4 Extension Point
+## M5 Extension Point
 
-M4 may add `--file-upstream`, third-party destination mapping, and the per-session 40-issues/hr cap. Until M4 lands, M3 remains one-by-one confirmed filing to the SLO-owned intake repo only.
+M5 dogfoods the full read -> match -> file flow against real targets. M5 may record filed issue URLs, but it must not change this filing discipline.


### PR DESCRIPTION
## Summary

- Adds the `/slo-sec-libs` M4 explicit upstream filing gate with `--file-upstream --upstream-dir <path>`.
- Preserves the default SLO-intake path when upstream filing is not explicitly requested.
- Extends the filing discipline with Hulumi/SunLitSecurityLibraries owner mapping, no-`--repo` upstream checkout rules, per-issue confirmation, decline fallback, and 40 issues/hr session cap spillover to `LESSONS-BACKLOG.md`.
- Adds M4 structural tests, runbook tracker/evidence, lessons, completion notes, and catalog update.

## Validation

- `git diff --check`
- `rustfmt --check crates/sldo-install/tests/e2e_sec_libs_m4.rs`
- `cargo test -p sldo-install --test e2e_sec_libs_m1`
- `cargo test -p sldo-install --test e2e_sec_libs_m2`
- `cargo test -p sldo-install --test e2e_sec_libs_m3`
- `cargo test -p sldo-install --test e2e_sec_libs_m4`
- `cargo test -p sldo-install --test e2e_agent_host_m2`
- `cargo test -p sldo-install`
- `cargo test --workspace`

## Notes

No live upstream issue was filed in this implementation pass because M4 still requires explicit per-issue confirmation.

Refs #4