### PR TITLE
Add slo-dast-tuner skill

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,9 @@ docs/legal
 docs/slo/research/**/run.log
 docs/research/**/run.log
 
+# In-progress runbooks live under docs/slo/ and stay local until promoted.
+docs/slo/RUNBOOK-*.md
+
 # Research dossier output directory
 output/
 

--- a/crates/sldo-install/tests/e2e_slo_nettacker.rs
+++ b/crates/sldo-install/tests/e2e_slo_nettacker.rs
@@ -30,9 +30,9 @@ fn nettacker_skill_is_discoverable_and_cataloged() {
     assert!(skill.contains("custom Nettacker"));
 
     let catalog = read(repo_root().join("docs/skill-pack-catalog.md"));
-    assert!(catalog.contains("Shipped skills at HEAD: 39"));
+    assert!(catalog.contains("Shipped skills at HEAD: 40"));
     assert!(catalog.contains("/slo-nettacker"));
-    assert!(catalog.contains("8 power tools"));
+    assert!(catalog.contains("9 power tools"));
 }
 
 #[test]

--- a/docs/skill-pack-catalog.md
+++ b/docs/skill-pack-catalog.md
@@ -5,7 +5,7 @@
 
 Use this file for the host-neutral list of shipped skills. Use [../CLAUDE.md](../CLAUDE.md) for the Claude Code overlay, [../copilot-instructions.md](../copilot-instructions.md) for the GitHub Copilot overlay, [../AGENTS.md](../AGENTS.md) for the Codex overlay, [getting-started.md](getting-started.md) for the first-run path, and [slo/design/agent-host-capabilities.md](slo/design/agent-host-capabilities.md) for current host support boundaries. Acronyms used here (TLA+, BDD, ICP, SEIS, IR35, ...) are defined in [GLOSSARY.md](GLOSSARY.md).
 
-**Shipped skills at HEAD: 39** (10 sprint flow + 5 ticket flow + 8 power tools + 4 business advisor + 11 business generator + 1 vendored). Skills with mode variants (`/slo-product roadmap|metrics|okrs`, `/slo-marketing b2b|b2c`, `/slo-metrics consumer|b2b`, `/slo-hire swe|ae|designer|ops`) are one skill per row in their section, except `/slo-product` whose three modes are listed individually because the output paths differ. To reconcile against disk, run `ls skills/ | grep -v README` — should be 39 entries.
+**Shipped skills at HEAD: 40** (10 sprint flow + 5 ticket flow + 9 power tools + 4 business advisor + 11 business generator + 1 vendored). Skills with mode variants (`/slo-product roadmap|metrics|okrs`, `/slo-marketing b2b|b2c`, `/slo-metrics consumer|b2b`, `/slo-hire swe|ae|designer|ops`) are one skill per row in their section, except `/slo-product` whose three modes are listed individually because the output paths differ. To reconcile against disk, run `ls skills/ | grep -v README` - should be 40 entries.
 
 ## Repo reality at HEAD
 
@@ -52,6 +52,7 @@ GitHub Issues-first path for small, reviewable work that should keep v4 rigor wi
 | `/slo-rulegen` | Bootstrap or extend Semgrep rule packs for Rust workspaces | Host-neutral. The bug-summary input can come from any agent-driven workflow. |
 | `/slo-ruleverify` | Run the deterministic SAST gate over an existing rule pack | Host-neutral. |
 | `/slo-sast` | Wire threat-model-driven SAST scanning into a target repo | Host-neutral. Subprocess invocations are `git`, `gh`, and `semgrep` — never an agent CLI. |
