### PR TITLE
agent-operating-contract: add shared AI agent contract

### DIFF
--- a/.github/agents/slo-design-reviewer.agent.md
+++ b/.github/agents/slo-design-reviewer.agent.md
@@ -1,0 +1,33 @@
+---
+name: slo-design-reviewer
+description: "Reviews UI-facing SLO runbooks for concrete design and interaction gaps"
+target: github-copilot
+tools: ["read", "search"]
+---
+
+# slo-design-reviewer
+
+You are the GitHub Copilot custom-agent profile for SLO design review. This is a host-native convenience for Copilot, not a SLO headless runtime harness. The canonical portable path is `/slo-critique` using the design persona.
+
+Use this profile only when the runbook has a UI surface. For backend, CLI, infrastructure, docs, or agent-config runbooks, return `N/A - no UI surface in this runbook`.
+
+## What To Check
+
+- AI-slop: ungrounded "modern" design, generic empty states, vague errors, or decorative clutter.
+- Interaction gaps: missing first-run, empty, loading, partial-failure, rate-limited, offline, success-with-warnings, or undo states.
+- Information hierarchy: buried primary actions, over-dominant secondary actions, contrast, density, and legibility.
+- Affordances: keyboard/mouse mismatch and unclear controls.
+- Destructive actions: named consequences, confirmation, and undo where appropriate.
+
+## Boundaries
+
+- Do not write files.
+- Return findings to the lead or user.
+- Do not propose a new design system.
+- Do not emit preference-only comments.
+- Do not modify `skills/`.
+- Do not claim Copilot custom agents are equivalent to the Claude-only SLO runtime harness.
+
+## Output
+
+Return only findings with at least 8/10 confidence. Each row needs category, runbook section, concrete user scenario, and specific recommendation.

--- a/.github/agents/slo-runbook-review-lead.agent.md
+++ b/.github/agents/slo-runbook-review-lead.agent.md
@@ -1,0 +1,33 @@
+---
+name: slo-runbook-review-lead
+description: "Consolidates SLO runbook critique findings into one bounded artifact"
+target: github-copilot
+tools: ["read", "search", "edit", "agent"]
+---
+
+# slo-runbook-review-lead
+
+You are the GitHub Copilot custom-agent profile for SLO runbook critique leadership. This is a host-native convenience for Copilot, not a SLO headless runtime harness. The canonical portable path is `/slo-critique`, which works across supported hosts.
+
+Use this profile when a runbook has passed `/slo-plan` and needs a critique before `/slo-execute`.
+
+## What To Do
+
+1. Read the target runbook end to end.
+2. Identify the public surfaces, threat-model rows, evidence requirements, and milestone allow-lists.
+3. If custom-agent invocation is available, ask `slo-security-reviewer`, `slo-design-reviewer`, and `slo-verification-lead` for bounded findings.
+4. If custom-agent invocation is unavailable, run the same four-persona `/slo-critique` rotation in this session.
+5. Dedupe findings, reject low-confidence noise, and write one consolidated artifact at `docs/slo/critique/<runbook-slug>.md`.
+
+## Boundaries
+
+- Write only `docs/slo/critique/<runbook-slug>.md`.
+- Do not edit `skills/`.
+- Do not change the runbook being reviewed unless the user explicitly asks.
+- Do not invent finding categories beyond `auto-fix`, `ask`, `hold-scope`, `reduce-scope`, and `defer`.
+- Do not cite CWE, OWASP, ASVS, or OpenCRE identifiers without checking `references/security/standards-mapping.md`.
+- Do not claim Copilot custom agents are equivalent to the Claude-only SLO runtime harness.
+
+## Output
+
+Return the critique path and a short summary of accepted findings. If no findings survive the confidence gate, say that clearly and name the residual test or host-runtime gap.

--- a/.github/agents/slo-security-reviewer.agent.md
+++ b/.github/agents/slo-security-reviewer.agent.md
@@ -1,0 +1,32 @@
+---
+name: slo-security-reviewer
+description: "Reviews SLO runbooks for security bug classes and residual risk"
+target: github-copilot
+tools: ["read", "search"]
+---
+
+# slo-security-reviewer
+
+You are the GitHub Copilot custom-agent profile for SLO security review. This is a host-native convenience for Copilot, not a SLO headless runtime harness. The canonical portable path is `/slo-critique` using the security persona.
+
+Use this profile when the runbook review lead or the user asks for a bounded security pass over a runbook.
+
+## What To Check
+
+- Bug classes from `skills/slo-critique/references/bug-class-catalog.md`.
+- Threat-model rows named in the runbook or in `docs/slo/design/<slug>-threat-model.md`.
+- CWE, OWASP, ASVS, and OpenCRE mappings from `references/security/standards-mapping.md`.
+- Variant-analysis evidence using ripgrep, ast-grep, Semgrep references, or an explicit `N/A` reason.
+
+## Boundaries
+
+- Do not write files.
+- Return findings to the lead or user.
+- Do not synthesize a threat model if one is missing; report the missing input and stop.
+- Do not accept vague "possibly present" findings. Use `eliminated`, `mitigated`, or `residual`.
+- Do not modify `skills/`.
+- Do not claim Copilot custom agents are equivalent to the Claude-only SLO runtime harness.
+
+## Output
+
+Return only findings with at least 8/10 confidence. Each row needs bug class, threat-model row id, elimination state, variant-analysis pointer, concrete exploit scenario, and recommendation.

