### PR TITLE
slo-sast + slo-dast-tuner: empirical rule-tuning guidance (adversarial NodeGoat/Juice Shop)

### DIFF
--- a/skills/slo-dast-tuner/SKILL.md
+++ b/skills/slo-dast-tuner/SKILL.md
@@ -19,6 +19,8 @@ You are a security engineer wiring DAST into a target repo. Treat ZAP as an impl
 - Treat SAST SARIF as evidence, not proof of DAST coverage.
 - Do not commit app-specific custom rules to SunLitOrchestra or zaprun. Keep them under the target repo's `.zaprun/scripts/`, an ignored scratch directory, or run artifacts.
 - Before touching a live target, confirm authorization, in-scope URL(s), auth permission, and any rate/concurrency limits.
+- **An unauthenticated scan of an authenticated app is a coverage failure, not a clean result.** Empirically, an unauthenticated NodeGoat scan missed its entire authenticated attack surface (eval-RCE, NoSQL `$where`, IDOR, SSRF, ReDoS, CSRF) while an authenticated probe proved every one was DAST-reachable. Never report "no findings" / low risk for auth-gated endpoints without verified logged-in state — escalate per [`references/authentication-coverage.md`](references/authentication-coverage.md). Authentication is the single highest-recall DAST lever.
+- **`zaprun ptk` requires a PTK-add-on-capable image.** The default pinned digest may lack the OWASP PTK add-on; an `Error(s) logged when setting configs` / `zap_report_missing` right after `Changing generic config key ptk.*` is an image mismatch, not "no findings". Validate the image and re-run per [`references/ptk-dom-xss.md`](references/ptk-dom-xss.md) before reporting any PTK result.
 
 ## Inputs
 