+| `/slo-dast-tuner` | Wire and tune zaprun-backed DAST for an authorized web app, including SARIF-guided tuning, auth-aware coverage, and generic-rule boundaries | Host-neutral. Operates ZAP only through `zaprun` and the latest approved digest-pinned zaprun image. |
 | `/slo-sec-libs` | Read CycloneDX declarations, match proactive controls to advertised capabilities, and file confirmed capability gaps | Host-neutral. M1-M2 are read-only: offline Python `jsonschema` reader plus catalog-grounded matcher. M3 files regex-validated SLO-intake issues; M4 adds explicit upstream filing with per-issue confirmation and a 40-issues/hr session cap. |
 | `/slo-nettacker` | Run authorized OWASP Nettacker assessment workflows, triage reports, and author safe custom Nettacker YAML modules | Host-neutral interactive skill. Uses local Nettacker CLI/Docker/API when available; no headless Codex/Copilot runtime harness is assumed. |
 

--- a/references/dast-tuner/cwe-to-rules.toml
+++ b/references/dast-tuner/cwe-to-rules.toml
@@ -1,0 +1,110 @@
+[[mappings]]
+cwe = "CWE-22"
+zap_rules = [
+  { id = "6", level = "WARN", surface = "both", note = "Path traversal passive signal" },
+  { id = "40035", level = "FAIL", surface = "web", note = "Hidden file finder" },
+]
+nuclei_templates = ["http/exposures/files/"]
+custom_scripts = []
+
+[[mappings]]
+cwe = "CWE-78"
+zap_rules = [{ id = "90020", level = "FAIL", surface = "both", note = "Remote OS command injection" }]
+nuclei_templates = ["http/cves/"]
+custom_scripts = []
+
+[[mappings]]
+cwe = "CWE-79"
+zap_rules = [
+  { id = "40012", level = "FAIL", surface = "both", note = "Reflected XSS" },
+  { id = "40014", level = "FAIL", surface = "web", note = "Persistent XSS" },
+  { id = "40016", level = "FAIL", surface = "web", note = "Persistent XSS spider prime" },
+  { id = "40017", level = "FAIL", surface = "web", note = "Persistent XSS spider" },
+  { id = "40026", level = "WARN", surface = "web", note = "DOM XSS nightly only" },
+]
+nuclei_templates = ["http/exposures/dom-xss/"]
+custom_scripts = ["cwe-79-dom-taint-flow.js"]
+
+[[mappings]]
+cwe = "CWE-89"
+zap_rules = [
+  { id = "40018", level = "FAIL", surface = "both", note = "SQL injection" },
+  { id = "40019", level = "FAIL", surface = "both", note = "SQL injection MySQL" },
+  { id = "40021", level = "FAIL", surface = "both", note = "SQL injection Oracle" },
+  { id = "40022", level = "FAIL", surface = "both", note = "SQL injection PostgreSQL" },
+  { id = "40024", level = "FAIL", surface = "both", note = "SQL injection SQLite" },
+  { id = "40027", level = "FAIL", surface = "both", note = "SQL injection MsSQL" },
+]
+nuclei_templates = []
+custom_scripts = []
+sqlmap_profile = "fast"
+
+[[mappings]]
+cwe = "CWE-200"
+zap_rules = [
+  { id = "10036", level = "WARN", surface = "both", note = "Server header leak" },
+  { id = "10037", level = "WARN", surface = "both", note = "X-Powered-By leak" },
+  { id = "40034", level = "FAIL", surface = "web", note = "Env information leak" },
+]
+nuclei_templates = ["http/exposures/"]
+custom_scripts = []
+
+[[mappings]]
+cwe = "CWE-287"
+zap_rules = [{ id = "10109", level = "WARN", surface = "web", note = "Modern web application auth signal" }]
+nuclei_templates = ["http/default-logins/"]
+custom_scripts = []
+
+[[mappings]]
+cwe = "CWE-352"
+zap_rules = [{ id = "20012", level = "FAIL", surface = "web", note = "Anti-CSRF tokens check" }]
+nuclei_templates = ["http/misconfiguration/csrf/"]
+custom_scripts = []
+
+[[mappings]]
+cwe = "CWE-502"
+zap_rules = [{ id = "90019", level = "FAIL", surface = "both", note = "Server-side code injection signal" }]
+nuclei_templates = ["http/cves/"]
+custom_scripts = []
+
+[[mappings]]
+cwe = "CWE-601"
+zap_rules = [{ id = "20019", level = "FAIL", surface = "both", note = "External redirect" }]
+nuclei_templates = ["http/misconfiguration/open-redirect/"]
+custom_scripts = []
+
+[[mappings]]
+cwe = "CWE-611"
+zap_rules = [{ id = "90023", level = "FAIL", surface = "api", note = "XXE" }]
+nuclei_templates = ["http/cves/"]
+custom_scripts = []
+
+[[mappings]]
+cwe = "CWE-770"
+zap_rules = [{ id = "40038", level = "FAIL", surface = "web", note = "Bypassing 403 may reveal resource controls" }]
+nuclei_templates = ["http/misconfiguration/"]
+custom_scripts = []
+
+[[mappings]]
+cwe = "CWE-798"
+zap_rules = [{ id = "10096", level = "WARN", surface = "both", note = "Timestamp disclosure adjacent passive signal" }]
+nuclei_templates = ["http/exposures/tokens/"]
+custom_scripts = []
+
+[[mappings]]
+cwe = "CWE-918"
+zap_rules = [{ id = "40042", level = "FAIL", surface = "web", note = "Spring actuator information leak" }]
+nuclei_templates = ["http/vulnerabilities/ssrf/"]
+custom_scripts = []
+
+[[mappings]]
+cwe = "CWE-1021"
+zap_rules = [{ id = "10020", level = "FAIL", surface = "web", note = "X-Frame-Options header" }]
+nuclei_templates = ["http/misconfiguration/clickjacking/"]
+custom_scripts = []
+
+[[mappings]]
+cwe = "CWE-1333"
+zap_rules = [{ id = "40040", level = "FAIL", surface = "web", note = "CORS misconfiguration can expose regex-like origin handling" }]
+nuclei_templates = ["http/misconfiguration/cors/"]
+custom_scripts = []