--- a/.github/agents/slo-verification-lead.agent.md
+++ b/.github/agents/slo-verification-lead.agent.md
@@ -1,0 +1,32 @@
+---
+name: slo-verification-lead
+description: "Maps SLO milestone promises to executable evidence and bounded verification reports"
+target: github-copilot
+tools: ["read", "search", "execute", "edit"]
+---
+
+# slo-verification-lead
+
+You are the GitHub Copilot custom-agent profile for SLO verification leadership. This is a host-native convenience for Copilot, not a SLO headless runtime harness. The canonical portable path is `/slo-verify`.
+
+Use this profile after `/slo-execute` finishes a milestone, or during runbook critique when the evidence surface needs review.
+
+## What To Do
+
+1. Map each BDD scenario, smoke test, compatibility item, and Evidence Log row to a concrete command or manual check.
+2. Run only the commands named by the milestone contract or verification pass.
+3. For docs-only milestones, record structural-test evidence instead of pretending there is runtime behavior.
+4. Write the verification report to `docs/slo/verify/<prefix>-m<N>.md`.
+5. If you find a bug, stop and ask for a regression-test-first fix path.
+
+## Boundaries
+
+- Write only `docs/slo/verify/<prefix>-m<N>.md`.
+- Do not edit `skills/`.
+- Do not modify implementation files while acting as verifier.
+- DAST is N/A unless the runbook declares a runnable smoke service.
+- Do not claim Copilot custom agents are equivalent to the Claude-only SLO runtime harness.
+
+## Output
+
+Return the verification report path, scenario coverage, bugs found, skipped-tool rows, and coverage gaps. Use `pass`, `fail`, `skipped`, or `N/A` for security/static rows.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,17 @@
+# SunLit Orchestra - GitHub Copilot Instructions
+
+This is the repository-wide GitHub Copilot custom-instructions file. For the detailed Copilot overlay, read [copilot-instructions.md](../copilot-instructions.md). For the canonical skill list, read [docs/skill-pack-catalog.md](../docs/skill-pack-catalog.md).
+
+Follow [references/agent/operating-contract.md](../references/agent/operating-contract.md): ask when ambiguous, make the smallest safe change, respect SLO allow-lists, verify before claiming, and keep host-boundary claims honest.
+
+Use SLO skills for process-heavy work. The portable skill contract is `skills/<name>/SKILL.md`; do not assume a Claude-only path is available in GitHub Copilot.
+
+Optional Copilot custom-agent profiles live under `.github/agents/*.agent.md`. They are bounded conveniences for selected review/verification roles, not a replacement for `/slo-critique` or `/slo-verify` and not a SLO headless runtime harness.
+
+Before claiming support for skills, custom instructions, custom agents, plugins, or headless runtime automation, check [docs/slo/design/agent-host-capabilities.md](../docs/slo/design/agent-host-capabilities.md).
+
+For this repo, the normal structural test baseline is:
+
+```bash
+cargo test -p sldo-common -p sldo-install -p sldo-research
+```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,10 @@ This file is the Codex overlay for the canonical living catalog at [docs/skill-p
 
 If you are new to the repo, start with [docs/getting-started.md](docs/getting-started.md). For the other host overlays, read [CLAUDE.md](CLAUDE.md) or [copilot-instructions.md](copilot-instructions.md).
 
+## Shared operating contract
+
+Follow [references/agent/operating-contract.md](references/agent/operating-contract.md) for the host-neutral agent rules: ask when ambiguous, make the smallest safe change, respect SLO allow-lists, verify before claiming, and keep host-boundary claims honest. Use [docs/skill-pack-catalog.md](docs/skill-pack-catalog.md) to pick the detailed SLO skill.
+
 ## Read this first
 
 1. [docs/getting-started.md](docs/getting-started.md) - first-run path

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,10 @@
 
 This file is the Claude Code overlay for the canonical living catalog at [docs/skill-pack-catalog.md](docs/skill-pack-catalog.md). Use it when you are working in Claude Code and need Claude-specific session notes. For the host-neutral list of shipped skills, read the catalog first. For GitHub Copilot-specific notes, read [copilot-instructions.md](copilot-instructions.md). For Codex-specific notes, read [AGENTS.md](AGENTS.md).
 
+## Shared operating contract
+
+Follow [references/agent/operating-contract.md](references/agent/operating-contract.md) for the host-neutral agent rules: ask when ambiguous, make the smallest safe change, respect SLO allow-lists, verify before claiming, and keep host-boundary claims honest. Detailed workflows still live in [docs/skill-pack-catalog.md](docs/skill-pack-catalog.md) and the installed `skills/<name>/SKILL.md` files.
+
 ## Skill pack — first-party `/slo-*` skills
 
 Sprint flow: Think → Plan → Build → Review → Test → Ship → Reflect.

--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ Supported interactive hosts:
 | GitHub Copilot | `~/.copilot/skills/` | [copilot-instructions.md](copilot-instructions.md) |
 | Codex | `~/.codex/skills/` | [AGENTS.md](AGENTS.md) |
 
+These install targets are `sldo-install` compatibility root paths. Current host-native project skill roots may differ: GitHub Copilot documents `.github/skills` and `.agents/skills`, and Codex documents `.agents/skills`. SunLit keeps `~/.copilot/skills`, `./.copilot/skills`, `~/.codex/skills`, and `./.codex/skills` stable until an explicit installer migration exists.
+
 ## The problem
 
 LLM-assisted development is fast at producing code and slow at producing the things that make code useful afterwards: a clear scope, a recorded rationale, an honest threat model, an executable verification plan, and lessons that survive the next conversation. The default failure modes are easy to recognise:
@@ -253,6 +255,7 @@ What success looks like:
 - `status` lists the installed skills for the host you chose.
 - Global installs land in `~/.claude/skills/`, `~/.copilot/skills/`, or `~/.codex/skills/`.
 - Local installs land in `./.claude/skills/`, `./.copilot/skills/`, or `./.codex/skills/` if you add `--local`.
+- These paths are SLO installer compatibility root paths. They intentionally remain documented even where the host's official project-skill root is now `.github/skills` or `.agents/skills`.
 - On Windows PowerShell, use `.\target\release\sldo-install.exe` with the same flags. Native Windows shells can rely on `%USERPROFILE%` when `HOME` is not set.
 - Linux and macOS installs use directory symlinks. Windows tries directory symlinks first, then falls back to directory junctions if symlink privileges are unavailable.
 
@@ -432,6 +435,7 @@ Unless you explicitly state otherwise, any contribution intentionally submitted 
 
 - Trail of Bits' [`semgrep-rules`](https://github.com/trailofbits/semgrep-rules) (AGPL) for the structural shape inspiration on the panic-DoS / CWE-755 rule. The SunLit Orchestra rule pack is independently re-authored from variation templates per the AGPL clean-room policy in [references/sast/AUTHORING.md](references/sast/AUTHORING.md).
 - The [BMad Method](https://github.com/bmad-code-org/BMAD-METHOD) for helping popularize structured, lifecycle-aware AI-assisted development. SunLit Orchestra arrives at a more contract-heavy, security-first shape, but it shares the belief that better outcomes come from explicit workflow rather than one-shot prompting.
+- Andrej Karpathy's four-rule CLAUDE.md framing, as summarized in [this r/AIAgentsInAction post](https://www.reddit.com/r/AIAgentsInAction/comments/1tgnulq/karpathys_4_rules_for_claudemd_was_1_on_github/): ask rather than assume, prefer the simplest working solution, leave unrelated code alone, and flag uncertainty explicitly. SunLit generalizes those rules into the shared [agent operating contract](references/agent/operating-contract.md) used by Claude Code, GitHub Copilot, and Codex overlays.
 - [TLA+](https://github.com/tlaplus/tlaplus), and the broader formal-methods tradition around it, for reinforcing the idea that some designs should be challenged as specifications before they are implemented as code. SunLit carries that idea through `/slo-tla` when concurrency, ordering, or protocol risk is real.
 - Jim Manico's talk [*Securing Claude Code: Guardrails for AI-Assisted Development*](https://youtu.be/thsdAsgIsFc?si=FvxYtdHyus7DQTe7) for sharpening the guardrail-first mindset behind the project's threat-modeling, verification, and "no agentic shortcuts" posture.
 - John Carmack's [*Best programming setup and IDE*](https://youtu.be/tzr7hRXcwkw?si=SeeakVCVpqWatOUl) clip from the Lex Fridman Podcast for influencing the v4 runbook template's Carmack-style reliability controls — debugger-first inspection, mandatory static analysis, assertion-driven invariants, bounded resource design, and "make invalid states unrepresentable".

--- a/copilot-instructions.md
+++ b/copilot-instructions.md
@@ -4,6 +4,10 @@ This file is the GitHub Copilot overlay for the canonical living catalog at [doc
 
 If you are new to the repo, start with [docs/getting-started.md](docs/getting-started.md). If you want the Claude-specific version of this file, read [CLAUDE.md](CLAUDE.md). If you want the Codex-specific version, read [AGENTS.md](AGENTS.md).
 
+## Shared operating contract
+
+Follow [references/agent/operating-contract.md](references/agent/operating-contract.md) for the host-neutral agent rules: ask when ambiguous, make the smallest safe change, respect SLO allow-lists, verify before claiming, and keep host-boundary claims honest. GitHub's repo-wide Copilot custom-instructions path is [.github/copilot-instructions.md](.github/copilot-instructions.md); this root file remains the detailed Copilot overlay linked by existing SunLit docs.
+
 ## Read this first
 
 1. [docs/getting-started.md](docs/getting-started.md) — first-run path
@@ -44,6 +48,7 @@ Global installs land in `~/.copilot/skills/`. Local installs land in `./.copilot
 
 - The installed skill contract is the same `SKILL.md` format used by Claude Code.
 - `sldo-install` can install, list, verify, and uninstall Copilot-targeted skills.
+- Optional Copilot custom-agent profiles for the SLO review/verification roles live under `.github/agents/*.agent.md`; they are bounded conveniences, not a SLO headless runtime harness.
 - The canonical skill list stays in [docs/skill-pack-catalog.md](docs/skill-pack-catalog.md), so this file only needs to explain Copilot-specific details.
 
 ## Current limitations
@@ -51,7 +56,7 @@ Global installs land in `~/.copilot/skills/`. Local installs land in `./.copilot
 - Headless runtime automation in GitHub Copilot is **not supported yet**. Do not assume there is a Copilot CLI runtime equivalent to the Claude-only test harnesses.
 - `/slo-research` now supports host-native interactive research without installing Claude. The separate `sldo-research` path remains an optional Claude batch backend when a user explicitly wants batch automation.
 - The live business judgment runtime harness remains Claude-only today because it shells out to `claude -p`.
-- **Specialist agents under [agents/](agents/) are Claude-Code-only** (sap-imp M5; per the [host-capability matrix](docs/slo/design/host-capability-matrix.md)). Copilot and Codex users continue to use `/slo-critique` and `/slo-verify` directly; this is the canonical portable path and produces the same `docs/slo/critique/<slug>.md` artifact format. No second-class treatment: every agent file declares a `copilot-fallback:` field naming `/slo-critique` or `/slo-verify` as the path.
+- **Specialist agents under [agents/](agents/) remain Claude-oriented**, and Copilot has bounded custom-agent profile counterparts under [.github/agents/](.github/agents/). Copilot and Codex users can always use `/slo-critique` and `/slo-verify` directly; this is the canonical portable path and produces the same `docs/slo/critique/<slug>.md` and `docs/slo/verify/<prefix>-m<N>.md` artifact formats. Codex has no shipped SLO host-native custom-agent equivalent.
 - **`.claude-plugin/plugin.json`** (sap-imp M4) is Claude Code only. Copilot users install via `sldo-install --host github-copilot` (canonical, multi-host).
 
 ## First session checklist

--- a/crates/sldo-install/README.md
+++ b/crates/sldo-install/README.md
@@ -41,6 +41,10 @@ sldo-install install
 # Install into a project-local GitHub Copilot skills directory.
 sldo-install --host github-copilot --local install
 
+# These are SLO installer compatibility root paths; current host-native
+# project skill roots may differ (for example `.github/skills` or
+# `.agents/skills`).
+
 # Show what would happen without making changes.
 sldo-install --dry-run install
 
@@ -78,6 +82,7 @@ sldo-install uninstall
 - MSRV: 1.75
 - macOS, Linux, Windows
 - Hosts: Claude Code and GitHub Copilot, plus the other host roots supported by `sldo-install --help`
+- Existing compatibility root paths include `~/.copilot/skills`, `./.copilot/skills`, `~/.codex/skills`, and `./.codex/skills`; they remain stable until an explicit migration is shipped.
 
 ## Status
 

--- a/crates/sldo-install/tests/e2e_agent_operating_contract.rs
+++ b/crates/sldo-install/tests/e2e_agent_operating_contract.rs
@@ -30,10 +30,10 @@ fn nonblank_line_count(contents: &str) -> usize {
 fn frontmatter<'a>(contents: &'a str, rel_path: &str) -> &'a str {
     let without_open = contents
         .strip_prefix("---\n")
-        .unwrap_or_else(|| panic!("{rel_path} must start with YAML frontmatter"));
+        .unwrap_or_else(|| panic!("{} must start with YAML frontmatter", rel_path));
     let close_pos = without_open
         .find("\n---")
-        .unwrap_or_else(|| panic!("{rel_path} must close YAML frontmatter"));
+        .unwrap_or_else(|| panic!("{} must close YAML frontmatter", rel_path));
     &without_open[..close_pos]
 }
 

--- a/crates/sldo-install/tests/e2e_agent_operating_contract.rs
+++ b/crates/sldo-install/tests/e2e_agent_operating_contract.rs
@@ -1,0 +1,301 @@
+//! Structural guards for the host-portable agent operating contract.
+//!
+//! The contract is intentionally small always-on context. Detailed procedures
+//! stay in SLO skills and host-specific overlays.
+
+use std::fs;
+use std::path::PathBuf;
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("crate dir parent")
+        .parent()
+        .expect("workspace root")
+        .to_path_buf()
+}
+
+fn read(rel_path: &str) -> String {
+    fs::read_to_string(repo_root().join(rel_path))
+        .unwrap_or_else(|_| panic!("missing required file: {rel_path}"))
+}
+
+fn nonblank_line_count(contents: &str) -> usize {
+    contents
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .count()
+}
+
+fn frontmatter<'a>(contents: &'a str, rel_path: &str) -> &'a str {
+    let without_open = contents
+        .strip_prefix("---\n")
+        .unwrap_or_else(|| panic!("{rel_path} must start with YAML frontmatter"));
+    let close_pos = without_open
+        .find("\n---")
+        .unwrap_or_else(|| panic!("{rel_path} must close YAML frontmatter"));
+    &without_open[..close_pos]
+}
+
+#[test]
+fn operating_contract_exists_and_stays_small() {
+    let contract = read("references/agent/operating-contract.md");
+
+    assert!(
+        contract.contains("# Agent Operating Contract"),
+        "shared agent operating contract must identify itself"
+    );
+    for required in [
+        "Ask When Ambiguous",
+        "Smallest Safe Change",
+        "Respect The Allow-List",
+        "Verify Before Claiming",
+        "Keep Host Boundaries Honest",
+    ] {
+        assert!(
+            contract.contains(required),
+            "operating contract missing required rule: {required}"
+        );
+    }
+    assert!(
+        nonblank_line_count(&contract) <= 120,
+        "operating contract is too large for always-on agent context"
+    );
+}
+
+#[test]
+fn host_overlays_point_to_the_shared_contract() {
+    for path in [
+        "CLAUDE.md",
+        "AGENTS.md",
+        "copilot-instructions.md",
+        ".github/copilot-instructions.md",
+    ] {
+        let contents = read(path);
+        assert!(
+            contents.contains("references/agent/operating-contract.md"),
+            "{path} must point to the shared operating contract"
+        );
+        assert!(
+            contents.contains("docs/skill-pack-catalog.md"),
+            "{path} must point back to the canonical skill catalog"
+        );
+    }
+}
+
+#[test]
+fn github_copilot_has_repo_wide_instruction_path() {
+    let copilot = read(".github/copilot-instructions.md");
+
+    assert!(
+        copilot.contains("GitHub Copilot"),
+        ".github/copilot-instructions.md must identify the Copilot host"
+    );
+    assert!(
+        copilot.contains("copilot-instructions.md"),
+        ".github/copilot-instructions.md must preserve the root Copilot overlay as the detailed companion"
+    );
+    assert!(
+        copilot.contains("docs/slo/design/agent-host-capabilities.md"),
+        "Copilot repo-wide instructions must route host-support claims through the capability matrix"
+    );
+    assert!(
+        nonblank_line_count(&copilot) <= 120,
+        ".github/copilot-instructions.md is too large for repo-wide always-on context"
+    );
+}
+
+#[test]
+fn living_docs_record_the_contract_as_a_shared_invariant() {
+    let architecture = read("docs/ARCHITECTURE.md");
+    let catalog = read("docs/skill-pack-catalog.md");
+
+    for (label, contents) in [
+        ("architecture", architecture.as_str()),
+        ("skill catalog", catalog.as_str()),
+    ] {
+        assert!(
+            contents.contains("references/agent/operating-contract.md"),
+            "{label} must record the shared agent operating contract"
+        );
+    }
+}
+
+#[test]
+fn m2_capability_docs_distinguish_official_roots_from_slo_compatibility_roots() {
+    let capabilities = read("docs/slo/design/agent-host-capabilities.md");
+    let matrix = read("docs/slo/design/host-capability-matrix.md");
+    let combined = format!("{capabilities}\n{matrix}");
+
+    for official_root in [".github/skills", ".agents/skills", ".github/agents"] {
+        assert!(
+            combined.contains(official_root),
+            "capability docs must mention official host-native root `{official_root}`"
+        );
+    }
+    for compatibility_root in [".copilot/skills", ".codex/skills"] {
+        assert!(
+            combined.contains(compatibility_root),
+            "capability docs must preserve SLO installer compatibility root `{compatibility_root}`"
+        );
+    }
+    assert!(
+        combined.contains("compatibility root"),
+        "capability docs must explicitly distinguish SLO installer compatibility roots from official host-native roots"
+    );
+    assert!(
+        combined.contains("2026-05-19"),
+        "capability docs must carry the M2 source refresh date"
+    );
+    assert!(
+        combined.contains("No Copilot or Codex runtime harness is shipped today"),
+        "capability docs must preserve the no-Copilot/no-Codex SLO runtime harness boundary"
+    );
+}
+
+#[test]
+fn m2_onboarding_docs_preserve_existing_installer_roots() {
+    for path in [
+        "README.md",
+        "docs/getting-started.md",
+        "skills/README.md",
+        "crates/sldo-install/README.md",
+    ] {
+        let contents = read(path);
+        assert!(
+            contents.contains(".copilot/skills") && contents.contains(".codex/skills"),
+            "{path} must keep existing SLO installer roots documented"
+        );
+        assert!(
+            contents.contains("compatibility root"),
+            "{path} must call those roots compatibility roots so readers do not confuse them with official project-skill roots"
+        );
+    }
+}
+
+#[test]
+fn m3_copilot_custom_agent_profiles_exist_and_are_bounded() {
+    for (name, expected_tools, portable_path) in [
+        (
+            "slo-runbook-review-lead",
+            r#"tools: ["read", "search", "edit", "agent"]"#,
+            "/slo-critique",
+        ),
+        (
+            "slo-security-reviewer",
+            r#"tools: ["read", "search"]"#,
+            "/slo-critique",
+        ),
+        (
+            "slo-design-reviewer",
+            r#"tools: ["read", "search"]"#,
+            "/slo-critique",
+        ),
+        (
+            "slo-verification-lead",
+            r#"tools: ["read", "search", "execute", "edit"]"#,
+            "/slo-verify",
+        ),
+    ] {
+        let rel_path = format!(".github/agents/{name}.agent.md");
+        let contents = read(&rel_path);
+        let fm = frontmatter(&contents, &rel_path);
+
+        assert!(
+            fm.contains(&format!("name: {name}")),
+            "{rel_path} must keep the SLO role name"
+        );
+        assert!(
+            fm.contains("description:"),
+            "{rel_path} must include GitHub's required description field"
+        );
+        assert!(
+            fm.contains("target: github-copilot"),
+            "{rel_path} must be scoped to GitHub Copilot"
+        );
+        assert!(
+            fm.contains(expected_tools),
+            "{rel_path} must use the bounded tool set `{expected_tools}`"
+        );
+        assert!(
+            contents.contains(portable_path) && contents.contains("canonical portable path"),
+            "{rel_path} must point non-Copilot users to the canonical portable path"
+        );
+        assert!(
+            contents.contains("not a SLO headless runtime harness"),
+            "{rel_path} must not imply Copilot runtime-harness parity"
+        );
+        assert!(
+            !contents.contains("../"),
+            "{rel_path} must not contain path traversal fragments"
+        );
+        assert!(
+            nonblank_line_count(&contents) <= 180,
+            "{rel_path} is too large for a bounded custom-agent prompt"
+        );
+    }
+}
+
+#[test]
+fn m3_copilot_profiles_preserve_review_output_boundaries() {
+    let lead = read(".github/agents/slo-runbook-review-lead.agent.md");
+    assert!(
+        lead.contains("docs/slo/critique/<runbook-slug>.md"),
+        "runbook review lead must write only the consolidated critique artifact"
+    );
+    assert!(
+        lead.contains("Do not edit `skills/`"),
+        "runbook review lead must not edit canonical skill prose"
+    );
+
+    for reviewer in ["slo-security-reviewer", "slo-design-reviewer"] {
+        let rel_path = format!(".github/agents/{reviewer}.agent.md");
+        let contents = read(&rel_path);
+        let fm = frontmatter(&contents, &rel_path);
+        assert!(
+            fm.contains(r#"tools: ["read", "search"]"#),
+            "{rel_path} must be read/search-only"
+        );
+        assert!(
+            contents.contains("Do not write files"),
+            "{rel_path} must return findings instead of writing artifacts directly"
+        );
+    }
+
+    let verification = read(".github/agents/slo-verification-lead.agent.md");
+    assert!(
+        verification.contains("docs/slo/verify/<prefix>-m<N>.md"),
+        "verification lead must write only the bounded verification report path"
+    );
+    assert!(
+        verification.contains("DAST is N/A unless the runbook declares a runnable smoke service"),
+        "verification lead must preserve the DAST smoke-service gate"
+    );
+}
+
+#[test]
+fn m3_capability_docs_record_profiles_without_runtime_parity_claims() {
+    let capabilities = read("docs/slo/design/agent-host-capabilities.md");
+    let matrix = read("docs/slo/design/host-capability-matrix.md");
+    let combined = format!("{capabilities}\n{matrix}");
+
+    for profile in [
+        ".github/agents/slo-runbook-review-lead.agent.md",
+        ".github/agents/slo-security-reviewer.agent.md",
+        ".github/agents/slo-design-reviewer.agent.md",
+        ".github/agents/slo-verification-lead.agent.md",
+    ] {
+        assert!(
+            combined.contains(profile),
+            "capability docs must name shipped Copilot profile `{profile}`"
+        );
+    }
+    assert!(
+        combined.contains("Codex") && combined.contains("no shipped SLO host-native custom-agent"),
+        "capability docs must keep Codex on the portable fallback path"
+    );
+    assert!(
+        combined.contains("No Copilot or Codex runtime harness is shipped today"),
+        "capability docs must preserve the no-Copilot/no-Codex runtime harness boundary"
+    );
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -19,8 +19,11 @@ The repo no longer ships `sldo-plan`, `sldo-run`, or `sldo-tauri` as active work
 | `README.md` | Repo orientation for humans browsing the project |
 | `docs/getting-started.md` | First-run guide with exact install and first-use steps |
 | `docs/skill-pack-catalog.md` | Canonical living catalog of shipped skills |
+| `references/agent/operating-contract.md` | Shared host-neutral operating rules for AI coding agents |
 | `CLAUDE.md` | Claude Code overlay for the catalog |
 | `copilot-instructions.md` | GitHub Copilot overlay for the catalog |
+| `.github/copilot-instructions.md` | GitHub Copilot repository-wide custom-instructions entrypoint |
+| `.github/agents/*.agent.md` | Optional GitHub Copilot custom-agent profiles for bounded SLO review/verification roles |
 | `AGENTS.md` | Codex overlay for the catalog |
 | `docs/slo/design/agent-host-capabilities.md` | Capability matrix for install, interactive use, and runtime boundaries |
 
@@ -40,7 +43,7 @@ The skill pack is the primary user-facing product. Each skill lives in `skills/<
 | Utilities | `skills/slo-{freeze,resume,second-opinion}` | Session control, resumption, and disagreement surfacing |
 | Vendored helper | `skills/get-api-docs` | Third-party API doc fetches via `chub` |
 | Examples gallery | `examples/` | Synthetic, non-normative gallery (7 files) showing what shipped SLO outputs look like — read [`examples/README.md`](../examples/README.md). Not installable; not consumed by any skill. |
-| Specialist agents (optional, Claude-only) | `agents/slo-{runbook-review-lead,security-reviewer,design-reviewer,verification-lead}.md` | Host-native agent files for Claude Code that mirror `/slo-critique` persona rotation. Output paths constrained to `docs/slo/critique/` and `docs/slo/verify/`. GitHub Copilot and Codex users use `/slo-critique` directly (canonical portable path). See [`docs/slo/design/host-capability-matrix.md`](slo/design/host-capability-matrix.md). |
+| Specialist agents (optional, host-native) | `agents/slo-{runbook-review-lead,security-reviewer,design-reviewer,verification-lead}.md` and `.github/agents/slo-*.agent.md` | Host-native agent/profile files that mirror `/slo-critique` and `/slo-verify` role boundaries. Output paths constrained to `docs/slo/critique/` and `docs/slo/verify/`. Codex users use `/slo-critique` and `/slo-verify` directly (canonical portable path). See [`docs/slo/design/host-capability-matrix.md`](slo/design/host-capability-matrix.md). |
 | Distribution channels | `sldo-install` (canonical, multi-host) + optional `.claude-plugin/plugin.json` (Claude-only, additive) | Tagged releases produce a downloadable zip via the SHA-pinned [`release-zip workflow`](../.github/workflows/release-zip.yml). |
 
 For the full host-neutral skill inventory, read `docs/skill-pack-catalog.md`.
@@ -49,10 +52,12 @@ For the full host-neutral skill inventory, read `docs/skill-pack-catalog.md`.
 
 - **Markdown-only skill contract.** The portable unit is `skills/<name>/SKILL.md`.
 - **Canonical catalog plus host overlays.** `docs/skill-pack-catalog.md` is the shared catalog. `CLAUDE.md`, `copilot-instructions.md`, and `AGENTS.md` are overlays, not competing sources of truth.
+- **Shared agent operating contract.** `references/agent/operating-contract.md` holds the small host-neutral behavior rules every overlay points at; detailed procedures stay in skills.
 - **Canonical planning artifact.** Every new feature runbook is `docs/RUNBOOK-<FEATURE>.md` and follows `docs/slo/templates/runbook-template_v_4_template.md` (v3 remains in place as the historical artifact for runbooks authored against it).
 - **Ticket-sized planning artifact.** Every bite-sized GitHub issue contract lives at `docs/slo/tickets/ticket-<issue>-<slug>.md` and follows `docs/slo/templates/ticket-contract-template_v_1.md`. The template stays compact while mirroring sprint-flow reversibility, exemplar / anti-exemplar, refactoring discipline, and AI tolerance rows with N/A paths.
 - **Reality-first ARCHITECTURE.md.** This file records implemented surfaces only.
 - **Host-aware installer roots.** Global installs land in `~/.claude/skills/`, `~/.copilot/skills/`, or `~/.codex/skills/`. Local installs land in `./.claude/skills/`, `./.copilot/skills/`, or `./.codex/skills/`.
+- **Installer compatibility roots vs. official host roots.** The roots above are SLO installer compatibility root paths. Current host-native project skill roots can differ: GitHub Copilot documents `.github/skills` and `.agents/skills`, and Codex documents `.agents/skills`. Do not treat a docs refresh as an installer migration.
 - **Cross-platform installer behavior.** Linux and macOS use directory symlinks. Windows tries directory symlinks first and falls back to directory junctions when symlink privileges are unavailable. Home resolution supports `HOME`, `USERPROFILE`, and `HOMEDRIVE` + `HOMEPATH`.
 - **Shared manifest with explicit host ownership.** `~/.sldo/install.toml` stores install records by host so `status`, `verify`, and `uninstall` stay scoped.
 - **Baseline test command.** `cargo test -p sldo-common -p sldo-install -p sldo-research`.
@@ -171,6 +176,8 @@ The current host line is simple:
 - Install support is multi-host.
 - The catalog and the `SKILL.md` contract are host-neutral.
 - Interactive skill use is supported in Claude Code, GitHub Copilot, and Codex.
+- `sldo-install` currently writes SLO compatibility roots for project-local Copilot and Codex installs (`./.copilot/skills`, `./.codex/skills`), while current official host-native repo-skill roots include `.github/skills` and `.agents/skills`.
+- GitHub Copilot has optional custom-agent profiles under `.github/agents/*.agent.md`; these are host-native prompt/tool profiles, not a SLO headless runtime harness. Codex has no shipped SLO host-native custom-agent equivalent.
 - Headless runtime automation is still Claude-specific where it exists today.
 - `/slo-research` interactive use is multi-host today; `sldo-research` remains an optional Claude batch backend.
 - `/slo-second-opinion` is host-neutral: it compares the current host against an external provider CLI (Codex or Gemini), and never silently falls back to asking the current host to imitate the other provider.

--- a/docs/RUNBOOK-AGENT-OPERATING-CONTRACT.md
+++ b/docs/RUNBOOK-AGENT-OPERATING-CONTRACT.md
@@ -1,0 +1,524 @@
+# Agent Operating Contract - SunLitOrchestra (AI-First Runbook v4)
+
+> **Purpose**: Add a small, host-portable operating contract for AI coding agents, wire Claude Code, Codex, and GitHub Copilot overlays to it, and protect the wiring with structural tests.
+> **Audience**: AI coding agents first, humans second.
+> **Core philosophy**: Keep always-on instructions short, route detailed behavior through SLO skills, and test host-support claims so stale platform assumptions do not quietly become product behavior.
+> **Prerequisite reading**: [docs/ARCHITECTURE.md](ARCHITECTURE.md), [docs/skill-pack-catalog.md](skill-pack-catalog.md), [docs/slo/design/agent-host-capabilities.md](slo/design/agent-host-capabilities.md), [docs/slo/design/host-capability-matrix.md](slo/design/host-capability-matrix.md), [CLAUDE.md](../CLAUDE.md), [AGENTS.md](../AGENTS.md), [copilot-instructions.md](../copilot-instructions.md).
+
+---
+
+## 1. Runbook Metadata
+
+| Field | Value |
+|---|---|
+| Runbook ID | `agent-operating-contract` |
+| Project name | `SunLitOrchestra` |
+| Primary stack | Markdown skills and overlays + Rust structural tests |
+| Primary package/app names | `skills/`, `sldo-install`, `docs/`, host overlay files |
+| Prefix for tests and lesson files | `agent-operating-contract` |
+| Default unit test command | `cargo test -p sldo-install --test e2e_agent_operating_contract` |
+| Default integration/BDD test command | `cargo test -p sldo-install --test e2e_agent_operating_contract` |
+| Default E2E/runtime validation command | `N/A - documentation and structural tests only in M1` |
+| Default build/boot command | `cargo test -p sldo-install --test e2e_agent_operating_contract --no-run` |
+| Default formatter command | `cargo fmt --all -- --check` |
+| Default static analysis / lint command | `cargo clippy -p sldo-install --tests -- -D warnings` |
+| Default dependency / security audit command | `N/A - no dependency changes allowed` |
+| Default debugger or state-inspection tool | `rg` plus targeted file reads; Rust test failure output for structural state |
+| Allowed new dependencies by default | `none` |
+| Schema/config migration allowed by default | `no` |
+| Public interfaces stable by default | `yes` |
+| Master GitHub issue | [#87](https://github.com/kerberosmansour/SunLitOrchestra/issues/87) |
+
+### Public Interfaces That Must Remain Stable
+
+- Existing skill names under `skills/<name>/SKILL.md`.
+- Existing installer host ids: `claude-code`, `github-copilot`, `codex`.
+- Existing default `sldo-install` behavior targeting Claude Code.
+- Existing global install roots documented today: `~/.claude/skills/`, `~/.copilot/skills/`, `~/.codex/skills/`.
+- Existing local install roots documented today: `./.claude/skills/`, `./.copilot/skills/`, `./.codex/skills/`. If Copilot project-skill support changes, add compatibility instead of silently replacing the old root.
+
+---
+
+## 2. Milestone Tracker
+
+| # | Milestone | Status | Started | Completed | Lessons File | Completion Summary |
+|---|---|---|---|---|---|---|
+| 1 | Operating contract and overlay wiring | `done` | 2026-05-19 | 2026-05-19 | | M1 shipped shared contract, overlay wiring, Copilot repo-wide instructions, and structural tests. |
+| 2 | Host capability refresh and Copilot install-root decision | `done` | 2026-05-19 | 2026-05-19 | `docs/slo/lessons/agent-operating-contract-m2.md` | M2 refreshed host capability truth docs, separated official roots from SLO compatibility roots, and guarded the distinction with structural tests. |
+| 3 | Optional host-native agent profile parity | `done` | 2026-05-19 | 2026-05-19 | `docs/slo/lessons/agent-operating-contract-m3.md` | M3 shipped bounded Copilot custom-agent profiles while preserving Codex and portable skill fallbacks. |
+
+<!-- Status values: not_started | in_progress | blocked | done -->
+<!-- Lessons files go in docs/slo/lessons/agent-operating-contract-m<N>.md -->
+<!-- Completion summaries go in docs/slo/completion/agent-operating-contract-m<N>.md -->
+
+---
+
+## 3. End-To-End Architecture Diagram
+
+```text
+User in Claude Code / Codex / GitHub Copilot
+  |
+  | reads always-on host instructions
+  v
++-------------------------------------------------------------+
+| SunLitOrchestra repo                                         |
+|                                                             |
+|  CLAUDE.md  ---------+                                      |
+|  AGENTS.md  ---------+----> references/agent/operating-     |
+|  copilot-instructions.md     contract.md                    |
+|  .github/copilot-instructions.md --+                        |
+|                                    |                        |
+|                                    v                        |
+|                       docs/skill-pack-catalog.md            |
+|                                    |                        |
+|                                    v                        |
+|                       skills/<name>/SKILL.md                |
+|                                    |                        |
+|                                    v                        |
+|                       host-specific skill roots             |
+|                                                             |
+|  Rust structural tests guard the links and stale claims.     |
++-------------------------------------------------------------+
+
+Legend: solid arrows are documentation guidance; tests enforce selected edges.
+```
+
+### Component Summary Table
+
+| Component | Responsibility | Existing/New/Changed | Milestone | Key Interfaces |
+|---|---|---|---|---|
+| `references/agent/operating-contract.md` | Shared tiny behavioral contract for agents | New | M1 | Markdown rules linked from overlays |
+| `CLAUDE.md` | Claude Code overlay | Changed | M1 | Project memory document |
+| `AGENTS.md` | Codex and cross-agent instruction file | Changed | M1 | Project instruction document |
+| `copilot-instructions.md` | Human-readable Copilot overlay kept for existing links | Changed | M1 | Existing root overlay path |
+| `.github/copilot-instructions.md` | Copilot repo-wide custom instructions path | New | M1 | GitHub-documented Copilot repository custom instructions |
+| `docs/slo/design/*host*capabilit*.md` | Host-support truth docs | Changed later | M2 | Capability matrices and source dates |
+| `agents/` / future `.github/agents/` | Host-native specialist agent profiles | Optional later | M3 | Claude agent files, possible Copilot profiles |
+
+### Data Flow Summary
+
+| Flow | From | To | Protocol/Mechanism | Bounded? | Failure Mode | Milestone |
+|---|---|---|---|---|---|---|
+| Always-on behavior | Host overlay | `references/agent/operating-contract.md` | Markdown link + summary | yes | overlay drift | M1 |
+| Skill execution | User prompt | `skills/<name>/SKILL.md` | Host-specific skill loading | yes | hidden Claude/Copilot assumption | M1-M2 |
+| Capability claims | Current platform docs | host matrices | Manual update + structural tests | yes | stale claim becomes product docs | M2 |
+| Agent role parity | Claude agents / Copilot agents | host-specific agent profiles | Host-native profile files | yes | second-class fallback or false parity | M3 |
+
+---
+
+## 4. TLA+ Section
+
+N/A - this runbook changes Markdown instruction files and structural tests. There is no shared mutable state, distributed ordering guarantee, resource lease, or failure-recovery protocol to model. Correctness is better guarded by structural tests that read the shipped artifacts at HEAD.
+
+---
+
+## 5. Milestone 1 - Operating Contract And Overlay Wiring
+
+### Goal
+
+At the end of M1, every supported host has a short always-on path to the same agent operating contract, and a Rust structural test fails if that wiring drifts.
+
+### Context
+
+The repo already has `CLAUDE.md`, `AGENTS.md`, and `copilot-instructions.md`, but only the Claude and Codex filenames are loaded by their primary hosts as-is. GitHub's current Copilot documentation names `.github/copilot-instructions.md` as the repository-wide custom-instructions path and also recognizes `AGENTS.md` for agent instructions. This milestone adds the missing Copilot path without changing the installer or any skill name.
+
+### Important Design Rule
+
+The operating contract must stay tiny. Put stable cross-host behavior there; keep detailed procedures in SLO skills and host-specific install/runtime notes in the overlays and capability matrices.
+
+### Refactor Budget
+
+No refactor permitted beyond direct implementation.
+
+### Contract Block
+
+| Contract Row | Value |
+|---|---|
+| Inputs | Current host overlays, GitHub/OpenAI/Anthropic instruction docs cited in research notes, existing agent-host tests |
+| Outputs | `references/agent/operating-contract.md`, `.github/copilot-instructions.md`, overlay edits, structural test |
+| Interfaces touched | Markdown instruction files only |
+| Files allowed to change | `docs/RUNBOOK-AGENT-OPERATING-CONTRACT.md`, `docs/slo/critique/agent-operating-contract.md`, `references/agent/operating-contract.md`, `CLAUDE.md`, `AGENTS.md`, `copilot-instructions.md`, `.github/copilot-instructions.md`, `docs/ARCHITECTURE.md`, `docs/skill-pack-catalog.md`, `crates/sldo-install/tests/e2e_agent_operating_contract.rs` |
+| Files to read before changing | `docs/ARCHITECTURE.md`, `docs/skill-pack-catalog.md`, `CLAUDE.md`, `AGENTS.md`, `copilot-instructions.md`, `crates/sldo-install/tests/e2e_agent_host_m2.rs`, `crates/sldo-install/tests/e2e_agent_host_m3.rs`, `crates/sldo-install/tests/e2e_agent_host_m5.rs` |
+| New files allowed | `references/agent/operating-contract.md`, `.github/copilot-instructions.md`, `crates/sldo-install/tests/e2e_agent_operating_contract.rs`, `docs/slo/critique/agent-operating-contract.md` |
+| New dependencies allowed | `none` |
+| Migration allowed | `no` |
+| Compatibility commitments | Do not remove or rename root `copilot-instructions.md`; do not change skill names; do not change installer host ids or roots in M1 |
+| Exemplar code to copy | `crates/sldo-install/tests/e2e_agent_host_m2.rs` for repo-root fixture reads and clear assertion messages |
+| Anti-exemplar code not to copy | `N/A - no anti-exemplar identified; existing structural tests are the local pattern` |
+| Refactoring discipline | N/A - no refactoring performed |
+| AI tolerance contract | N/A - no LLM runtime behavior or eval harness is introduced |
+| Data classification | Public |
+| Proactive controls in play | OWASP C1 Define Security Requirements - instruction sources and host boundaries must be explicit; C5 Validate Inputs - structural tests validate paths and required phrases |
+| Abuse acceptance scenarios | `stale_host_claim_rejected` and `copilot_path_not_silent` BDD rows below |
+| Resource bounds introduced/changed | Operating contract should remain <= 120 nonblank lines; always-on Copilot instructions should remain <= 120 nonblank lines |
+| Invariants/assertions required | Structural test asserts every overlay mentions `references/agent/operating-contract.md`; Copilot repo-wide instructions exist under `.github/`; contract contains the named core rules |
+| Debugger / inspection expectation | N/A - test failure output and direct file reads are sufficient state inspection |
+| Static-analysis gates | `cargo fmt --all -- --check`; `cargo test -p sldo-install --test e2e_agent_operating_contract`; `cargo test -p sldo-install --test e2e_agent_host_m2 --test e2e_agent_host_m3 --test e2e_agent_host_m5` |
+| Reversibility / rollback path | Remove the new contract/test/Copilot file and revert overlay references; no persisted data or installer behavior changes |
+| Forbidden shortcuts | Do not paste a long generic agent template; do not remove host-specific limitations; do not claim Copilot/Codex headless runtime parity; do not replace root Copilot overlay in M1 |
+
+### Out Of Scope / Must Not Do
+
+- Do not change `sldo-install` path resolution in M1.
+- Do not port Claude `agents/` into `.github/agents/` in M1.
+- Do not add a new host-runtime abstraction.
+- Do not weaken existing "Claude-only" labels where the runtime really is Claude-only.
+
+### Files Allowed To Change
+
+| File | Planned Change |
+|---|---|
+| `references/agent/operating-contract.md` | New small host-neutral operating contract |
+| `CLAUDE.md` | Add concise pointer to the operating contract |
+| `AGENTS.md` | Add concise pointer to the operating contract |
+| `copilot-instructions.md` | Add pointer to the operating contract and `.github/` companion |
+| `.github/copilot-instructions.md` | New repo-wide Copilot custom instructions file |
+| `docs/ARCHITECTURE.md` | Mention the shared operating contract and Copilot repo-wide instructions |
+| `docs/skill-pack-catalog.md` | Mention the shared operating contract under shared invariants |
+| `crates/sldo-install/tests/e2e_agent_operating_contract.rs` | New structural test |
+| `docs/slo/critique/agent-operating-contract.md` | M1 critique artifact |
+
+### Step-By-Step
+
+1. Add failing structural test for the operating-contract and overlay-wiring invariants.
+2. Run the new test and confirm it fails because files/references are missing.
+3. Add the shared operating contract.
+4. Wire `CLAUDE.md`, `AGENTS.md`, root `copilot-instructions.md`, and `.github/copilot-instructions.md`.
+5. Update architecture/catalog references.
+6. Run the new test and existing agent-host tests.
+7. Run formatter.
+8. Record evidence in this runbook.
+
+### BDD Acceptance Scenarios
+
+| Scenario | Category | Given | When | Then | Evidence |
+|---|---|---|---|---|---|
+| `overlays_share_one_contract` | happy path | A contributor opens any host overlay | The structural test reads `CLAUDE.md`, `AGENTS.md`, `copilot-instructions.md`, and `.github/copilot-instructions.md` | Each points to `references/agent/operating-contract.md` | `cargo test -p sldo-install --test e2e_agent_operating_contract` |
+| `contract_stays_small` | invalid input | A future edit bloats the always-on operating contract | The structural test counts nonblank lines | The test fails above the configured cap | same test |
+| `copilot_path_not_silent` | empty / degraded state | GitHub Copilot ignores the root overlay path | The repo contains `.github/copilot-instructions.md` | Copilot has a documented repo-wide custom-instructions file that points at SLO sources | same test |
+| `stale_host_claim_rejected` | abuse case | A future doc implies Copilot/Codex runtime parity without capability review | The operating contract and Copilot instructions are read | They route runtime assumptions to the host capability docs instead of making a blanket promise | same test + existing agent-host tests |
+
+### Regression Tests
+
+- `cargo test -p sldo-install --test e2e_agent_host_m2`
+- `cargo test -p sldo-install --test e2e_agent_host_m3`
+- `cargo test -p sldo-install --test e2e_agent_host_m5`
+
+### Compatibility Checklist
+
+- [x] Root `copilot-instructions.md` remains present.
+- [x] Existing overlay tests still pass.
+- [x] No installer path or host id changes.
+- [x] No skill names or `SKILL.md` contracts change.
+
+### E2E Runtime Validation
+
+N/A - M1 is documentation and structural-test only. Host-session smoke belongs in M2 after capability-matrix refresh.
+
+### Smoke Tests
+
+- Read `.github/copilot-instructions.md` and confirm it is short enough for always-on Copilot context.
+- Read `AGENTS.md` and confirm Codex still sees Codex-specific install guidance.
+- Read `CLAUDE.md` and confirm Claude-specific catalog details remain intact.
+
+### Evidence Log
+
+| Check | Command / Action | Expected Result | Actual Result | Status | Notes |
+|---|---|---|---|---|---|
+| New test fails first | `cargo test -p sldo-install --test e2e_agent_operating_contract` | fails before implementation | Failed with 4 expected failures: missing `references/agent/operating-contract.md`, missing `.github/copilot-instructions.md`, missing overlay links, missing architecture/catalog invariant | `pass` | Confirms the test was red for the intended contract gaps |
+| Formatter | `cargo fmt --all -- --check` | passes | Failed on pre-existing rustfmt drift in unrelated Rust test files; new `e2e_agent_operating_contract.rs` was not listed in the diff | `blocked-unrelated` | Did not run `cargo fmt` because it would churn unrelated files outside the M1 allow-list |
+| Scoped clippy | `cargo clippy -p sldo-install --test e2e_agent_operating_contract -- -D warnings` | passes | Passed | `pass` | New Rust test is clean |
+| Full clippy | `cargo clippy -p sldo-install --tests -- -D warnings` | passes | Failed on pre-existing unrelated warnings in `tests/common/claude_runtime.rs` and `tests/e2e_biz_followup_m5.rs` | `blocked-unrelated` | Recorded for follow-up; not fixed in M1 because outside allow-list |
+| New structural test | `cargo test -p sldo-install --test e2e_agent_operating_contract` | passes | Passed: 4 tests | `pass` | |
+| Regression tests | `cargo test -p sldo-install --test e2e_agent_host_m2 --test e2e_agent_host_m3 --test e2e_agent_host_m5` | passes | Passed: 8 tests across 3 test binaries | `pass` | Existing agent-host contracts preserved |
+| Compatibility check | `git status --short` | only intended files changed | Only M1 allow-list files changed | `pass` | No installer path or skill-name changes |
+
+### Definition Of Done
+
+- [x] Shared operating contract exists and stays small.
+- [x] All four host-facing instruction files link to it.
+- [x] `.github/copilot-instructions.md` exists for GitHub's repo-wide custom-instructions path.
+- [x] Structural test fails before implementation and passes after.
+- [x] Existing agent-host regression tests pass.
+
+---
+
+## 6. Milestone 2 - Host Capability Refresh And Copilot Install-Root Decision
+
+### Goal
+
+At the end of M2, the living host-capability docs distinguish official host-native instruction/skill/agent paths from SunLit's existing `sldo-install` compatibility roots, and the repo has structural tests that fail if those distinctions disappear.
+
+### Context
+
+M1 added `.github/copilot-instructions.md` and the shared agent operating contract. While doing that work, current official docs showed that Copilot's documented project skill roots include `.github/skills`, `.claude/skills`, and `.agents/skills`; Codex's documented repository skill root is `.agents/skills`; and Claude Code reads `CLAUDE.md`, not `AGENTS.md`, unless `CLAUDE.md` imports it. SunLit still has shipped installer compatibility roots at `./.copilot/skills` and `./.codex/skills`, plus global roots under `~/.copilot/skills` and `~/.codex/skills`. M2 updates the truth docs and onboarding language without changing installer behavior.
+
+### Important Design Rule
+
+Do not silently migrate or remove an existing install root. M2 is a documentation and structural-guard milestone: it records the official host-native paths and the existing SLO compatibility roots, then defers any installer migration to a separate explicit contract.
+
+### Refactor Budget
+
+No refactor permitted beyond direct implementation.
+
+### Contract Block
+
+| Contract Row | Value |
+|---|---|
+| Inputs | Official host docs retrieved on 2026-05-19; current `sldo-install` host descriptor table; existing M1 artifacts; issue #87 |
+| Outputs | Refreshed capability matrices, onboarding docs, installer README notes, structural tests, issue progress comment |
+| Interfaces touched | Documentation and structural tests only; no CLI behavior changes |
+| Files allowed to change | `docs/RUNBOOK-AGENT-OPERATING-CONTRACT.md`, `docs/slo/critique/agent-operating-contract.md`, `docs/slo/design/agent-host-capabilities.md`, `docs/slo/design/host-capability-matrix.md`, `docs/ARCHITECTURE.md`, `docs/skill-pack-catalog.md`, `README.md`, `docs/getting-started.md`, `skills/README.md`, `crates/sldo-install/README.md`, `crates/sldo-install/tests/e2e_agent_operating_contract.rs`, `docs/slo/verify/agent-operating-contract-m2.md`, `docs/slo/lessons/agent-operating-contract-m2.md`, `docs/slo/completion/agent-operating-contract-m2.md` |
+| Files to read before changing | `crates/sldo-install/src/host.rs`, `crates/sldo-install/src/paths.rs`, `README.md`, `docs/getting-started.md`, `skills/README.md`, `crates/sldo-install/README.md`, `docs/slo/design/agent-host-capabilities.md`, `docs/slo/design/host-capability-matrix.md`, `docs/ARCHITECTURE.md`, `docs/skill-pack-catalog.md` |
+| New files allowed | none |
+| New dependencies allowed | `none` |
+| Migration allowed | `no` |
+| Compatibility commitments | `sldo-install --host github-copilot --local` still documents `./.copilot/skills`; `sldo-install --host codex --local` still documents `./.codex/skills`; no host id, manifest, or symlink behavior changes in M2 |
+| Exemplar code to copy | `crates/sldo-install/tests/e2e_agent_operating_contract.rs` for structural assertions over living docs |
+| Anti-exemplar code not to copy | Do not copy old matrix rows that say Copilot has "no equivalent" agent support; current docs say Copilot custom agents exist in preview |
+| Refactoring discipline | N/A - no refactoring performed |
+| AI tolerance contract | N/A - no LLM runtime behavior or eval harness is introduced |
+| Data classification | Public |
+| Proactive controls in play | OWASP C1 Define Security Requirements - official host paths and SLO compatibility roots must be named explicitly; C5 Validate Inputs - tests guard path claims and "no runtime harness" wording |
+| Abuse acceptance scenarios | `official_roots_not_erased`, `compatibility_roots_not_removed`, and `cloud_agent_not_confused_with_slo_runtime_harness` BDD rows below |
+| Resource bounds introduced/changed | No runtime resources; docs should avoid duplicating a full catalog and link to the canonical catalog instead |
+| Invariants/assertions required | Structural test asserts docs mention `.github/skills`, `.agents/skills`, `.copilot/skills`, `.codex/skills`, `.github/agents`, and "no Copilot or Codex runtime harness is shipped today" |
+| Debugger / inspection expectation | N/A - test failure output and direct file reads are sufficient |
+| Static-analysis gates | `cargo test -p sldo-install --test e2e_agent_operating_contract`; `cargo test -p sldo-install --test e2e_agent_host_m2 --test e2e_agent_host_m3 --test e2e_agent_host_m5`; `cargo clippy -p sldo-install --test e2e_agent_operating_contract -- -D warnings`; `cargo fmt --all -- --check` recorded honestly if still blocked by unrelated drift |
+| Reversibility / rollback path | Revert M2 doc/test edits; installer behavior is untouched |
+| Forbidden shortcuts | Do not change `crates/sldo-install/src/host.rs` or `paths.rs`; do not claim Copilot/Codex have a shipped SLO headless runtime harness; do not remove `.copilot/skills` or `.codex/skills` from existing install docs; do not add `.github/agents` profiles in M2 |
+
+### Out Of Scope / Must Not Do
+
+- Do not implement installer migration to `.github/skills` or `.agents/skills`.
+- Do not generate Copilot custom-agent profiles; that is M3.
+- Do not alter `.claude-plugin/plugin.json` or release packaging.
+- Do not close issue #87 or mark M3 planned before M2 evidence is recorded.
+
+### Files Allowed To Change
+
+| File | Planned Change |
+|---|---|
+| `crates/sldo-install/tests/e2e_agent_operating_contract.rs` | Add M2 structural assertions |
+| `docs/slo/design/agent-host-capabilities.md` | Refresh capability matrix and per-skill/host notes |
+| `docs/slo/design/host-capability-matrix.md` | Update source dates, official path rows, and Copilot agent preview status |
+| `README.md` | Clarify SLO installer compatibility roots versus official host-native roots |
+| `docs/getting-started.md` | Same clarification for first-run users |
+| `skills/README.md` | Same clarification for skill-pack readers |
+| `crates/sldo-install/README.md` | Same clarification for installer users |
+| `docs/ARCHITECTURE.md` | Record the compatibility-root versus official-root distinction |
+| `docs/skill-pack-catalog.md` | Record the invariant without duplicating the matrices |
+| `docs/slo/critique/agent-operating-contract.md` | Add M2 critique rows if needed |
+| `docs/RUNBOOK-AGENT-OPERATING-CONTRACT.md` | Track evidence and milestone status |
+| `docs/slo/verify/agent-operating-contract-m2.md` | M2 verification report |
+| `docs/slo/lessons/agent-operating-contract-m2.md` | M2 lessons learned |
+| `docs/slo/completion/agent-operating-contract-m2.md` | M2 completion summary |
+
+### Step-By-Step
+
+1. Update issue #87 with the working branch and M2 start.
+2. Add failing structural assertions for official host-native roots and SLO compatibility roots.
+3. Run the targeted test and confirm it fails for missing M2 wording.
+4. Update the capability docs and onboarding docs using official source dates.
+5. Run the targeted structural test and agent-host regression tests.
+6. Run scoped clippy for the changed test.
+7. Run formatter and record any unrelated blocker.
+8. Fill the M2 Evidence Log and update issue #87.
+
+### BDD Acceptance Scenarios
+
+| Scenario | Category | Given | When | Then | Evidence |
+|---|---|---|---|---|---|
+| `official_roots_not_erased` | happy path | A reader checks current host-native skill roots | The structural test reads capability docs | Docs name Copilot `.github/skills` and `.agents/skills`, and Codex `.agents/skills` | `cargo test -p sldo-install --test e2e_agent_operating_contract` |
+| `compatibility_roots_not_removed` | backward compat | A current SLO user follows existing installer docs | The structural test reads onboarding docs | Docs still name `.copilot/skills` and `.codex/skills` as SLO installer compatibility roots | same test |
+| `unknown_migration_not_silent` | invalid input | A future edit removes compatibility-root language while leaving installer code unchanged | The structural test runs | The test fails before docs can imply a migration happened | same test |
+| `cloud_agent_not_confused_with_slo_runtime_harness` | abuse case | A future doc sees Copilot cloud/custom-agent support and calls it SLO runtime automation | The structural test reads capability docs | Docs still say no Copilot or Codex SLO runtime harness is shipped today | same test + existing agent-host tests |
+
+### Regression Tests
+
+- `cargo test -p sldo-install --test e2e_agent_operating_contract`
+- `cargo test -p sldo-install --test e2e_agent_host_m2 --test e2e_agent_host_m3 --test e2e_agent_host_m5`
+
+### Compatibility Checklist
+
+- [x] `sldo-install` behavior and host descriptors unchanged.
+- [x] Existing `.copilot/skills` docs retained as compatibility roots.
+- [x] Existing `.codex/skills` docs retained as compatibility roots.
+- [x] Official `.github/skills` / `.agents/skills` paths recorded in capability docs.
+- [x] Copilot custom-agent support recorded as preview / future-M3 input, not shipped SLO parity.
+
+### E2E Runtime Validation
+
+N/A - M2 is documentation and structural-test only. No live host session or installer mutation is required.
+
+### Smoke Tests
+
+- Read `docs/slo/design/agent-host-capabilities.md` and confirm a new user can distinguish "official host-native root" from "SLO installer compatibility root".
+- Read `README.md` and confirm existing `sldo-install --host github-copilot --local` users are not told their install path vanished.
+- Read `docs/slo/design/host-capability-matrix.md` and confirm M3 has enough information to decide on `.github/agents/*.agent.md`.
+
+### Evidence Log
+
+| Check | Command / Action | Expected Result | Actual Result | Status | Notes |
+|---|---|---|---|---|---|
+| Issue workpad update | Comment on issue #87 | Branch and M2 start recorded | Commented on issue #87 with branch `slo/agent-operating-contract` and M2 start. | `pass` | Existing master issue remains open for M3. |
+| New M2 test fails first | `cargo test -p sldo-install --test e2e_agent_operating_contract` | fails before docs update | Failed with 2 expected M2 failures: capability docs did not yet name `.github/skills`; onboarding docs did not yet use `compatibility root` wording. | `pass` | Confirms the new assertions were red for the intended gap. |
+| New structural test | `cargo test -p sldo-install --test e2e_agent_operating_contract` | passes | Passed: 6 tests. | `pass` | Covers M1 wiring plus M2 root/capability distinctions. |
+| Regression tests | `cargo test -p sldo-install --test e2e_agent_host_m2 --test e2e_agent_host_m3 --test e2e_agent_host_m5` | passes | Passed: 8 tests across 3 binaries after preserving the existing `Headless runtime automation` anchor. | `pass` | The first run caught an over-eager row rename; fixed in docs before recording green. |
+| Scoped clippy | `cargo clippy -p sldo-install --test e2e_agent_operating_contract -- -D warnings` | passes | Passed. | `pass` | New structural test is lint-clean. |
+| Formatter | `cargo fmt --all -- --check` | passes or same unrelated blocker recorded | Failed on pre-existing rustfmt drift in unrelated Rust test files. | `blocked-unrelated` | Did not run global `cargo fmt` because it would churn files outside M2's allow-list. |
+| Verification report | Write `docs/slo/verify/agent-operating-contract-m2.md` | Runtime/static verification recorded | Written with docs-only runtime scope, static test evidence, and DAST marked N/A. | `pass` | No live Copilot/Codex harness exists for this milestone. |
+| Compatibility check | `git diff --stat && git status --short` | only intended files changed | Intended M1/M2 docs, one Rust test, and SLO closeout artifacts changed; no `crates/sldo-install/src/host.rs` or `paths.rs` changes. | `pass` | Installer behavior unchanged. |
+
+### Definition Of Done
+
+- [x] M2 official host docs refreshed with 2026-05-19 source date.
+- [x] Official host-native roots and SLO compatibility roots are both documented.
+- [x] No installer behavior changed.
+- [x] M2 structural test fails before docs update and passes after.
+- [x] Issue #87 has an M2 progress/evidence comment.
+
+## 7. Milestone 3 - Optional Host-Native Agent Profile Parity
+
+### Goal
+
+At the end of M3, GitHub Copilot has host-native custom-agent profiles for the four existing SLO review/verification roles, and the docs/tests make clear that these profiles are a Copilot preview convenience, not a shipped Copilot or Codex SLO runtime harness. Codex keeps using the canonical portable SLO skill path.
+
+### Context
+
+M2 established the current host story: Copilot supports repository custom-agent profiles under `.github/agents/*.agent.md` in public preview, while Codex has no shipped SLO host-native agent-profile equivalent. Current GitHub docs retrieved on 2026-05-19 say a Copilot custom agent profile is a Markdown file with YAML frontmatter; `description` is required; `tools` is optional and can restrict access; and `target: github-copilot` can scope the profile to Copilot. The existing SLO Claude-oriented agent files under `agents/` already define four bounded roles with explicit `copilot-fallback` fields. M3 ports those roles into GitHub's native profile shape while preserving the portable fallback.
+
+### Important Design Rule
+
+Custom-agent files may improve Copilot UX, but they do not create automatic SLO multi-agent orchestration on Codex or Copilot. The portable contract remains `/slo-critique` and `/slo-verify`; `.github/agents/*.agent.md` profiles must say so in their own prompt bodies.
+
+### Refactor Budget
+
+No refactor permitted beyond direct profile/docs/test implementation.
+
+### Contract Block
+
+| Contract Row | Value |
+|---|---|
+| Inputs | M2 lessons file; existing `agents/*.md`; GitHub Copilot custom-agent docs retrieved 2026-05-19; capability matrices; issue #87 |
+| Outputs | Four `.github/agents/*.agent.md` profiles, structural M3 tests, capability-doc updates, issue progress comment, M3 verification/retro artifacts |
+| Interfaces touched | GitHub Copilot repository custom-agent profile files; Markdown docs; structural tests |
+| Files allowed to change | `docs/RUNBOOK-AGENT-OPERATING-CONTRACT.md`, `docs/slo/critique/agent-operating-contract.md`, `crates/sldo-install/tests/e2e_agent_operating_contract.rs`, `.github/agents/slo-runbook-review-lead.agent.md`, `.github/agents/slo-security-reviewer.agent.md`, `.github/agents/slo-design-reviewer.agent.md`, `.github/agents/slo-verification-lead.agent.md`, `docs/slo/design/agent-host-capabilities.md`, `docs/slo/design/host-capability-matrix.md`, `.github/copilot-instructions.md`, `copilot-instructions.md`, `README.md`, `docs/ARCHITECTURE.md`, `docs/skill-pack-catalog.md`, `docs/slo/verify/agent-operating-contract-m3.md`, `docs/slo/lessons/agent-operating-contract-m3.md`, `docs/slo/completion/agent-operating-contract-m3.md` |
+| Files to read before changing | `docs/slo/lessons/agent-operating-contract-m2.md`, `agents/slo-runbook-review-lead.md`, `agents/slo-security-reviewer.md`, `agents/slo-design-reviewer.md`, `agents/slo-verification-lead.md`, `xtasks/sast-verify/tests/sap_imp_m5_agents.rs`, `crates/sldo-install/tests/e2e_agent_operating_contract.rs`, `docs/slo/design/agent-host-capabilities.md`, `docs/slo/design/host-capability-matrix.md`, `.github/copilot-instructions.md`, `copilot-instructions.md`, `docs/ARCHITECTURE.md`, `docs/skill-pack-catalog.md` |
+| New files allowed | `.github/agents/slo-runbook-review-lead.agent.md`, `.github/agents/slo-security-reviewer.agent.md`, `.github/agents/slo-design-reviewer.agent.md`, `.github/agents/slo-verification-lead.agent.md`, `docs/slo/verify/agent-operating-contract-m3.md`, `docs/slo/lessons/agent-operating-contract-m3.md`, `docs/slo/completion/agent-operating-contract-m3.md` |
+| New dependencies allowed | `none` |
+| Migration allowed | `no` |
+| Compatibility commitments | Existing `agents/*.md` files remain Claude-oriented and keep their `copilot-fallback` fields; no installer roots or host ids change; Codex guidance remains the portable SLO skill path |
+| Exemplar code to copy | Existing `agents/*.md` role boundaries and `xtasks/sast-verify/tests/sap_imp_m5_agents.rs` path-boundary assertions |
+| Anti-exemplar code not to copy | Do not copy Claude-specific `host-required: claude-code` frontmatter into Copilot profiles; GitHub custom-agent frontmatter uses GitHub's `description`, `tools`, and optional `target` fields |
+| Refactoring discipline | N/A - no production refactoring |
+| AI tolerance contract | N/A - profiles route human-invoked Copilot behavior; no deterministic LLM eval harness is introduced |
+| Data classification | Public |
+| Proactive controls in play | OWASP C1 Define Security Requirements - profile scopes and fallback paths are explicit; C5 Validate Inputs - tests validate profile path, tool, line-cap, and no-runtime-parity wording |
+| Abuse acceptance scenarios | `copilot_profiles_are_bounded`, `portable_fallback_not_erased`, `codex_not_promised_agent_parity`, and `preview_support_not_runtime_harness` BDD rows below |
+| Resource bounds introduced/changed | Each Copilot profile must stay <= 180 nonblank lines; profile prompt bodies must avoid embedding full SLO skill prose |
+| Invariants/assertions required | Structural test asserts all four `.github/agents/*.agent.md` files exist, include required frontmatter, restrict tools, mention the canonical portable fallback, avoid path traversal, and preserve the no-Copilot/no-Codex runtime-harness boundary |
+| Debugger / inspection expectation | N/A - test failure output and direct file reads are sufficient |
+| Static-analysis gates | `cargo test -p sldo-install --test e2e_agent_operating_contract`; `cargo test -p sldo-install --test e2e_agent_host_m2 --test e2e_agent_host_m3 --test e2e_agent_host_m5`; `cargo clippy -p sldo-install --test e2e_agent_operating_contract -- -D warnings`; `cargo fmt --all -- --check` recorded honestly if still blocked by unrelated drift |
+| Reversibility / rollback path | Delete `.github/agents/*.agent.md`, revert M3 docs/test edits, and leave existing Claude agents plus portable SLO skills unchanged |
+| Forbidden shortcuts | Do not edit `skills/slo-critique/SKILL.md` or `skills/slo-verify/SKILL.md`; do not add a Copilot/Codex headless harness; do not change `sldo-install` roots; do not claim Codex custom-agent parity |
+
+### Out Of Scope / Must Not Do
+
+- Do not change existing Claude `agents/*.md` files.
+- Do not add installer support for `.github/agents/`.
+- Do not attempt to test GitHub Copilot cloud execution live.
+- Do not add MCP servers or secrets to custom-agent frontmatter.
+- Do not change SLO skill prose for `/slo-critique` or `/slo-verify`.
+
+### Files Allowed To Change
+
+| File | Planned Change |
+|---|---|
+| `crates/sldo-install/tests/e2e_agent_operating_contract.rs` | Add M3 structural assertions |
+| `.github/agents/slo-runbook-review-lead.agent.md` | New Copilot custom-agent profile for consolidated runbook critique |
+| `.github/agents/slo-security-reviewer.agent.md` | New Copilot custom-agent profile for security review |
+| `.github/agents/slo-design-reviewer.agent.md` | New Copilot custom-agent profile for UI/design review |
+| `.github/agents/slo-verification-lead.agent.md` | New Copilot custom-agent profile for verification review/runtime QA |
+| `docs/slo/design/agent-host-capabilities.md` | Record shipped Copilot custom-agent profiles while preserving runtime-harness boundary |
+| `docs/slo/design/host-capability-matrix.md` | Update M3 decision/status |
+| `.github/copilot-instructions.md` | Mention optional Copilot custom-agent profiles without making them always-on requirements |
+| `copilot-instructions.md` | Same companion note for humans |
+| `README.md` | User-requested acknowledgement of Karpathy's four-rule CLAUDE.md framing |
+| `docs/ARCHITECTURE.md` | Record Copilot profile layer |
+| `docs/skill-pack-catalog.md` | Record portable fallback invariant for profiles |
+| `docs/slo/critique/agent-operating-contract.md` | Add M3 critique rows/resolution notes |
+| `docs/RUNBOOK-AGENT-OPERATING-CONTRACT.md` | Track M3 evidence and status |
+| `docs/slo/verify/agent-operating-contract-m3.md` | M3 verification report |
+| `docs/slo/lessons/agent-operating-contract-m3.md` | M3 lessons learned |
+| `docs/slo/completion/agent-operating-contract-m3.md` | M3 completion summary |
+
+### Step-By-Step
+
+1. Read M2 lessons and prior-retro issue carry-forward.
+2. Run repo hygiene gate and baseline structural test.
+3. Add failing M3 structural tests for the four Copilot profiles and fallback/runtime-boundary wording.
+4. Run the targeted test and confirm it fails because `.github/agents/*.agent.md` profiles are absent.
+5. Add the four bounded Copilot custom-agent profiles.
+6. Update capability docs, Copilot overlays, architecture, catalog, and critique notes.
+7. Run the targeted structural test and agent-host regression tests.
+8. Run scoped clippy and formatter; record unrelated formatter blocker if unchanged.
+9. Fill the M3 Evidence Log, write verification/lessons/completion, update issue #87.
+
+### BDD Acceptance Scenarios
+
+| Scenario | Category | Given | When | Then | Evidence |
+|---|---|---|---|---|---|
+| `copilot_profiles_are_bounded` | happy path | The repo has Copilot custom-agent files | The structural test reads `.github/agents/*.agent.md` | All four expected profiles exist, have GitHub frontmatter, bounded tools, line caps, and no path traversal | `cargo test -p sldo-install --test e2e_agent_operating_contract` |
+| `portable_fallback_not_erased` | backward compat | A non-Copilot user reads host docs or profiles | The structural test reads profiles and capability docs | Profiles route users to `/slo-critique` and `/slo-verify` as canonical portable paths | same test |
+| `codex_not_promised_agent_parity` | invalid input | A future doc claims Codex has these host-native profiles | The structural test reads capability docs | Docs continue to say Codex has no shipped SLO host-native custom-agent equivalent | same test |
+| `preview_support_not_runtime_harness` | abuse case | A future edit conflates Copilot custom agents with SLO runtime automation | The structural test reads docs and profiles | Docs/profiles keep the no-Copilot/no-Codex runtime-harness boundary | same test + existing agent-host tests |
+
+### Regression Tests
+
+- `cargo test -p sldo-install --test e2e_agent_operating_contract`
+- `cargo test -p sldo-install --test e2e_agent_host_m2 --test e2e_agent_host_m3 --test e2e_agent_host_m5`
+
+### Compatibility Checklist
+
+- [x] Existing Claude `agents/*.md` files unchanged.
+- [x] Existing `copilot-fallback` fields in Claude agents remain intact.
+- [x] No installer host id, root, manifest, or symlink behavior changed.
+- [x] Codex remains documented as using the canonical portable SLO skills path.
+- [x] Copilot custom-agent profiles are marked preview/convenience, not runtime harness parity.
+
+### E2E Runtime Validation
+
+No live Copilot cloud-agent execution is required in M3. Verification is structural because the repo cannot deterministically run GitHub Copilot custom agents from local CI.
+
+### Smoke Tests
+
+- Read `.github/agents/slo-runbook-review-lead.agent.md` and confirm it can only write the consolidated critique artifact.
+- Read `.github/agents/slo-security-reviewer.agent.md` and `.github/agents/slo-design-reviewer.agent.md` and confirm they are read/search-only reviewers.
+- Read `.github/agents/slo-verification-lead.agent.md` and confirm it points to `/slo-verify` and bounded report paths.
+- Read `docs/slo/design/agent-host-capabilities.md` and confirm Codex is not promised custom-agent parity.
+
+### Evidence Log
+
+| Check | Command / Action | Expected Result | Actual Result | Status | Notes |
+|---|---|---|---|---|---|
+| Previous lessons reviewed | Read `docs/slo/lessons/agent-operating-contract-m2.md` | M2 rules applied | Read; M3 keeps runtime-harness boundary and separates profiles from installer roots. | `pass` | |
+| Prior-retro carry-forward | `gh issue list --label retro-derived --search "agent-operating-contract" --state open --json number,title,body,url` | prior retro issues surfaced or empty | Empty result. | `pass` | No carry-forward candidates. |
+| Repo hygiene | `git status --short --branch`; `git rev-parse --abbrev-ref HEAD`; `git symbolic-ref --short refs/remotes/origin/HEAD` | work continues on task branch | Branch before/after: `slo/agent-operating-contract`; default branch `origin/main`; dirty tree contains in-progress M1/M2/M3 files. | `pass` | No branch switch needed. |
+| Baseline structural test | `cargo test -p sldo-install --test e2e_agent_operating_contract` | passes before M3 edits | Passed: 6 tests. | `pass` | Baseline from completed M2. |
+| New M3 test fails first | `cargo test -p sldo-install --test e2e_agent_operating_contract` | fails before profiles exist | Failed with 3 expected M3 failures: missing `.github/agents/slo-runbook-review-lead.agent.md` and capability docs missing shipped Copilot profile names. | `pass` | Confirms the new assertions were red for intended profile/doc gaps. |
+| New M3 structural test | `cargo test -p sldo-install --test e2e_agent_operating_contract` | passes | Passed: 9 tests. | `pass` | Covers M1, M2, and M3 invariants. |
+| Regression tests | `cargo test -p sldo-install --test e2e_agent_host_m2 --test e2e_agent_host_m3 --test e2e_agent_host_m5` | passes | Passed: 8 tests across 3 binaries. | `pass` | Existing host-boundary tests preserved. |
+| Claude agent invariant regression | `cargo test -p sast-verify --test sap_imp_m5_agents` | passes | Passed: 7 tests; package compile emitted existing non-fatal warnings. | `pass` | Existing `agents/*.md` files remain structurally valid. |
+| Scoped clippy | `cargo clippy -p sldo-install --test e2e_agent_operating_contract -- -D warnings` | passes | Passed. | `pass` | Changed Rust test target is lint-clean. |
+| Formatter | `cargo fmt --all -- --check` | passes or same unrelated blocker recorded | Failed on pre-existing rustfmt drift in unrelated Rust test files. | `blocked-unrelated` | Same blocker as M1/M2; global formatting would churn files outside M3's allow-list. |
+| Verification report | Write `docs/slo/verify/agent-operating-contract-m3.md` | Runtime/static verification recorded | Written with structural profile evidence and live-Copilot execution marked out of scope. | `pass` | |
+| Compatibility check | `git diff --stat && git status --short` | only intended files changed | Intended M1-M3 docs/profiles/tests plus user-requested README acknowledgement changed; `git diff -- agents` is empty; no installer source changes. | `pass` | Existing Claude agents unchanged. |
+
+### Definition Of Done
+
+- [x] Four Copilot custom-agent profiles exist under `.github/agents/*.agent.md`.
+- [x] M3 structural test fails before profiles and passes after.
+- [x] Capability docs record the profiles without claiming Codex parity or runtime-harness support.
+- [x] Existing Claude agent files and portable fallback paths remain intact.
+- [x] Issue #87 has an M3 progress/evidence comment.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -67,6 +67,7 @@ What success looks like:
 - `status` prints the installed skills for the host you chose.
 - Global installs land in `~/.claude/skills/`, `~/.copilot/skills/`, or `~/.codex/skills/`.
 - Local installs land in `./.claude/skills/`, `./.copilot/skills/`, or `./.codex/skills/` if you add `--local`.
+- These are SLO installer compatibility root paths. Current host-native project skill roots may differ: GitHub Copilot documents `.github/skills` and `.agents/skills`, and Codex documents `.agents/skills`. SunLit keeps `.copilot/skills` and `.codex/skills` compatible until a deliberate installer migration exists.
 - On Windows PowerShell, use `.\target\release\sldo-install.exe` with the same flags shown above.
 - Linux and macOS installs use directory symlinks. Windows tries directory symlinks first, then falls back to directory junctions if symlink privileges are unavailable.
 

--- a/docs/skill-pack-catalog.md
+++ b/docs/skill-pack-catalog.md
@@ -94,16 +94,16 @@ These skills generate exactly one primary artifact each.
 |---|---|---|
 | `/get-api-docs` | Fetch current third-party API docs via `chub` before coding against an external API | `npm install -g @aisuite/chub` |
 
-## Specialist agents (optional, host-native - Claude Code only)
+## Specialist agents (optional, host-native)
 
-Additive Claude-only enhancements that mirror `/slo-critique`'s four-persona rotation. Output paths are constrained to `docs/slo/critique/` and `docs/slo/verify/` - same artifact paths the canonical portable path writes. GitHub Copilot and Codex users continue to use `/slo-critique` directly (canonical portable path; no second-class treatment).
+Additive host-native profiles that mirror `/slo-critique` and `/slo-verify` role boundaries. Claude Code uses `agents/*.md`; GitHub Copilot has bounded counterparts under `.github/agents/*.agent.md`. Output paths are constrained to `docs/slo/critique/` and `docs/slo/verify/` - same artifact paths the canonical portable path writes. Codex users continue to use `/slo-critique` and `/slo-verify` directly.
 
-| Agent | Role | Output paths | Copilot fallback |
-|---|---|---|---|
-| `agents/slo-runbook-review-lead.md` | Lead — scopes a runbook, dispatches specialists, dedupes, writes consolidated critique | `docs/slo/critique/` | `/slo-critique` persona rotation |
-| `agents/slo-security-reviewer.md` | Security specialist — class elimination + variant analysis | `docs/slo/critique/` | `/slo-critique` security persona |
-| `agents/slo-design-reviewer.md` | Design specialist — UI-only; N/A on non-UI runbooks | `docs/slo/critique/` | `/slo-critique` design persona |
-| `agents/slo-verification-lead.md` | Verification specialist — review-time + runtime modes | `docs/slo/critique/`, `docs/slo/verify/` | `/slo-verify` |
+| Role | Claude profile | Copilot profile | Output paths | Portable path |
+|---|---|---|---|---|
+| Lead runbook review | `agents/slo-runbook-review-lead.md` | `.github/agents/slo-runbook-review-lead.agent.md` | `docs/slo/critique/` | `/slo-critique` persona rotation |
+| Security review | `agents/slo-security-reviewer.md` | `.github/agents/slo-security-reviewer.agent.md` | `docs/slo/critique/` | `/slo-critique` security persona |
+| Design review | `agents/slo-design-reviewer.md` | `.github/agents/slo-design-reviewer.agent.md` | `docs/slo/critique/` | `/slo-critique` design persona |
+| Verification review/runtime QA | `agents/slo-verification-lead.md` | `.github/agents/slo-verification-lead.agent.md` | `docs/slo/critique/`, `docs/slo/verify/` | `/slo-verify` |
 
 See [`docs/slo/design/host-capability-matrix.md`](slo/design/host-capability-matrix.md) for the green-lit decision and host capability rationale.
 
@@ -121,8 +121,11 @@ Synthetic, non-normative gallery at [`examples/`](../examples/) shows what shipp
 
 - Every new feature runbook lives at `docs/RUNBOOK-<FEATURE>.md` and follows `docs/slo/templates/runbook-template_v_4_template.md` (v3 remains in place as the historical artifact for runbooks already authored against it).
 - Every ticket-sized issue contract lives at `docs/slo/tickets/ticket-<issue>-<slug>.md` and follows `docs/slo/templates/ticket-contract-template_v_1.md`, which preserves the v4 Contract Block, BDD, evidence, static-analysis, assertion, and resource-bound gates in compact form.
+- `references/agent/operating-contract.md` is the shared host-neutral operating contract for AI coding agents. Keep it small and route detailed procedures through installed SLO skills.
 - `README.md` is the orientation doc, `docs/getting-started.md` is the first-run guide, and this file is the host-neutral skill catalog.
 - Host overlays (`CLAUDE.md`, `copilot-instructions.md`, `AGENTS.md`) must stay overlays. They can add session-specific guidance, but they should point back here instead of becoming competing catalogs.
+- Host install docs must distinguish SLO installer compatibility root paths (`.copilot/skills`, `.codex/skills`) from current official host-native project skill roots such as `.github/skills` and `.agents/skills`.
+- Host-native agent/profile docs must keep the canonical portable fallbacks visible: `/slo-critique` and `/slo-verify` remain the cross-host paths, and Copilot profiles are not a SLO headless runtime harness.
 - `references/biz/`, `references/security/`, and `references/sast/` are shared scaffolding trees. They are read by skills, but they are not skill directories.
 
 ## Current host boundaries

--- a/docs/slo/completion/agent-operating-contract-m2.md
+++ b/docs/slo/completion/agent-operating-contract-m2.md
@@ -1,0 +1,48 @@
+# Completion Summary — agent-operating-contract Milestone 2
+
+## Goal completed
+- The living host capability docs now distinguish official host-native instruction, skill, and agent paths from SunLit's existing `sldo-install` compatibility roots.
+
+## Files changed
+- `docs/slo/design/agent-host-capabilities.md`
+- `docs/slo/design/host-capability-matrix.md`
+- `README.md`
+- `docs/getting-started.md`
+- `skills/README.md`
+- `crates/sldo-install/README.md`
+- `docs/ARCHITECTURE.md`
+- `docs/skill-pack-catalog.md`
+- `crates/sldo-install/tests/e2e_agent_operating_contract.rs`
+- `docs/RUNBOOK-AGENT-OPERATING-CONTRACT.md`
+- `docs/slo/verify/agent-operating-contract-m2.md`
+- `docs/slo/lessons/agent-operating-contract-m2.md`
+- `docs/slo/completion/agent-operating-contract-m2.md`
+
+## Tests added
+- Added M2 structural assertions to `crates/sldo-install/tests/e2e_agent_operating_contract.rs`.
+
+## Runtime validations added
+- `docs/slo/verify/agent-operating-contract-m2.md` records the docs-only verification pass and static evidence.
+
+## Compatibility checks performed
+- Confirmed `.copilot/skills` and `.codex/skills` remain documented as SLO installer compatibility roots.
+- Confirmed `.github/skills`, `.agents/skills`, and `.github/agents/*.agent.md` are recorded as host-native paths or future inputs, not as a silent installer migration.
+- Confirmed `crates/sldo-install/src/host.rs` and `crates/sldo-install/src/paths.rs` were not changed.
+
+## Documentation updated
+- Host capability matrix and onboarding docs now carry the compatibility-root distinction.
+- Architecture and catalog docs now preserve that distinction as a project invariant.
+
+## .gitignore changes
+- None.
+
+## Test artifact cleanup verified
+- `git status --short` shows intended source/doc changes and new SLO process artifacts only; no generated test artifacts were left behind.
+
+## Deferred follow-ups
+- M3 still needs to decide whether to add Copilot custom-agent profiles under `.github/agents/*.agent.md` or keep `/slo-critique` as the canonical portable fallback.
+- Any migration from compatibility roots to official host-native skill roots needs a separate explicit runbook.
+
+## Known non-blocking limitations
+- No live Copilot or Codex host session was invoked in M2.
+- `cargo fmt --all -- --check` remains blocked by pre-existing unrelated rustfmt drift outside the M2 allow-list.

--- a/docs/slo/completion/agent-operating-contract-m3.md
+++ b/docs/slo/completion/agent-operating-contract-m3.md
@@ -1,0 +1,55 @@
+# Completion Summary — agent-operating-contract Milestone 3
+
+## Goal completed
+- GitHub Copilot now has bounded custom-agent profiles for the four SLO review/verification roles, while Codex and all hosts keep the canonical portable `/slo-critique` and `/slo-verify` paths.
+
+## Files changed
+- `.github/agents/slo-runbook-review-lead.agent.md`
+- `.github/agents/slo-security-reviewer.agent.md`
+- `.github/agents/slo-design-reviewer.agent.md`
+- `.github/agents/slo-verification-lead.agent.md`
+- `crates/sldo-install/tests/e2e_agent_operating_contract.rs`
+- `docs/slo/design/agent-host-capabilities.md`
+- `docs/slo/design/host-capability-matrix.md`
+- `.github/copilot-instructions.md`
+- `copilot-instructions.md`
+- `README.md`
+- `docs/ARCHITECTURE.md`
+- `docs/skill-pack-catalog.md`
+- `docs/slo/critique/agent-operating-contract.md`
+- `docs/RUNBOOK-AGENT-OPERATING-CONTRACT.md`
+- `docs/slo/verify/agent-operating-contract-m3.md`
+- `docs/slo/lessons/agent-operating-contract-m3.md`
+- `docs/slo/completion/agent-operating-contract-m3.md`
+
+## Tests added
+- Added M3 structural assertions to `crates/sldo-install/tests/e2e_agent_operating_contract.rs`.
+
+## Runtime validations added
+- `docs/slo/verify/agent-operating-contract-m3.md` records the structural verification pass. Live Copilot execution is out of scope because local CI cannot deterministically run Copilot cloud-agent sessions.
+
+## Compatibility checks performed
+- Confirmed `agents/*.md` files were not changed.
+- Confirmed no installer source files changed.
+- Confirmed capability docs preserve the no-Copilot/no-Codex runtime-harness boundary.
+- Confirmed Codex remains on the portable SLO skill path.
+
+## Documentation updated
+- Host capability docs now name the shipped Copilot custom-agent profile files.
+- Copilot overlays now mention optional profile files without making them always-on requirements.
+- README now acknowledges the Karpathy four-rule framing.
+- Architecture and catalog docs now describe the host-native profile layer and portable fallbacks.
+
+## .gitignore changes
+- None.
+
+## Test artifact cleanup verified
+- `git status --short` shows intended source/doc changes and new SLO process artifacts only; no generated test artifacts were left behind.
+
+## Deferred follow-ups
+- Live GitHub Copilot profile discovery smoke testing can be added after the branch is merged to the default branch.
+- Any installer support for official host-native skill roots remains a separate explicit runbook.
+
+## Known non-blocking limitations
+- No live GitHub Copilot cloud-agent session was invoked.
+- `cargo fmt --all -- --check` remains blocked by pre-existing unrelated rustfmt drift outside the M3 allow-list.

--- a/docs/slo/critique/agent-operating-contract.md
+++ b/docs/slo/critique/agent-operating-contract.md
@@ -1,0 +1,20 @@
+# Critique - agent-operating-contract
+
+| id | persona | category | runbook section | finding | concrete scenario | recommendation |
+|---|---|---|---|---|---|---|
+| F-CEO-1 | ceo | defer | M2 / M3 | Copilot install-root and custom-agent parity are real product decisions, but M1 correctly avoids mixing them into the always-on contract work. | A future agent tries to "fix Copilot" by changing installer roots and agent profiles in the same PR as instruction wiring; review becomes too wide and a compatibility break hides inside docs churn. | Keep M1 docs/test-only. Expand M2 only after M1 passes and explicitly decide whether `.copilot/skills` remains a compatibility root alongside GitHub's documented `.github/skills` project root. |
+| F-ENG-1 | eng | auto-fix | M1 BDD | The structural test should guard both existence and size of the always-on files, otherwise the operating contract can become the same long generic rule file this runbook is trying to avoid. | A well-meaning contributor adds 300 lines of style advice to `.github/copilot-instructions.md`; Copilot receives noisy always-on context and stops using the skill catalog efficiently. | Include nonblank-line caps in `e2e_agent_operating_contract.rs` for `references/agent/operating-contract.md` and `.github/copilot-instructions.md`. |
+| F-SEC-1 | security | ask | M1 Contract Block | The abuse scenario says stale runtime claims should be rejected, but M1's allow-list does not include the host capability matrices. | A future edit adds "Copilot custom agents now mean multi-agent dispatch is supported" to `.github/copilot-instructions.md`; no matrix row changes, so downstream users cannot tell whether the claim is grounded. | In M1, keep runtime claims out of the new always-on files and link to the capability docs. In M2, update capability matrices with current source dates before making stronger claims. |
+| F-DESIGN-1 | design | N/A | whole runbook | N/A - no UI surface in this runbook. | N/A | N/A |
+| F-ENG-2 | eng | auto-fix | M3 structural tests | Copilot profile parity needs tests over the GitHub-native profile files, not only over the capability docs. | A future edit adds `.github/agents/slo-security-reviewer.agent.md` with broad tools or no fallback path; docs say parity exists but the agent can edit arbitrary files. | Add M3 structural tests that assert the four `.github/agents/*.agent.md` files exist, use bounded tools, point to `/slo-critique` or `/slo-verify`, and preserve the no-runtime-harness wording. |
+| F-SEC-2 | security | auto-fix | M3 custom-agent profiles | The verification profile can execute commands, so its prompt must keep execution tied to milestone-declared checks and the DAST smoke-service gate. | Copilot selects `slo-verification-lead` and the profile starts running broad scanners or networked DAST without a runnable target in the runbook. | In the profile body, restrict execution to milestone-declared commands, require scope expansion before widening, and state that DAST is N/A without a runnable smoke service. |
+| F-CEO-2 | ceo | auto-fix | M3 docs | Porting Copilot profiles could be misread as Codex parity unless Codex's fallback is stated near the new Copilot rows. | A Codex user sees `.github/agents/` in the catalog and expects Codex subagent profiles to load automatically, then treats a missing feature as a product bug. | Update capability docs and catalog to say Codex has no shipped SLO host-native custom-agent equivalent and uses `/slo-critique` / `/slo-verify` directly. |
+
+## Resolution Notes
+
+- F-ENG-1 accepted into M1 test design.
+- F-SEC-1 resolved by keeping M1 wording route-to-matrix only; no runtime parity claims in the new Copilot file.
+- F-CEO-1 remains deferred as the explicit M2/M3 sequencing rule.
+- F-ENG-2 accepted into M3 test design.
+- F-SEC-2 accepted into `slo-verification-lead` profile boundaries.
+- F-CEO-2 accepted into M3 capability docs and catalog updates.

--- a/docs/slo/design/agent-host-capabilities.md
+++ b/docs/slo/design/agent-host-capabilities.md
@@ -7,19 +7,33 @@ This document is the capability matrix for the current host story. Use it when y
 - If the capability is in the catalog, it is part of the pack.
 - If the capability is in this matrix, it is honest about current host support.
 - If a capability is missing here, do not promise it.
+- Source refresh date for host-native instruction / skill / agent paths: 2026-05-19.
 
 ## Capability matrix
 
 | Capability | Claude Code | GitHub Copilot | Codex | Notes |
 |---|---|---|---|---|
-| Install skills with `sldo-install` | Supported | Supported | Supported | Same `SKILL.md` contract; different install roots |
-| Project-local install with `--local` | Supported | Supported | Supported | Writes to `./.claude/skills/`, `./.copilot/skills/`, or `./.codex/skills/` |
+| Install skills with `sldo-install` | Supported | Supported | Supported | SLO installer compatibility root behavior; not always the same as the host's current official project-skill root |
+| SLO global compatibility root | `~/.claude/skills/` | `~/.copilot/skills/` | `~/.codex/skills/` | Existing `sldo-install` behavior preserved in agent-operating-contract M2 |
+| SLO project-local compatibility root with `--local` | `./.claude/skills/` | `./.copilot/skills/` | `./.codex/skills/` | Existing behavior; M2 does not migrate or remove these roots |
+| Current host-native project skill roots | `./.claude/skills/` through existing SLO/Claude skill contract | `.github/skills`, `.claude/skills`, or `.agents/skills` | `.agents/skills` | Official host docs now distinguish these from SLO compatibility roots |
+| Repository-wide instruction file | `CLAUDE.md` | `.github/copilot-instructions.md`; `AGENTS.md` also applies to agents | `AGENTS.md` | Root `copilot-instructions.md` remains the detailed human-readable Copilot overlay for SunLit docs |
+| Host-native custom agent profiles | Claude-oriented `agents/<name>.md` files currently shipped | Shipped preview profiles under `.github/agents/*.agent.md` | Codex has no shipped SLO host-native custom-agent equivalent | M3 ports the four SLO review/verification roles to Copilot while preserving portable skill fallbacks |
 | Read the canonical skill catalog | Supported | Supported | Supported | Catalog is host-neutral |
 | Interactive use of installed skills | Supported | Supported | Supported | Exact UX depends on the host's skill/session model |
-| Host-specific overlay doc | `CLAUDE.md` | `copilot-instructions.md` | `AGENTS.md` | All overlays point back to the same canonical catalog |
+| Host-specific overlay doc | `CLAUDE.md` | `.github/copilot-instructions.md` plus root `copilot-instructions.md` | `AGENTS.md` | All overlays point back to the same canonical catalog |
 | Optional Claude batch backend (`sldo-research`) | Supported | Not supported yet | Not supported yet | The interactive `/slo-research` path is host-neutral; only the optional batch backend is Claude-only |
-| Headless runtime automation | Supported on specific Claude-only paths | Not supported yet | Not supported yet | No Copilot or Codex runtime harness is shipped today |
+| Headless runtime automation (SLO harness) | Supported on specific Claude-only paths | Not supported yet | Not supported yet | No Copilot or Codex runtime harness is shipped today |
 | Live business judgment runtime harness | Supported as opt-in Claude-only automation | Not supported yet | Not supported yet | Current harness depends on `claude -p`; the helper module is `crates/sldo-install/tests/common/claude_runtime.rs` |
+
+## Sources Checked 2026-05-19
+
+- GitHub Copilot repository custom instructions: `.github/copilot-instructions.md`, path-specific `.github/instructions/*.instructions.md`, and `AGENTS.md` for agent instructions.
+- GitHub Copilot agent skills: project skills under `.github/skills`, `.claude/skills`, or `.agents/skills`; personal skills under `~/.copilot/skills` or `~/.agents/skills`.
+- GitHub Copilot custom agents: repository profiles under `.github/agents/*.agent.md` in public preview. M3 ships `.github/agents/slo-runbook-review-lead.agent.md`, `.github/agents/slo-security-reviewer.agent.md`, `.github/agents/slo-design-reviewer.agent.md`, and `.github/agents/slo-verification-lead.agent.md`.
+- OpenAI Codex `AGENTS.md`: Codex reads global and project `AGENTS.md` / `AGENTS.override.md` layers.
+- OpenAI Codex skills: repository skills under `.agents/skills`; user skills under `~/.agents/skills`.
+- Claude Code memory: `CLAUDE.md` project memory and import mechanics.
 
 ## Per-skill notes
 
@@ -38,6 +52,8 @@ This list covers skills whose host story is non-obvious. Skills not listed here 
 
 - The installer is multi-host now. The runtime story is not.
 - GitHub Copilot and Codex should be treated as interactive hosts today, not headless automation targets.
+- Copilot custom-agent profiles are host-native prompt/tool profiles, not a SLO headless runtime harness. No Copilot or Codex runtime harness is shipped today.
+- The current `sldo-install` project-local roots for Copilot and Codex are compatibility roots (`./.copilot/skills/`, `./.codex/skills/`). Official host-native repo-skill roots now include `.github/skills` and `.agents/skills`; M2 documents this but does not migrate installer behavior.
 - `/slo-research` no longer hides a second-agent dependency in the interactive path. Only the optional batch backend remains Claude-specific.
 
 ## What to read next

--- a/docs/slo/design/host-capability-matrix.md
+++ b/docs/slo/design/host-capability-matrix.md
@@ -2,26 +2,31 @@
 
 > **Purpose**: Document what each supported host (Claude Code, GitHub Copilot, Codex) can install + invoke + run. Drives decisions in M4 (plugin packaging), M5 (host-native agents), and future host additions.
 > **Authored**: 2026-05-01 during /slo-execute M4. Retrieval-date for upstream docs cited inline.
-> **Status**: ACTIVE — consulted by M5 gate and any future runbook touching host-specific install / invocation paths.
+> **Status**: ACTIVE — consulted by M5 gate and any future runbook touching host-specific install / invocation paths. Refreshed for agent-operating-contract M2 on 2026-05-19.
 
 ## Matrix
 
 | Capability | Claude Code | GitHub Copilot | Codex | Notes |
 |---|---|---|---|---|
-| Install Markdown skills via `~/<host>/skills/<name>/SKILL.md` | YES (default, `.claude/skills/`) | YES (`.copilot/skills/`) | YES (`.codex/skills/`) | All three supported by `sldo-install` today |
-| Project-local install via `./.<host>/skills/` | YES | YES | YES | `--local` selects the host-specific project root |
+| Install Markdown skills via `sldo-install` compatibility root | YES (default, `.claude/skills/`) | YES (`.copilot/skills`) | YES (`.codex/skills`) | Existing SLO behavior preserved; these are compatibility roots, not necessarily each host's current official project-skill root |
+| Project-local install via `./.<host>/skills/` compatibility root | YES | YES (`./.copilot/skills`) | YES (`./.codex/skills`) | M2 documents the mismatch; it does not migrate installer behavior |
+| Official host-native project skill root | `.claude/skills` in the existing SLO contract | `.github/skills`, `.claude/skills`, or `.agents/skills` | `.agents/skills` | Use this row when designing future host-native install support |
+| Repository instruction file | `CLAUDE.md` | `.github/copilot-instructions.md` and agent `AGENTS.md` | `AGENTS.md` | Root `copilot-instructions.md` remains a SunLit overlay but `.github/copilot-instructions.md` is Copilot's repo-wide entrypoint |
 | Install via plugin packaging (`.claude-plugin/plugin.json`) | YES (org-install supported) | NO (no equivalent format) | NO (no equivalent format) | Claude-only path |
-| Install host-native agents (`agents/<name>.md`) | EXPERIMENTAL - Claude Code agent SDK supports declarative agent files | NO (no equivalent format) | NO (no equivalent format) | M5 gate input |
+| Install host-native agents | EXPERIMENTAL - existing SLO files under `agents/<name>.md` | PREVIEW - SLO ships `.github/agents/slo-runbook-review-lead.agent.md`, `.github/agents/slo-security-reviewer.agent.md`, `.github/agents/slo-design-reviewer.agent.md`, `.github/agents/slo-verification-lead.agent.md` | Codex has no shipped SLO host-native custom-agent equivalent | M3 profile files exist; still do not treat this as Copilot/Codex runtime harness parity |
 | Invoke skills via slash commands (`/<name>`) | YES | YES | YES | All hosts consume the portable Markdown `SKILL.md` contract interactively |
-| Run multi-agent dispatch (lead -> specialists) | EXPERIMENTAL | NO | NO | Out of scope for M5 unless an explicit feature-flag fallback is documented |
+| Run SLO multi-agent dispatch (lead -> specialists) | EXPERIMENTAL | Not shipped | Not shipped | No Copilot or Codex runtime harness is shipped today |
 | Maintain shared install manifest (`~/.sldo/install.toml`) | YES | YES | YES | Manifest records per-host entries |
 
 ## Sources (retrieval-date)
 
 - Claude Code plugin format: Anthropic public docs (snapshot 2026-05-01).
 - Anthropic Claude Agent SDK: public docs (snapshot 2026-05-01).
-- GitHub Copilot extensibility: GitHub docs (snapshot 2026-05-01).
-- Codex skill-root behavior: local Codex runtime contract in this repo (`~/.codex/skills/`, `./.codex/skills/`) as of 2026-05-03.
+- GitHub Copilot repository custom instructions: GitHub docs (snapshot 2026-05-19).
+- GitHub Copilot agent skills: GitHub docs (snapshot 2026-05-19) — project roots `.github/skills`, `.claude/skills`, `.agents/skills`; personal roots `~/.copilot/skills`, `~/.agents/skills`.
+- GitHub Copilot custom agents: GitHub docs (snapshot 2026-05-19) — repository profiles under `.github/agents/*.agent.md`.
+- Codex `AGENTS.md` and skills: OpenAI docs (snapshot 2026-05-19) — project instructions via `AGENTS.md`, repo skills under `.agents/skills`.
+- SLO compatibility roots: local `sldo-install` contract in this repo (`~/.copilot/skills`, `./.copilot/skills`, `~/.codex/skills`, `./.codex/skills`) as of 2026-05-19.
 
 ## Decisions
 
@@ -44,20 +49,53 @@
 
 ### M5 host-native agents — `green-lit, with portable fallback documented`
 
-**Decision**: ship 4 agent files under `agents/`. Each file declares `copilot-fallback: /slo-critique persona rotation` (or equivalent) so non-Claude users are not second-class. The agent files are an additive Claude-only enhancement; the canonical portable critique flow stays `/slo-critique` persona rotation.
+**Decision**: ship 4 agent files under `agents/`. Each file declares `copilot-fallback: /slo-critique persona rotation` (or equivalent) so non-Claude users are not second-class. This decision originally shipped an additive Claude-oriented enhancement; agent-operating-contract M3 later adds Copilot custom-agent profile files without changing the canonical portable critique flow.
 
 **Reasoning**:
 
 1. Anthropic's Claude Agent SDK supports declarative agent files at `agents/<name>.md`.
-2. GitHub Copilot and Codex have no host-native agent equivalent in this repo. Per the matrix, both can run `/slo-critique` directly, which performs four-persona rotation in-skill. That IS the fallback.
+2. At the time of M5, GitHub Copilot and Codex had no host-native agent equivalent in this repo. Per the matrix, both could run `/slo-critique` directly, which performs four-persona rotation in-skill. Agent-operating-contract M3 adds Copilot custom-agent profiles; Codex still uses the portable fallback.
 3. The structural-contract test asserts each agent file declares `copilot-fallback:` — so the portable fallback story is *enforced*, not just *promised*.
 4. Output paths constrained to `{docs/slo/critique/, docs/slo/verify/}` (per F-SEC-6 critique resolution).
 
 **Gate**: M5 may proceed if and only if this matrix says agents are installable on at least one host AND non-Claude hosts have a documented fallback. Both conditions hold here.
 
+### M2 compatibility-root decision — `green-lit`
+
+**Decision**: preserve existing `sldo-install` compatibility roots for M2 and document current official host-native roots separately. Do not silently migrate Copilot local installs from `./.copilot/skills` to `.github/skills`, and do not silently migrate Codex local installs from `./.codex/skills` to `.agents/skills`.
+
+**Reasoning**:
+
+1. Existing tests, docs, and user workflows already depend on `./.copilot/skills` and `./.codex/skills`.
+2. Current host docs now expose official project-skill roots that differ from those compatibility roots.
+3. A migration would require explicit installer behavior, manifest, uninstall, smoke-test, and rollback design. That is larger than M2's docs/test-only contract.
+4. Future work may add an explicit `--scope project-native` or host-root override, but it must preserve manifest safety and uninstall boundaries.
+
+### M3 Copilot custom-agent profiles — `green-lit, preview convenience`
+
+**Decision**: ship four GitHub Copilot custom-agent profiles under `.github/agents/*.agent.md`, matching the existing SLO review/verification roles:
+
+- `.github/agents/slo-runbook-review-lead.agent.md`
+- `.github/agents/slo-security-reviewer.agent.md`
+- `.github/agents/slo-design-reviewer.agent.md`
+- `.github/agents/slo-verification-lead.agent.md`
+
+**Reasoning**:
+
+1. GitHub's current custom-agent docs support repository agent profiles in `.github/agents/` with `.agent.md` filenames, required `description`, optional `tools`, and optional `target: github-copilot`.
+2. The existing Claude-oriented `agents/*.md` roles are already bounded by output-path and fallback tests; the Copilot profiles mirror those role boundaries rather than inventing new behavior.
+3. Codex has no shipped SLO host-native custom-agent equivalent. Codex users keep using `/slo-critique` and `/slo-verify` directly.
+4. These profiles are not a SLO headless runtime harness. No Copilot or Codex runtime harness is shipped today.
+
+**Guardrails**:
+
+- Lead profile may read/search/edit and invoke other custom agents; specialist security/design profiles are read/search only.
+- Verification profile may execute the milestone's declared checks and write only bounded verification reports.
+- No profile edits `skills/`, installer code, or host-root behavior.
+
 ## When to revisit
 
 - New host emerges (e.g., Cursor, Cody) — add a column to the matrix and re-run M4 + M5 gates.
 - Anthropic plugin format changes — update Sources retrieval date and re-verify the plugin.json shape.
-- GitHub Copilot or Codex adds host-native plugin/agent install — promote fallback rows from "documented fallback" to "first-class" and update agent files.
+- GitHub Copilot or Codex adds stronger host-native plugin/agent install — promote fallback rows from "documented fallback" to "first-class" only after profile files, tests, and runtime boundaries are updated.
 - Stale retrieval-date (> 12 months from authoring) — re-fetch upstream docs and update the matrix.

--- a/docs/slo/lessons/agent-operating-contract-m2.md
+++ b/docs/slo/lessons/agent-operating-contract-m2.md
@@ -1,0 +1,47 @@
+# Lessons Learned — agent-operating-contract Milestone 2
+
+## What changed
+- Refreshed the host capability docs with a 2026-05-19 source date and separated official host-native roots from SLO installer compatibility roots.
+- Added M2 structural assertions to `crates/sldo-install/tests/e2e_agent_operating_contract.rs`.
+- Updated onboarding docs so existing `.copilot/skills` and `.codex/skills` users are not silently told their install paths vanished.
+- Recorded Copilot custom agents as M3 input, not as shipped SLO parity.
+
+## Design decisions and why
+- Kept installer behavior unchanged. M2 is a truth-doc and guardrail milestone, not a migration.
+- Used the terms "official host-native root" and "SLO installer compatibility root" so docs can describe current host behavior without breaking existing users.
+- Preserved the existing `Headless runtime automation` anchor phrase because older structural tests already use it as the compatibility signal.
+
+## Mistakes made
+- The first docs edit renamed the `Headless runtime automation` row too aggressively, which broke an existing regression test.
+- The M2 allow-list initially omitted SLO closeout artifacts even though `/slo-verify` and `/slo-retro` require them.
+
+## Root causes
+- The repo previously mixed official host paths and installer compatibility paths in one mental bucket.
+- Some structural tests intentionally depend on stable wording, so meaningful wording changes need to preserve those anchor strings.
+
+## What was harder than expected
+- Making the docs more precise without implying a migration had already happened.
+- Keeping Copilot custom-agent preview support visible while still saying plainly that SLO does not ship a Copilot/Codex headless runtime harness today.
+
+## Naming conventions established
+- `official host-native root` means a path documented by the host vendor for native host behavior.
+- `SLO installer compatibility root` means a path currently produced or documented by `sldo-install`.
+- `.github/agents/*.agent.md` is reserved for any future Copilot custom-agent profile work.
+
+## Test patterns that worked well
+- Failing structural tests over multiple docs caught both missing official roots and missing compatibility-root wording.
+- Keeping existing agent-host tests in the regression set caught the accidental loss of a stable anchor phrase.
+
+## Missing tests that should exist now
+- M3 should add structural coverage for any `.github/agents/*.agent.md` profiles before creating them.
+- A later installer-migration runbook should test CLI status output if `sldo-install` ever starts writing official host-native roots.
+
+## Rules for the next milestone
+- Read the previous lessons before expanding M3.
+- Do not call Copilot custom agents equivalent to SLO runtime automation.
+- If M3 emits `.github/agents/*.agent.md`, write structural tests first for paths, frontmatter, allowed tools, and fallback wording.
+- Keep installer compatibility-root docs separate from host-native agent-profile docs.
+
+## Template improvements suggested
+- Runbook milestones should include `/slo-verify` and `/slo-retro` artifact paths in their allow-list when the user asks to follow every SLO step.
+- Doc-heavy milestones should reserve one evidence row for stable anchor-string regressions.

--- a/docs/slo/lessons/agent-operating-contract-m3.md
+++ b/docs/slo/lessons/agent-operating-contract-m3.md
@@ -1,0 +1,42 @@
+# Lessons Learned — agent-operating-contract Milestone 3
+
+## What changed
+- Added four GitHub Copilot custom-agent profiles under `.github/agents/*.agent.md`.
+- Added M3 structural tests covering profile presence, frontmatter, tool scopes, portable fallback wording, output boundaries, and no-runtime-harness wording.
+- Updated capability docs, Copilot overlays, architecture, catalog, and critique notes to reflect the new profile layer.
+- Added the user-requested README acknowledgement for Karpathy's four-rule CLAUDE.md framing.
+
+## Design decisions and why
+- Scoped the profiles with `target: github-copilot` because the M3 goal is GitHub Copilot profile support, not generic editor behavior.
+- Kept security and design reviewers read/search-only. They return findings; the lead writes the consolidated artifact.
+- Allowed execution only on the verification profile because verification may need to run milestone-declared checks.
+- Kept Codex on `/slo-critique` and `/slo-verify` because there is no shipped SLO Codex custom-agent profile equivalent.
+
+## Mistakes made
+- The first M3 contract omitted `README.md`; the user's explicit acknowledgement request required a scoped allow-list amendment.
+
+## Root causes
+- Host-native profile work is adjacent to repo-facing docs, so user-visible acknowledgement/docs requests can arrive while a milestone is in flight.
+
+## What was harder than expected
+- Avoiding false parity language. Copilot custom-agent profiles are useful, but they are not the same thing as the Claude-only runtime harnesses already called out in the capability matrix.
+
+## Naming conventions established
+- Copilot custom-agent profile files use `.github/agents/<slo-role>.agent.md`.
+- Copilot profiles keep the same role names as the existing Claude-oriented `agents/*.md` files.
+
+## Test patterns that worked well
+- Testing for profile files before creating them gave a clean missing-file red state.
+- Testing exact tool arrays kept the profile permissions simple and auditable.
+
+## Missing tests that should exist now
+- A future live-host smoke test could verify that GitHub Copilot actually lists the profiles after merge to the default branch.
+- A future installer migration runbook should test native project roots separately from custom-agent profile discovery.
+
+## Rules for the next milestone
+- Keep host-native profile files small; do not paste full skill prose into them.
+- Treat custom-agent profiles as host UX, not installer behavior.
+- Do not add live runtime claims without a deterministic host smoke path.
+
+## Template improvements suggested
+- SLO runbooks should have a standard way to record user-requested mid-milestone scope additions without making them look accidental.

--- a/docs/slo/verify/agent-operating-contract-m2.md
+++ b/docs/slo/verify/agent-operating-contract-m2.md
@@ -1,0 +1,40 @@
+# Verification Report — agent-operating-contract Milestone 2
+
+## What was exercised
+
+| Scenario | Category | How exercised | Result | Evidence |
+|---|---|---|---|---|
+| `official_roots_not_erased` | happy path | Ran `cargo test -p sldo-install --test e2e_agent_operating_contract`; test reads capability docs for `.github/skills`, `.agents/skills`, `.github/agents`, and the 2026-05-19 source date. | pass | Capability docs now distinguish official host-native roots from SLO compatibility roots. |
+| `compatibility_roots_not_removed` | backward compat | Ran `cargo test -p sldo-install --test e2e_agent_operating_contract`; test reads `README.md`, `docs/getting-started.md`, `skills/README.md`, and `crates/sldo-install/README.md`. | pass | Onboarding docs still name `.copilot/skills` and `.codex/skills` as compatibility roots. |
+| `unknown_migration_not_silent` | invalid input | Confirmed the new M2 assertions failed before the docs update, then passed after the docs update. | pass | Initial failure reported missing `.github/skills` and missing `compatibility root` wording. |
+| `cloud_agent_not_confused_with_slo_runtime_harness` | abuse case | Ran `cargo test -p sldo-install --test e2e_agent_host_m2 --test e2e_agent_host_m3 --test e2e_agent_host_m5`. | pass | Docs keep the exact invariant that no Copilot or Codex SLO runtime harness is shipped today. |
+
+## Pass 4 Security / Static Evidence
+
+| Stack / tool | Command | Result | Evidence |
+|---|---|---|---|
+| Rust structural tests | `cargo test -p sldo-install --test e2e_agent_operating_contract` | pass | 6 tests passed. |
+| Rust regression tests | `cargo test -p sldo-install --test e2e_agent_host_m2 --test e2e_agent_host_m3 --test e2e_agent_host_m5` | pass | 8 tests passed across 3 binaries. |
+| Rust lint | `cargo clippy -p sldo-install --test e2e_agent_operating_contract -- -D warnings` | pass | Changed test target is lint-clean. |
+| Formatter | `cargo fmt --all -- --check` | skipped | Pre-existing unrelated rustfmt drift remains outside the M2 allow-list. |
+| Dependency audit | N/A | N/A | No dependency graph changes. |
+| DAST | N/A | N/A | Markdown and structural-test milestone; no smoke service or OpenAPI surface. |
+| Biz PII scan | N/A | N/A | M2 does not write `docs/biz-public/` artifacts. |
+
+## Bugs found
+
+| id | severity | scenario | regression test | status |
+|----|----------|----------|-----------------|--------|
+| N/A | N/A | No M2 bugs found. | N/A | N/A |
+
+## Environment
+
+- OS: Darwin 25.4.0 arm64.
+- Rust: `rustc 1.95.0 (59807616e 2026-04-14)`.
+- Cargo: `cargo 1.95.0 (f2d3ce0bd 2026-03-21)`.
+- Browser: N/A — no UI surface.
+
+## Coverage gaps
+
+- No live Copilot, Codex, or Claude host session was invoked; M2 is intentionally documentation and structural-test only.
+- Global `cargo fmt --all -- --check` remains blocked by pre-existing unrelated formatting drift.

--- a/docs/slo/verify/agent-operating-contract-m3.md
+++ b/docs/slo/verify/agent-operating-contract-m3.md
@@ -1,0 +1,41 @@
+# Verification Report — agent-operating-contract Milestone 3
+
+## What was exercised
+
+| Scenario | Category | How exercised | Result | Evidence |
+|---|---|---|---|---|
+| `copilot_profiles_are_bounded` | happy path | Ran `cargo test -p sldo-install --test e2e_agent_operating_contract`; test reads `.github/agents/*.agent.md` files for expected names, frontmatter, tools, target, line caps, and no traversal fragments. | pass | Four Copilot profiles exist with bounded tools and `target: github-copilot`. |
+| `portable_fallback_not_erased` | backward compat | Same test reads profiles and capability docs for `/slo-critique`, `/slo-verify`, and canonical portable path wording. | pass | Profiles explicitly preserve the portable SLO skill paths. |
+| `codex_not_promised_agent_parity` | invalid input | Same test reads capability docs for the Codex no-custom-agent-equivalent wording. | pass | Capability docs say Codex has no shipped SLO host-native custom-agent equivalent. |
+| `preview_support_not_runtime_harness` | abuse case | Same test plus `cargo test -p sldo-install --test e2e_agent_host_m2 --test e2e_agent_host_m3 --test e2e_agent_host_m5`. | pass | Docs and profiles preserve the no-Copilot/no-Codex runtime-harness boundary. |
+
+## Pass 4 Security / Static Evidence
+
+| Stack / tool | Command | Result | Evidence |
+|---|---|---|---|
+| Rust structural tests | `cargo test -p sldo-install --test e2e_agent_operating_contract` | pass | 9 tests passed. |
+| Rust regression tests | `cargo test -p sldo-install --test e2e_agent_host_m2 --test e2e_agent_host_m3 --test e2e_agent_host_m5` | pass | 8 tests passed across 3 binaries. |
+| Existing Claude agent invariant tests | `cargo test -p sast-verify --test sap_imp_m5_agents` | pass | 7 tests passed; package compile emitted existing non-fatal warnings in `sast-verify`. |
+| Rust lint | `cargo clippy -p sldo-install --test e2e_agent_operating_contract -- -D warnings` | pass | Changed test target is lint-clean. |
+| Formatter | `cargo fmt --all -- --check` | skipped | Pre-existing unrelated rustfmt drift remains outside the M3 allow-list. |
+| Dependency audit | N/A | N/A | No dependency graph changes. |
+| DAST | N/A | N/A | Markdown profile/docs milestone; no smoke service or OpenAPI surface. |
+| Live Copilot custom-agent execution | N/A | N/A | M3 is structural; local CI cannot deterministically run GitHub Copilot cloud-agent sessions. |
+
+## Bugs found
+
+| id | severity | scenario | regression test | status |
+|----|----------|----------|-----------------|--------|
+| N/A | N/A | No M3 bugs found. | N/A | N/A |
+
+## Environment
+
+- OS: Darwin 25.4.0 arm64.
+- Rust: `rustc 1.95.0 (59807616e 2026-04-14)`.
+- Cargo: `cargo 1.95.0 (f2d3ce0bd 2026-03-21)`.
+- Browser: N/A — no UI surface.
+
+## Coverage gaps
+
+- No live GitHub Copilot cloud-agent session was invoked.
+- Global `cargo fmt --all -- --check` remains blocked by pre-existing unrelated formatting drift.

--- a/references/agent/operating-contract.md
+++ b/references/agent/operating-contract.md
@@ -1,0 +1,31 @@
+# Agent Operating Contract
+
+This is the shared always-on contract for AI coding agents working in SunLit Orchestra. Keep it small. Detailed workflows live in `skills/<name>/SKILL.md`; host-specific install and runtime limits live in `CLAUDE.md`, `AGENTS.md`, `copilot-instructions.md`, and `docs/slo/design/agent-host-capabilities.md`.
+
+## Ask When Ambiguous
+
+Ask a concise question when the next edit depends on information that cannot be discovered from the repo or current sources. If the risk is low, make a conservative assumption and say what you assumed.
+
+## Smallest Safe Change
+
+Prefer the smallest change that satisfies the active SLO contract. Do not broaden scope, rename public interfaces, add dependencies, or refactor adjacent code unless the runbook, ticket, or user explicitly allows it.
+
+## Respect The Allow-List
+
+When an SLO runbook or ticket names files allowed to change, treat that list as binding. If the fix needs another file, stop and surface the contract gap before editing it.
+
+## Verify Before Claiming
+
+Evidence beats confidence. Run the relevant formatter, build, lint, structural tests, runtime checks, or manual smoke steps before saying work is done. If a check cannot run, record why.
+
+## Keep Host Boundaries Honest
+
+Do not invent parity between Claude Code, Codex, and GitHub Copilot. Before claiming a host supports skills, instructions, agents, plugins, or runtime automation, check `docs/slo/design/agent-host-capabilities.md`.
+
+## Keep Instructions Layered
+
+Always-on files should orient agents, not carry whole workflows. Link to the canonical catalog at `docs/skill-pack-catalog.md`, then use the relevant installed SLO skill for detailed procedure.
+
+## Preserve User Work
+
+Treat uncommitted changes as user work unless proven otherwise. Never reset, discard, or overwrite unrelated changes to make a task easier.

--- a/skills/README.md
+++ b/skills/README.md
@@ -32,6 +32,8 @@ cargo build --release --bin sldo-install
                                                        # project-local GitHub Copilot install: ./.copilot/skills/<name>/
 ```
 
+The paths above are SLO installer compatibility root paths. Current host-native project skill roots may differ: GitHub Copilot documents `.github/skills` and `.agents/skills`, and Codex documents `.agents/skills`. Keep `.copilot/skills` and `.codex/skills` working until an explicit installer migration is designed and tested.
+
 Running the installer twice is a no-op. `claude-code` is the default host if you do not pass `--host`. Pass `--force` to replace an existing symlink that points somewhere else. Pass `--dry-run` to see what would change.
 
 ## Uninstall


### PR DESCRIPTION
## Summary

Adds a host-portable operating contract for AI coding agents, wires Claude Code, Codex, and GitHub Copilot overlays to it, refreshes host capability truth docs, and adds bounded GitHub Copilot custom-agent profiles for the SLO review/verification roles. Closes #87.

## Milestones completed

- M1 — Operating contract and overlay wiring — shared contract, overlay wiring, Copilot repo-wide instructions, and structural tests.
- M2 — Host capability refresh and Copilot install-root decision — official host-native roots separated from SLO installer compatibility roots, with docs/tests preserving the distinction.
- M3 — Optional host-native agent profile parity — four bounded Copilot custom-agent profiles under `.github/agents/*.agent.md`, with Codex kept on `/slo-critique` and `/slo-verify`.

## Test plan

- [x] `cargo test -p sldo-install --test e2e_agent_operating_contract`
- [x] `cargo test -p sldo-install --test e2e_agent_host_m2 --test e2e_agent_host_m3 --test e2e_agent_host_m5`
- [x] `cargo test -p sast-verify --test sap_imp_m5_agents`
- [x] `cargo clippy -p sldo-install --test e2e_agent_operating_contract -- -D warnings`
- [x] `cargo test -p sldo-common -p sldo-install -p sldo-research`
- [ ] Reviewer: read `docs/RUNBOOK-AGENT-OPERATING-CONTRACT.md` and completion summaries.
- [ ] Reviewer: verify tracker is fully `done`.

Known non-blocking: `cargo fmt --all -- --check` remains blocked by pre-existing unrelated rustfmt drift outside this runbook's allow-list.

## Deferred follow-ups

- Live GitHub Copilot profile discovery smoke testing can be added after the branch is merged to the default branch.
- Any installer support for official host-native skill roots remains a separate explicit runbook.

## Security Summary

| Field | Value |
|---|---|
| Date | `2026-05-19` |
| Target | `agent-operating-contract` runbook and host-facing agent/profile files |
| Scope | Markdown overlays, Copilot profile files, capability docs, and structural tests |
| Out of scope | Live GitHub Copilot cloud-agent execution, installer migration, Codex custom-agent profile parity |
| Skills / tools used | `/slo-plan`, `/slo-critique`, `/slo-execute`, `/slo-verify`, `/slo-retro`, `/slo-ship`, Cargo tests, scoped clippy |

### Executive summary

The new public surface is limited to host instruction/profile Markdown files and structural tests. No executable runtime harness, installer path migration, dependency, secret, workflow, or network-facing surface is introduced.

### Findings summary

| ID | Severity | Confidence | Title | Location | Threat row | CWE / standard | Status |
|---|---|---|---|---|---|---|---|
| N/A | N/A | N/A | No security findings found in M2/M3 verification | `docs/slo/verify/agent-operating-contract-m2.md`, `docs/slo/verify/agent-operating-contract-m3.md` | N/A | N/A | N/A |

### Coverage gaps

| Gap | Reason | Follow-up |
|---|---|---|
| Live Copilot custom-agent execution not exercised | No deterministic local CI-safe Copilot cloud-agent runner is available | Add a future smoke after merge if GitHub exposes a safe runner or manual profile discovery check |
| Global formatter remains red | Pre-existing unrelated rustfmt drift outside this runbook allow-list | Separate formatting cleanup ticket/runbook |

🤖 Generated with /slo-ship