@@ -40,7 +42,8 @@ Use argv-list subprocess discipline from [`../../references/templates/tool-safet
 |---|---|
 | First install | Read [`references/workflow.md`](references/workflow.md), then run `zaprun init --target-dir <repo> [--deployment-target <url>]`. |
 | Drift check | Read [`references/workflow.md`](references/workflow.md), then run `zaprun rederive --target-dir <repo>`. |
-| SARIF-guided tuning | Read [`references/sarif-guided-scans.md`](references/sarif-guided-scans.md). When M3 is available, run `zaprun triage-sarif`; until then, classify the evidence and do not claim automated tuning. |
+| SARIF-guided tuning | Read [`references/sarif-guided-scans.md`](references/sarif-guided-scans.md), then run `zaprun triage-sarif`. Note: a plain Semgrep SARIF carries no HTTP route/method, so the guided map will be empty (0 dast-detectable is correct, not a bug) — do not claim a guided scan exists without route/OpenAPI evidence. |
+| SPA / DOM-XSS target | Read [`references/ptk-dom-xss.md`](references/ptk-dom-xss.md). For Angular/React/JS-heavy apps run `zaprun ptk` with a PTK-capable image — it is the only lane that finds DOM-based XSS (`web-pr` cannot execute the SPA). |
 | Authenticated coverage | Read [`references/authentication-coverage.md`](references/authentication-coverage.md). Auth failure is a coverage failure, not a clean scan. |
 | Rule authoring or promotion | Read [`references/rule-boundary.md`](references/rule-boundary.md) before proposing any custom script or generic rule. |
 
@@ -61,6 +64,9 @@ Report:
 - Promoting a one-app script into a shared rule because it found one real bug.
 - Lowering thresholds to hide findings without expiry and rationale.
 - Reporting "no vulnerabilities" when crawling, auth, fixtures, or endpoint reachability failed.
+- Reporting an unauthenticated scan of an auth-gated app as clean/low-risk (auth-gated endpoints are unproven, not safe).
+- Running `zaprun ptk` on a non-PTK image and reporting the `zap_report_missing` abort as "no findings".
+- Using `web-pr` on a SPA and concluding no XSS — DOM-XSS needs the PTK lane.
 - Committing credentials, session cookies, auth diagnostics, private SARIF, or app-specific scripts to a public/shared repo.
 
 **Loops**: Security-tuning loop - see [docs/LOOPS-ENGINEERING.md#security-tuning-loop](../../docs/LOOPS-ENGINEERING.md#security-tuning-loop).

--- a/skills/slo-dast-tuner/references/ptk-dom-xss.md
+++ b/skills/slo-dast-tuner/references/ptk-dom-xss.md
@@ -1,0 +1,54 @@
+---
+name: slo-dast-tuner-ptk-dom-xss
+source_skill: skills/slo-dast-tuner/SKILL.md
+status: stable-reference
+---
+
+# PTK Client-Spider as the DOM-XSS lane
+
+An adversarial DAST exercise (NodeGoat + Juice Shop) established when and how to use
+`zaprun ptk`, and the failure mode to guard against.
+
+## Why PTK
+
+The traditional `web-pr` spider + active scan cannot execute a JavaScript SPA, so it does not
+see DOM-based sinks. On OWASP Juice Shop (Angular), a ~47 s PTK Client-Spider run found:
+
+- **2 High — DOM XSS via innerHTML (Angular)** (CWE-79)
+- **6 Medium — Inline event handler built from dynamic data** (CWE-79)
+- Route-controlled `history.replaceState` (CWE-601, client-side redirect)
+- Sensitive information in browser `localStorage` (CWE-359)
+
+None of these are produced by `web-pr` or even the `spa-pr` profile in a bounded budget. PTK is
+the DOM-XSS / client-side lane and should be selected for SPA or JS-heavy targets, not as an
+afterthought.
+
+`spa-pr` (browser-backed Ajax + active) discovered more URLs (119 Ajax URLs on NodeGoat) but its
+active phase exceeded the wall-clock budget under emulation and produced no report. Prefer
+**PTK Client-Spider (deep-narrow) as the reliable DOM lane**; treat `spa-pr` full active as
+budget-sensitive.
+
+## Mandatory image guard
+
+`zaprun ptk` emits an Automation Framework plan that sets `ptk.automatedScanning.enabled` and
+`ptk.scanrules.{DAST,IAST,SAST}.enabled`. These keys require the **OWASP PTK add-on** in the ZAP
+image. The default pinned digest (zaprun v0.1.0) does **not** ship PTK → ZAP logs
+`Error(s) logged when setting configs`, the plan aborts (`failOnError: true`), and zaprun exits
+with `zap_report_missing` and no findings.
+
+- Before any `zaprun ptk` run, confirm a PTK-add-on-capable image (e.g. the `…/zaprun:ptk-local`
+  build) and pass it via `--image <repo>@sha256:<digest>`.
+- A `zap_report_missing` immediately after `Changing generic config key ptk.*` is the PTK-image
+  mismatch, not a target problem — do not report it as "no findings". Re-run with a PTK image.
+
+## Selection rule
+
+| Target shape | Lane |
+|---|---|
+| SPA / Angular / React / heavy client JS | `zaprun ptk` (PTK-capable image) — DOM-XSS lane |
+| Server-rendered HTML | `zaprun scan --active` (`web-pr`) |
+| API (OpenAPI) | `zaprun api` |
+| Need both server + client | `web-pr` for server surface **plus** `ptk` for DOM surface |
+
+Report PTK and traditional findings separately; a DOM-XSS High from PTK is not visible to
+`web-pr` and vice-versa — neither lane alone is "covered".

--- a/skills/slo-sast/SKILL.md
+++ b/skills/slo-sast/SKILL.md
@@ -47,6 +47,17 @@ Coverage-gap summaries may use [`../../references/security/security-assessment-s
 | Method (M4 — manifest + Preview-mode UX) | [`references/methodology-m4-manifest.md`](references/methodology-m4-manifest.md): Manifest schema v1.0, first install vs Re-derivation, mixed pre-existing state with workflow/config, rollback on decline, manifest symlink defense, defensive design not regulatory mandate. |
 | Method (M5 — re-derivation loop) | [`references/methodology-m5-pr-creation.md`](references/methodology-m5-pr-creation.md): Re-derivation trigger evaluation, `scanner-orch-rederivation-triggers.md`, `no drift detected`, PR creation, argv-list `gh pr create`, no `--repo`, max 1 PR per invocation, TempDir dogfood with file-content copy, template-skeleton / manifest-derived PR body, Auto-merge forbidden. |
 
+## Custom rule shape (when the registry under-covers the threat model)
+
+When the threat model needs coverage the registry does not provide, project-specific rules are
+authored. Empirically validated rule shape — taint mode + a destructuring propagator as the
+default for request-data-flow classes, intrinsic-sink structural rules for flow-free classes,
+driver-split DB sinks with the matching CWE, receiver-constrained heuristic sinks, default
+doc/fixture excludes, and explicit intra-file-taint / no-SCA caveats — is specified in
+[`references/custom-rule-shape.md`](references/custom-rule-shape.md). Apply it to any hand-authored
+web pack; it roughly doubled recall in an adversarial NodeGoat + Juice Shop test with one net
+false positive, and generalised unmodified across apps.
+
 ## Common Anti-patterns
 
 - Treating CWE references inside HTML comments, code fences, or `~~~text` user-string fences as authoritative.
@@ -54,6 +65,8 @@ Coverage-gap summaries may use [`../../references/security/security-assessment-s
 - Inferring stack or selecting rules while running only the M1 parser path.
 - Falling back to a default rule pack on missing threat-model input.
 - Running subprocesses outside the stage-specific contract.
+- Authoring web rules that match a literal `req.*` at the sink (the dominant false-negative shape — use taint + propagator per `references/custom-rule-shape.md`).
+- Implying dependency (CWE-1035/937) coverage from Semgrep alone; recommend a paired SCA step.
 
 ## See also
 
@@ -64,6 +77,7 @@ Coverage-gap summaries may use [`../../references/security/security-assessment-s
 - [`../../references/sast/scanner-orch-action-shas.md`](../../references/sast/scanner-orch-action-shas.md)
 - [`../../references/sast/scanner-orch-manifest-schema.md`](../../references/sast/scanner-orch-manifest-schema.md)
 - [`../../references/sast/scanner-orch-rederivation-triggers.md`](../../references/sast/scanner-orch-rederivation-triggers.md)
+- [`references/custom-rule-shape.md`](references/custom-rule-shape.md) — empirical custom-rule shape (taint+propagator, driver-split CWE, default excludes, coverage caveats)
 - [`../../docs/slo/design/scanner-orchestration-threat-model.md`](../../docs/slo/design/scanner-orchestration-threat-model.md)
 - [`../../docs/slo/design/scanner-orchestration-interfaces.md`](../../docs/slo/design/scanner-orchestration-interfaces.md)
 - [`../../docs/slo/completed/RUNBOOK-SCANNER-ORCHESTRATION.md`](../../docs/slo/completed/RUNBOOK-SCANNER-ORCHESTRATION.md)

--- a/skills/slo-sast/references/custom-rule-shape.md
+++ b/skills/slo-sast/references/custom-rule-shape.md
@@ -1,0 +1,96 @@
+---
+name: slo-sast-custom-rule-shape
+source_skill: skills/slo-sast/SKILL.md
+status: stable-reference
+---
+
+# /slo-sast Custom Rule Shape — empirical guidance
+
+`/slo-sast` selects registry rules by CWE. When the threat model needs coverage the registry
+does not provide, project-specific rules are authored (hand-written, or via `/slo-rulegen` for
+Rust). This reference captures what an adversarial NodeGoat + Juice Shop tuning exercise proved
+about rule shape — recall roughly doubled (33% → 63% on NodeGoat) and the same unmodified pack
+hit 8 exact Juice Shop ground-truth sinks. Apply this shape to any hand-authored web pack.
+
+## 1. Default to taint mode, not literal-sink patterns
+
+The dominant false-negative driver for web rules is matching a literal request access *at the
+sink* (`eval(req.body.x)`). Real apps extract `req.*` in the route then reach the sink through a
+local variable, **object destructuring**, or another module (route → DAO/service). A literal-sink
+rule misses every such flow: NoSQL `$where`, SSRF, ReDoS, log injection, stored-XSS-via-autoescape
+were all missed this way.
+
+Mandatory shape for request-data-flow classes:
+
+- `mode: taint`
+- `pattern-sources`: include **both** the member forms (`req.body.$X`, `req.query.$X`,
+  `req.params.$X`) **and the whole objects** (`req.body`, `req.query`, `req.params`). The
+  whole-object source is what makes the propagator below fire.
+- `pattern-sinks`: the dangerous call only.
+- `pattern-sanitizers`: the real neutralizers (`String(...)`, `parseInt`, `Number`, `ObjectId`,
+  `path.basename`, `encodeURIComponent`, framework escapers).
+
+## 2. Always add the destructuring propagator
+
+`const { userName } = req.body` is the dominant Express input-extraction idiom. Without a
+propagator, taint dies at the destructure. Add to every taint rule:
+
+```yaml
+pattern-propagators:
+  - pattern: "const { $TO } = $FROM"
+    from: $FROM
+    to: $TO
+  - pattern: "let { $TO } = $FROM"
+    from: $FROM
+    to: $TO
+  - pattern: "var { $TO } = $FROM"
+    from: $FROM
+    to: $TO
+```
+
+In the exercise this single addition flipped log-injection and IDOR from miss to hit.
+
+## 3. Keep intrinsic-sink structural rules for flow-free classes
+
+Some classes are dangerous regardless of flow and need no taint: Mongo `$where` with any
+non-constant value, catastrophic-backtracking regex literal `\([^)]*[+*]\)[+*]`, template engine
+`autoescape:false`, `helmet` absent from an `express()` file, MD5/SHA1 password hashing,
+hardcoded private key / HMAC secret. Author these as plain `pattern`/`patterns` rules.
+
+## 4. Split DB-query sinks by driver and emit the matching CWE
+
+A generic `$C.find($SINK)` sink matches Mongo *and* Sequelize/Knex/pg. On Juice Shop this
+labelled Sequelize SQLi as NoSQL — right risk class, wrong CWE, ~36 partial false positives.
+Author **separate** sinks per driver family (Mongo/Mars → CWE-943; Sequelize/Knex/pg/raw SQL →
+CWE-89) so the finding's CWE is correct and audit-defensible.
+
+## 5. Constrain heuristic sinks by receiver name
+
+Broad sinks over-fire. Example: an IDOR rule whose sink is `$DAO.$M(reqId, ...)` matched
+`needle.get(url)`. Constrain with `metavariable-regex` on the receiver
+(`(?i).*(dao|model|repo|repository|collection|db|store|service)`). This removed the false
+positive without losing the true IDOR. Model authorization both ways: exclude handlers that
+reference `req.session`/`req.user` **and** (follow-up) JWT/`isAuthorized()` middleware.
+
+## 6. Default security-profile excludes (false-positive control)
+
+Context-blind file matching was the dominant baseline false-positive driver (`plaintext-http-link`
+on teaching HTML, `detected-bcrypt-hash` on seed fixtures). The emitted `.semgrep.yml` /
+scan invocation SHOULD exclude by default: `**/views/**`, `**/templates/**`, `**/tutorial/**`,
+`**/docs/**`, `**/artifacts/**`, `**/fixtures/**`, `**/*fixture*`, `**/seed*/**`, `**/test/**`,
+`**/build/**`, `**/dist/**`, `**/node_modules/**`. Document deviations in the M4 manifest.
+
+## 7. State the coverage caveats explicitly
+
+- **Intra-file taint only** (Semgrep OSS): route→DAO cross-file flows (plaintext password / PII
+  persisted in a different module) stay false-negative. Recommend interprocedural taint or a
+  manual review note for CWE-256/312 when source and sink are in different files.
+- **No SCA**: the vulnerable-and-outdated-components class (CWE-1035 / CWE-937, e.g.
+  `marked@0.3.5`) is unreachable by Semgrep patterns. `/slo-sast` MUST recommend a paired SCA
+  step and not imply dependency coverage.
+
+## Reference pack
+
+A vetted generic Node/Express + Angular starter pack built to this shape (taint + propagator,
+driver-split intent, intrinsic-sink rules, receiver-constrained IDOR) is the recommended
+starting point; see the SAST/DAST adversarial tuning exercise deliverables.


### PR DESCRIPTION
## Summary

Skill updates derived from an adversarial SAST+DAST rule-tuning exercise against OWASP NodeGoat and Juice Shop. Closes the methodology gaps surfaced in #78 and #79.

- **slo-sast**: new `references/custom-rule-shape.md` — taint mode + destructuring propagator as the default web rule shape, intrinsic-sink structural rules, driver-split DB sinks (CWE-943 vs CWE-89), receiver-constrained IDOR heuristic, default doc/fixture excludes, explicit intra-file-taint + no-SCA caveats. Wired into SKILL.md (Method, Anti-patterns, See-also).
- **slo-dast-tuner**: new `references/ptk-dom-xss.md` — PTK Client-Spider is the DOM-XSS lane; mandatory PTK-add-on image guard. SKILL.md hardened: an unauthenticated scan of an auth-gated app is a *coverage failure*; `zaprun ptk` must validate a PTK-capable image; `triage-sarif` guided-map is empty without route metadata; new SPA/DOM-XSS dispatch row + anti-patterns.

## Evidence (from the exercise)

- Custom Semgrep recall ~2x baseline (NodeGoat 33%->63%) with one net FP; same unmodified pack hit 8 exact Juice Shop ground-truth sinks. Driver-split SQLi rules then closed JS-01/JS-02 (FN in baseline *and* tuned) with 0 NodeGoat FP regression; NoSQL mislabel FP 36->4.
- DAST: an unauthenticated NodeGoat scan missed the entire authenticated attack surface; an authenticated probe proved SSRF/IDOR/ReDoS/enumeration are fully reachable -> auth is the #1 recall lever.
- PTK found 2 High Angular-innerHTML DOM-XSS on Juice Shop that traditional scans cannot; `zaprun ptk` aborts opaquely on the pinned image because it lacks the PTK add-on.

## Scope

Docs/methodology only — no code, no rule binaries, no behavioural change to the skills' runtime contract. Reference rule pack + full report live in the companion `DaSTvsSASTskills` workspace.

## Test plan

- [ ] Review `custom-rule-shape.md` and `ptk-dom-xss.md` for accuracy
- [ ] Confirm SKILL.md links resolve and Method/Anti-pattern additions read consistently
- [ ] Spot-check the recall/FP claims against the companion report

Refs #78, #79.

🤖 Generated with [Claude Code](https://claude.com/claude-code)