--- a/references/dast-tuner/manifest-v1.json
+++ b/references/dast-tuner/manifest-v1.json
@@ -1,0 +1,72 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/kerberosmansour/zaprun/blob/main/schema/manifest-v1.json",
+  "title": "zaprun DAST manifest v1",
+  "type": "object",
+  "required": [
+    "$schema",
+    "schema_version",
+    "generated_at",
+    "generated_by_zaprun_version",
+    "image_digest",
+    "upstream_image_digest",
+    "cwes_claimed",
+    "cwes_actually_covered",
+    "cwes_uncovered",
+    "detected_stack",
+    "detected_surface",
+    "detected_auth",
+    "selected_scanners",
+    "selected_rules",
+    "selection_strategy"
+  ],
+  "properties": {
+    "$schema": { "type": "string" },
+    "schema_version": { "const": "1.0" },
+    "generated_at": { "type": "string" },
+    "generated_by_zaprun_version": { "type": "string" },
+    "image_digest": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" },
+    "upstream_image_digest": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" },
+    "threat_model_sha": {
+      "anyOf": [
+        { "type": "string", "pattern": "^[0-9a-f]{40}$" },
+        { "type": "null" }
+      ]
+    },
+    "cwes_claimed": { "type": "array", "items": { "$ref": "#/$defs/cwe" } },
+    "cwes_actually_covered": { "type": "array", "items": { "$ref": "#/$defs/cwe" } },
+    "cwes_uncovered": { "type": "array", "items": { "$ref": "#/$defs/cwe" } },
+    "coverage_gaps": { "type": "array" },
+    "detected_stack": { "type": "array", "items": { "type": "string" } },
+    "detected_surface": { "type": "string" },
+    "detected_auth": { "type": "string" },
+    "selected_scanners": { "type": "array", "items": { "type": "string" } },
+    "selected_rules": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["id", "source", "level"],
+        "properties": {
+          "id": { "type": "string" },
+          "source": { "type": "string" },
+          "level": { "type": "string" },
+          "metadata_cwe": { "type": "array", "items": { "$ref": "#/$defs/cwe" } },
+          "script_path": {
+            "anyOf": [
+              { "type": "string" },
+              { "type": "null" }
+            ]
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "selection_strategy": { "enum": ["threat-model-cwe", "default-fallback"] },
+    "findings_summary": { "type": ["object", "null"] },
+    "baseline_summary": { "type": ["object", "null"] }
+  },
+  "additionalProperties": false,
+  "$defs": {
+    "cwe": { "type": "string", "pattern": "^CWE-[0-9]+$" }
+  }
+}

--- a/references/dast-tuner/zap-image-pin.toml
+++ b/references/dast-tuner/zap-image-pin.toml
@@ -1,0 +1,20 @@
+[upstream]
+image = "cgr.dev/chainguard/wolfi-base"
+digest = "sha256:31da6565f35af6401031c1d7aa91dc84ac76c5c48edd17fb90f0ed9e3173c7a9"
+checked_at = "2026-05-06"
+note = "Clean Wolfi base resolved with docker buildx imagetools inspect cgr.dev/chainguard/wolfi-base:latest."
+
+[zap_release]
+version = "2.17.0"
+tag = "v2.17.0"
+asset = "ZAP_2.17.0_Linux.tar.gz"
+url = "https://github.com/zaproxy/zaproxy/releases/download/v2.17.0/ZAP_2.17.0_Linux.tar.gz"
+digest = "sha256:efe799aaa3627db683b43f00c9c210aea0b75c00cc8f0a0f0434d12bb3ddde5a"
+checked_at = "2026-05-06"
+note = "Latest GitHub release asset digest from the official zaproxy/zaproxy release API."
+
+[ours]
+image = "ghcr.io/kerberosmansour/zaprun"
+digest = "sha256:1caa4c454beac1a5ca67bb06484282b94e43a5cd01ba772ec1a2b78a6ed4c649"
+checked_at = "2026-05-12"
+note = "v0.1.0 release digest - first publicly signed and attested image. Future releases auto-bump this field via release.yml's bump-pins job."

--- a/skills/slo-dast-tuner/SKILL.md
+++ b/skills/slo-dast-tuner/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: slo-dast-tuner
+description: >
+  Use this skill to wire and tune DAST for an authorized web app or web service
+  through zaprun only. Operates OWASP ZAP via the latest approved digest-pinned
+  ghcr.io/kerberosmansour/zaprun image, reads threat models, OpenAPI/routes/auth
+  context, and SAST SARIF, then tunes generic DAST policy while keeping
+  app-specific custom rules in the target repo or run artifacts.
+---
+
+# /slo-dast-tuner - zaprun-backed DAST tuning
+
+You are a security engineer wiring DAST into a target repo. Treat ZAP as an implementation detail owned by `zaprun`; this skill orchestrates `zaprun` commands and records evidence.
+
+## Non-negotiable Boundaries
+
+- Run ZAP only through `zaprun` and the latest approved digest-pinned `ghcr.io/kerberosmansour/zaprun@sha256:<digest>` image.
+- Never call `zap-baseline.py`, `zap-full-scan.py`, `zap-api-scan.py`, or handwritten user-derived Automation Framework YAML.
+- Treat SAST SARIF as evidence, not proof of DAST coverage.
+- Do not commit app-specific custom rules to SunLitOrchestra or zaprun. Keep them under the target repo's `.zaprun/scripts/`, an ignored scratch directory, or run artifacts.
+- Before touching a live target, confirm authorization, in-scope URL(s), auth permission, and any rate/concurrency limits.
+
+## Inputs
+
+- Target repo root, either cwd or explicit `--target-dir`.
+- `docs/slo/design/<slug>-threat-model.md` when present.
+- Optional OpenAPI spec, route/controller source, framework manifests, existing `.zaprun/manifest.json`.
+- Optional SAST SARIF file(s).
+- Optional staging URL and auth material. Credentials must never be written to committed files.
+
+## Resolve the Runner
+
+Prefer an installed `zaprun`. If unavailable and a sibling zaprun checkout exists, run `cargo run -p zaprun --` from that checkout. If neither is available, ask for the zaprun checkout path or install instructions; do not invent ZAP commands.
+
+Use argv-list subprocess discipline from [`../../references/templates/tool-safety-section.md`](../../references/templates/tool-safety-section.md). Never interpolate target URLs, SARIF paths, headers, or credentials into shell strings.
+
+## Method Dispatch
+
+| Intent | Action |
+|---|---|
+| First install | Read [`references/workflow.md`](references/workflow.md), then run `zaprun init --target-dir <repo> [--deployment-target <url>]`. |
+| Drift check | Read [`references/workflow.md`](references/workflow.md), then run `zaprun rederive --target-dir <repo>`. |
+| SARIF-guided tuning | Read [`references/sarif-guided-scans.md`](references/sarif-guided-scans.md). When M3 is available, run `zaprun triage-sarif`; until then, classify the evidence and do not claim automated tuning. |
+| Authenticated coverage | Read [`references/authentication-coverage.md`](references/authentication-coverage.md). Auth failure is a coverage failure, not a clean scan. |
+| Rule authoring or promotion | Read [`references/rule-boundary.md`](references/rule-boundary.md) before proposing any custom script or generic rule. |
+
+## Expected Output
+
+Report:
+
+- commands run, cwd, exit codes, and artifact paths
+- selected profile and image digest
+- CWEs claimed versus covered, plus coverage gaps
+- SARIF findings classified as `dast-detectable`, `dast-partial`, `dast-not-applicable`, or `needs-human-input`
+- auth coverage status and diagnostics path when applicable
+- any target-owned custom rule candidates and why they are not generic yet
+
+## Anti-patterns
+
+- Saying "DAST covered" because SARIF mentioned a CWE.
+- Promoting a one-app script into a shared rule because it found one real bug.
+- Lowering thresholds to hide findings without expiry and rationale.
+- Reporting "no vulnerabilities" when crawling, auth, fixtures, or endpoint reachability failed.
+- Committing credentials, session cookies, auth diagnostics, private SARIF, or app-specific scripts to a public/shared repo.
+
+**Loops**: Security-tuning loop - see [docs/LOOPS-ENGINEERING.md#security-tuning-loop](../../docs/LOOPS-ENGINEERING.md#security-tuning-loop).

--- a/skills/slo-dast-tuner/references/authentication-coverage.md
+++ b/skills/slo-dast-tuner/references/authentication-coverage.md
@@ -1,0 +1,44 @@
+---
+name: slo-dast-tuner-authentication-coverage
+source_skill: skills/slo-dast-tuner/SKILL.md
+status: stable-reference
+---
+
+# Authentication Coverage
+
+This reference follows the direction of ZAP's "Authentication Improvements" article (2025-07-03): authentication is scan-quality infrastructure, not a vulnerability rule.
+
+## Auth First
+
+For any authenticated app, record:
+
+- auth mode: unauthenticated, API token/header, browser-based auth, browser steps, or client-side Zest auth
+- credential source: secret manager, CI secret, local env, or manual-only
+- logged-in verification signal
+- logout URL/control patterns
+- whether AJAX/client crawling runs inside an authenticated browser session
+
+Do not place credentials, cookies, local storage, or screenshots containing secrets in committed files.
+
+## Escalation Ladder
+
+1. API token/header or basic login when the app is API-only.
+2. Browser-backed auth with login URL and credentials for JavaScript-heavy apps.
+3. Browser-backed auth with explicit steps when simple form detection fails.
+4. Client-side Zest auth only when the flow is too custom for the previous modes.
+
+## Coverage Failure States
+
+Report `needs-human-input` or coverage failure when:
+
+- login cannot be completed
+- logged-in verification is absent or unstable
+- the crawler logs out
+- required tenant/role/fixture state is missing
+- authenticated endpoints are in SARIF but scan config is unauthenticated
+
+"No findings" is not meaningful until auth state is verified for the endpoints under test.
+
+## Diagnostics
+
+When auth fails, preserve diagnostics only in sensitive artifact locations: screenshots, HTTP traffic, browser storage, page elements, and session verification output. Redact before sharing outside the target team.

--- a/skills/slo-dast-tuner/references/rule-boundary.md
+++ b/skills/slo-dast-tuner/references/rule-boundary.md
@@ -1,0 +1,45 @@
+---
+name: slo-dast-tuner-rule-boundary
+source_skill: skills/slo-dast-tuner/SKILL.md
+status: stable-reference
+---
+
+# Rule Boundary
+
+The load-bearing rule: shared repos may contain generic scanner policy, schemas, validators, and reusable examples. App-specific custom rules stay in the target repo or run artifacts.
+
+## Generic Rule Candidate
+
+A rule can be proposed for zaprun only when it:
+
+- detects a vulnerability class across more than one application shape
+- avoids private endpoint names, tenant ids, fixture ids, product strings, and bespoke response text
+- has synthetic vulnerable and patched fixtures
+- documents supported surface: API, web, SPA, or framework-scoped
+- passes the future DAST verify gate
+
+Framework-specific rules are allowed only when the framework behavior is the class under test and the scope is named.
+
+## Target-Owned Rule Candidate
+
+A rule must remain target-owned when it depends on:
+
+- one private route or schema
+- a tenant/account/fixture value
+- app-specific auth/session shape
+- proprietary response text
+- a SARIF result that has not been generalized
+- manual setup that cannot be reproduced in synthetic fixtures
+
+Target-owned scripts may live under `.zaprun/scripts/` or an ignored run-artifact directory in the target repo.
+
+## Promotion Flow
+
+1. Confirm the issue with zaprun evidence or replay.
+2. Write the narrow target-owned candidate if needed.
+3. Extract the vulnerability class and remove app literals.
+4. Add synthetic vulnerable and patched fixtures.
+5. Run the generic-rule gate when M4 lands.
+6. Only then propose a shared zaprun rule.
+
+Skipping steps 3 to 5 is a false-negative fix for one app, not a generic scanner improvement.

--- a/skills/slo-dast-tuner/references/sarif-guided-scans.md
+++ b/skills/slo-dast-tuner/references/sarif-guided-scans.md
@@ -1,0 +1,43 @@
+---
+name: slo-dast-tuner-sarif-guided-scans
+source_skill: skills/slo-dast-tuner/SKILL.md
+status: stable-reference
+---
+
+# SARIF-Guided DAST Tuning
+
+This workflow borrows the useful pattern from ZAP's "Guided ZAP Scans: Faster CI/CD Feedback Using Static Analysis" article (2026-03-27): SAST is most useful to DAST when it points to endpoint, HTTP method, and CWE, not just file and line.
+
+## Required Classification
+
+For each SARIF result, classify:
+
+- `dast-detectable`: externally observable through HTTP with route/request evidence.
+- `dast-partial`: some HTTP symptom is plausible, but custom replay, fixtures, or a target-owned script may be needed.
+- `dast-not-applicable`: not externally observable by DAST.
+- `needs-human-input`: route, auth, fixture, exploitability, or live request is unclear.
+
+Never classify as `dast-detectable` from CWE alone.
+
+## Preferred SARIF Facts
+
+Look for:
+
+- CWE tags, rule id, severity, stable fingerprint.
+- endpoint path and HTTP method from result metadata.
+- source file/line plus taint/dataflow trace.
+- route/controller mapping to the source location.
+- whether the route requires authentication or a role.
+- whether an OpenAPI operation confirms the path and method.
+
+If SARIF lacks endpoint/method, infer only from typed route/OpenAPI evidence. If inference is ambiguous, mark `needs-human-input`.
+
+## Guided Scan Map
+
+When M3 lands, `zaprun triage-sarif` should produce an endpoint x CWE map consumed by zaprun. Until that command exists, the skill may write a human-readable assessment, but must not claim an automated guided scan exists.
+
+The guided PR lane is a fast feedback lane, not the whole DAST program. Keep broader scheduled scans for coverage SAST did not expose.
+
+## False Positive And False Negative Handling
+
+False positive candidates need replay evidence, baseline rationale, expiry, or threshold tuning. False negative candidates need a route-confirmed request, relevant ZAP rule selection, auth/fixture setup, or a target-owned custom rule candidate. Generic-rule promotion requires the rule-boundary reference.

--- a/skills/slo-dast-tuner/references/workflow.md
+++ b/skills/slo-dast-tuner/references/workflow.md
@@ -1,0 +1,46 @@
+---
+name: slo-dast-tuner-workflow
+source_skill: skills/slo-dast-tuner/SKILL.md
+status: stable-reference
+---
+
+# /slo-dast-tuner Workflow
+
+## First Install
+
+Run `zaprun init` against the target repo:
+
+```text
+zaprun init --target-dir <target-repo> --deployment-target <https-url>
+```
+
+If no staging URL is available, `zaprun` may emit a local default, but the skill must tell the user that live coverage remains unproven until a reachable target is supplied.
+
+Expected target-owned outputs:
+
+- `.zaprun/policy-pr.yml`
+- `.zaprun/policy-nightly.yml`
+- `.zaprun/rules.tsv`
+- `.zaprun/baseline.json`
+- `.zaprun/manifest.json`
+- `.github/workflows/dast.yml`
+
+The generated workflow must invoke the latest approved digest-pinned zaprun image with first arg `zaprun`. It must not call legacy ZAP scripts.
+
+## Drift Check
+
+Run:
+
+```text
+zaprun rederive --target-dir <target-repo>
+```
+
+If no drift is detected, record the stderr/stdout note and stop. If drift exists, `zaprun` owns any re-derivation PR creation. The skill must not hand-roll PR bodies from threat-model prose.
+
+## Choosing Inputs
+
+Supply a staging URL when the target is externally reachable or CI can start it. Supply an OpenAPI spec when an API has one; otherwise let `zaprun` fall back to web scan mode. Supply route/controller context when SARIF lacks endpoint/method metadata.
+
+## Evidence Discipline
+
+Record the selected image digest from `.zaprun/manifest.json`. Treat a generated config as planned coverage until a zaprun run produces artifacts such as `summary.json`, `coverage.json`, `observations.json`, and `zap.sarif`.


### PR DESCRIPTION
## Summary
- add the `/slo-dast-tuner` Codex skill and references for zaprun-backed DAST tuning
- document SARIF-guided tuning, authentication coverage, and generic-vs-target-owned rule boundaries
- add DAST tuner reference data for CWE mappings, manifest schema, and latest approved zaprun image pin
- update the skill catalog/test counts and keep in-progress runbooks local under `docs/slo/RUNBOOK-*.md`

## Validation
- `./target/release/sldo-install --host codex`
- `./target/release/sldo-install --host codex status`
- `./target/release/sldo-install --host codex verify`
- `git diff --cached --check`
- `cargo test -p sldo-install --test e2e_slo_nettacker`

## Companion
- zaprun implementation PR: https://github.com/kerberosmansour/zaprun/pull/1