### PR TITLE
chore(fmt): clean up workspace rustfmt drift across 13 test files

### DIFF
--- a/crates/sldo-install/tests/e2e_biz_imp_m1.rs
+++ b/crates/sldo-install/tests/e2e_biz_imp_m1.rs
@@ -133,7 +133,9 @@ fn hmrc_vcm_index_verbatim() {
         "hmrc-vcm-index.md must have quoted_text blocks for VCM34080, VCM3000, VCM31000, and Abingdon Health"
     );
     assert!(
-        body.contains("https://www.gov.uk/hmrc-internal-manuals/venture-capital-schemes-manual/vcm34080"),
+        body.contains(
+            "https://www.gov.uk/hmrc-internal-manuals/venture-capital-schemes-manual/vcm34080"
+        ),
         "hmrc-vcm-index.md must cite VCM34080 gov.uk URL"
     );
 }

--- a/crates/sldo-install/tests/e2e_biz_imp_m2.rs
+++ b/crates/sldo-install/tests/e2e_biz_imp_m2.rs
@@ -71,7 +71,9 @@ fn five_intake_contracts_exist_with_conversational_framing() {
             body.contains("## Restate-and-confirm step"),
             "{rel} must define a restate-and-confirm step"
         );
-        for field in ["### F1.", "### F2.", "### F3.", "### F4.", "### F5.", "### F6."] {
+        for field in [
+            "### F1.", "### F2.", "### F3.", "### F4.", "### F5.", "### F6.",
+        ] {
             assert!(body.contains(field), "{rel} missing required field {field}");
         }
         for forbidden in [
@@ -156,7 +158,9 @@ fn every_advisor_skill_md_cites_m1_authority_files() {
             "{rel} must cite the closed regulator enum"
         );
         assert!(
-            authority_refs.iter().any(|authority| body.contains(authority)),
+            authority_refs
+                .iter()
+                .any(|authority| body.contains(authority)),
             "{rel} must cite at least one source-verified M1 authority file"
         );
     }
@@ -170,7 +174,8 @@ fn legal_intake_form_renamed() {
         "legal-intake-form.md must be renamed, not left as a duplicate"
     );
     assert!(
-        root.join("references/biz/legal-intake-contract.md").exists(),
+        root.join("references/biz/legal-intake-contract.md")
+            .exists(),
         "legal-intake-contract.md must exist after rename"
     );
 }

--- a/crates/sldo-install/tests/e2e_cloud_threat_model_m1.rs
+++ b/crates/sldo-install/tests/e2e_cloud_threat_model_m1.rs
@@ -160,7 +160,11 @@ fn scenario_catalog_covers_aws_github_and_cloudflare() {
     let on_disk: std::collections::BTreeSet<String> = fs::read_dir(&scenarios)
         .expect("scenarios dir missing")
         .filter_map(|e| e.ok())
-        .filter_map(|e| e.path().file_stem().map(|s| s.to_string_lossy().into_owned()))
+        .filter_map(|e| {
+            e.path()
+                .file_stem()
+                .map(|s| s.to_string_lossy().into_owned())
+        })
         .collect();
     let declared: std::collections::BTreeSet<String> =
         SCENARIO_ORDER.iter().map(|s| s.to_string()).collect();
@@ -213,14 +217,23 @@ fn citation_map_stays_in_sync_between_doc_and_script() {
         "SOC2-TSC-2017",
         "Hulumi-Policy",
     ] {
-        assert!(doc.contains(framework), "doc missing framework `{framework}`");
+        assert!(
+            doc.contains(framework),
+            "doc missing framework `{framework}`"
+        );
         assert!(
             script.contains(framework),
             "script missing framework `{framework}`"
         );
     }
     // Hulumi policy rule IDs are cited as bare IDs (framework Hulumi-Policy).
-    for rule in ["CF_DNS_1", "CF_DNSSEC_1", "CF_ORIGIN_1", "X_ORIGIN_1", "G_OIDC_1"] {
+    for rule in [
+        "CF_DNS_1",
+        "CF_DNSSEC_1",
+        "CF_ORIGIN_1",
+        "X_ORIGIN_1",
+        "G_OIDC_1",
+    ] {
         assert!(script.contains(rule), "script missing rule `{rule}`");
         assert!(doc.contains(rule), "doc missing rule `{rule}`");
     }
@@ -260,7 +273,8 @@ fn registered_in_skill_pack_catalog() {
 fn skill_md_does_not_link_to_examples() {
     let body = read(skill_path().join("SKILL.md"));
     assert!(
-        !body.contains("](examples/") && !body.contains("](../examples/")
+        !body.contains("](examples/")
+            && !body.contains("](../examples/")
             && !body.contains("](../../examples/"),
         "SKILL.md must not link into examples/"
     );

--- a/crates/sldo-install/tests/e2e_sec_exec_m1.rs
+++ b/crates/sldo-install/tests/e2e_sec_exec_m1.rs
@@ -60,7 +60,8 @@ fn secure_construction_reference_exists_with_gap_routing() {
 
 #[test]
 fn secure_construction_reference_blocks_silent_hand_rolled_security() {
-    let body = read(repo_root().join("skills/slo-execute/references/secure-construction-preflight.md"));
+    let body =
+        read(repo_root().join("skills/slo-execute/references/secure-construction-preflight.md"));
     for needle in [
         "hand-rolled crypto",
         "hand-rolled auth",
@@ -72,4 +73,3 @@ fn secure_construction_reference_blocks_silent_hand_rolled_security() {
         assert!(body.contains(needle), "missing guardrail `{needle}`");
     }
 }
-

--- a/crates/sldo-install/tests/e2e_sec_exec_m2.rs
+++ b/crates/sldo-install/tests/e2e_sec_exec_m2.rs
@@ -46,7 +46,8 @@ fn secure_construction_matrix_covers_core_surfaces() {
 
 #[test]
 fn vocabulary_distinguishes_hulumi_from_generic_pulumi() {
-    let vocab = read(repo_root().join("skills/slo-plan/references/proactive-controls-vocabulary.md"));
+    let vocab =
+        read(repo_root().join("skills/slo-plan/references/proactive-controls-vocabulary.md"));
     for needle in [
         "Hulumi explicit",
         "Generic Pulumi TypeScript",
@@ -60,7 +61,8 @@ fn vocabulary_distinguishes_hulumi_from_generic_pulumi() {
 
 #[test]
 fn typescript_and_java_fallback_forbids_model_memory_claims() {
-    let vocab = read(repo_root().join("skills/slo-plan/references/proactive-controls-vocabulary.md"));
+    let vocab =
+        read(repo_root().join("skills/slo-plan/references/proactive-controls-vocabulary.md"));
     for needle in [
         "TypeScript / Java fallback",
         "do not invent library capability claims",
@@ -70,4 +72,3 @@ fn typescript_and_java_fallback_forbids_model_memory_claims() {
         assert!(vocab.contains(needle), "fallback missing `{needle}`");
     }
 }
-

--- a/crates/sldo-install/tests/e2e_sec_exec_m3.rs
+++ b/crates/sldo-install/tests/e2e_sec_exec_m3.rs
@@ -35,7 +35,12 @@ fn pass4_dast_guidance_converges_on_zaprun() {
     assert!(commands.contains("/slo-dast-tuner"));
     assert!(commands.contains("unauthenticated") && commands.contains("coverage failure"));
 
-    for forbidden in ["zap-api-scan.py", "zap-baseline.py", "zap-full-scan.py", "dastardly:latest"] {
+    for forbidden in [
+        "zap-api-scan.py",
+        "zap-baseline.py",
+        "zap-full-scan.py",
+        "dastardly:latest",
+    ] {
         assert!(
             !commands.contains(forbidden),
             "Pass 4 must not teach direct `{forbidden}` DAST invocation"
@@ -49,4 +54,3 @@ fn dast_tuner_cross_links_verify_selector() {
     assert!(skill.contains("Security-test selector"));
     assert!(skill.contains("skills/slo-verify/references/security-pass-commands.md"));
 }
-

--- a/crates/sldo-install/tests/e2e_sec_exec_m4.rs
+++ b/crates/sldo-install/tests/e2e_sec_exec_m4.rs
@@ -21,7 +21,8 @@ fn read(path: impl AsRef<Path>) -> String {
 
 #[test]
 fn cloud_iac_reference_exists_with_hulumi_and_pulumi_rules() {
-    let body = read(repo_root().join("skills/slo-execute/references/cloud-iac-secure-construction.md"));
+    let body =
+        read(repo_root().join("skills/slo-execute/references/cloud-iac-secure-construction.md"));
     for needle in [
         "Pulumi TypeScript",
         "Hulumi explicit or detected",
@@ -33,7 +34,10 @@ fn cloud_iac_reference_exists_with_hulumi_and_pulumi_rules() {
         "preview evidence",
         "drift evidence",
     ] {
-        assert!(body.contains(needle), "cloud-IaC reference missing `{needle}`");
+        assert!(
+            body.contains(needle),
+            "cloud-IaC reference missing `{needle}`"
+        );
     }
 }
 
@@ -48,7 +52,9 @@ fn cloud_threat_model_hands_off_to_secure_iac_lane() {
 fn secure_construction_matrix_covers_cloud_platforms() {
     let matrix = read(repo_root().join("skills/slo-plan/references/secure-construction-matrix.md"));
     for needle in ["AWS", "GitHub", "Cloudflare", "OIDC", "SecureBucket"] {
-        assert!(matrix.contains(needle), "matrix missing cloud/platform `{needle}`");
+        assert!(
+            matrix.contains(needle),
+            "matrix missing cloud/platform `{needle}`"
+        );
     }
 }
-

--- a/crates/sldo-install/tests/e2e_sec_exec_m5.rs
+++ b/crates/sldo-install/tests/e2e_sec_exec_m5.rs
@@ -56,4 +56,3 @@ fn loops_doc_mentions_secure_construction_loop() {
     assert!(loops.contains("/slo-execute"));
     assert!(loops.contains("/slo-sec-libs"));
 }
-

--- a/crates/sldo-install/tests/e2e_sec_libs_m1.rs
+++ b/crates/sldo-install/tests/e2e_sec_libs_m1.rs
@@ -141,7 +141,9 @@ fn schema_url_and_sha_are_captured() {
     assert!(script.contains("https://cyclonedx.org/schema/bom-1.6.schema.json"));
     assert!(methodology.contains("https://cyclonedx.org/schema/bom-1.6.schema.json"));
     assert!(script.contains("1ebcb88a2c845ecb6ff7bee7aeabdff9422cb0347f3d6875b241bd444b7e098f"));
-    assert!(methodology.contains("1ebcb88a2c845ecb6ff7bee7aeabdff9422cb0347f3d6875b241bd444b7e098f"));
+    assert!(
+        methodology.contains("1ebcb88a2c845ecb6ff7bee7aeabdff9422cb0347f3d6875b241bd444b7e098f")
+    );
 }
 
 #[test]

--- a/xtasks/sast-verify/tests/sap_imp_m2_examples.rs
+++ b/xtasks/sast-verify/tests/sap_imp_m2_examples.rs
@@ -349,11 +349,7 @@ fn every_abbreviates_ref_resolves() {
         };
 
         // Resolution rule (a): walk skills/<name>/SKILL.md for matching frontmatter `name`.
-        let resolves_via_skill_name = root
-            .join("skills")
-            .join(&abbr)
-            .join("SKILL.md")
-            .exists();
+        let resolves_via_skill_name = root.join("skills").join(&abbr).join("SKILL.md").exists();
 
         // Resolution rule (b): treat as filesystem path.
         let resolves_via_path = root.join(&abbr).exists();

--- a/xtasks/sast-verify/tests/sap_imp_m3_standards.rs
+++ b/xtasks/sast-verify/tests/sap_imp_m3_standards.rs
@@ -141,7 +141,8 @@ fn stale_rows_warned() {
 
     for (line_num, _line, date) in &rows {
         if let Ok(d) = NaiveDate::parse_from_str(date, "%Y-%m-%d") {
-            let months_old = ((now.year() - d.year()) * 12) + (now.month() as i32 - d.month() as i32);
+            let months_old =
+                ((now.year() - d.year()) * 12) + (now.month() as i32 - d.month() as i32);
             if months_old > 12 {
                 eprintln!(
                     "WARNING: standards-mapping.md row at line {} has stale retrieval-date {} ({} months old); consider re-fetching",
@@ -162,7 +163,9 @@ fn four_skills_cite_standards_mapping() {
         let skill_md = root.join("skills").join(skill).join("SKILL.md");
         let markdown = read(&skill_md);
         let links = extract_link_destinations(&markdown);
-        let cites = links.iter().any(|d| d.ends_with(target) || d.contains(target));
+        let cites = links
+            .iter()
+            .any(|d| d.ends_with(target) || d.contains(target));
         if !cites {
             failures.push(format!(
                 "skills/{}/SKILL.md does not link to references/security/standards-mapping.md",

--- a/xtasks/sast-verify/tests/sap_imp_m4_workflow_pinning.rs
+++ b/xtasks/sast-verify/tests/sap_imp_m4_workflow_pinning.rs
@@ -154,7 +154,10 @@ fn host_capability_matrix_exists_with_decision() {
     let has_decision = content.contains("`green-lit`")
         || content.contains("`not green-lit`")
         || content.contains("`deferred`");
-    assert!(has_decision, "decision row missing — must contain `green-lit` / `not green-lit` / `deferred`");
+    assert!(
+        has_decision,
+        "decision row missing — must contain `green-lit` / `not green-lit` / `deferred`"
+    );
 }
 
 #[test]
@@ -184,10 +187,7 @@ fn walk_json_for_paths(v: &JsonValue, ptr: &str, violations: &mut Vec<String>) {
             // Any string containing `..` segments or starting with `/`, `\`,
             // `.claude-plugin/skills/` is suspect.
             if s.split(['/', '\\']).any(|seg| seg == "..") {
-                violations.push(format!(
-                    "{} contains `..` traversal segment (`{}`)",
-                    ptr, s
-                ));
+                violations.push(format!("{} contains `..` traversal segment (`{}`)", ptr, s));
             }
             if Path::new(s).is_absolute() {
                 violations.push(format!("{} is absolute (`{}`)", ptr, s));
@@ -223,7 +223,8 @@ fn release_workflow_trigger_in_acceptable_set() {
 
     // Acceptable triggers: tags:, release:, workflow_dispatch:, schedule:.
     // Forbidden: push: with default branches, pull_request:.
-    let has_tags = content.contains("tags:") || content.contains("- 'v*'") || content.contains("v*");
+    let has_tags =
+        content.contains("tags:") || content.contains("- 'v*'") || content.contains("v*");
     let has_release = content.contains("release:");
     let has_dispatch = content.contains("workflow_dispatch:");
     let has_schedule = content.contains("schedule:");

--- a/xtasks/sast-verify/tests/sap_imp_m5_agents.rs
+++ b/xtasks/sast-verify/tests/sap_imp_m5_agents.rs
@@ -149,7 +149,13 @@ fn every_agent_has_required_frontmatter() {
                 continue;
             }
         };
-        for required in &["name", "role", "output-paths", "copilot-fallback", "host-required"] {
+        for required in &[
+            "name",
+            "role",
+            "output-paths",
+            "copilot-fallback",
+            "host-required",
+        ] {
             if !map.contains_key(serde_yaml_ng::Value::String((*required).into())) {
                 failures.push(format!(
                     "agents/{}.md frontmatter missing field `{}`",
@@ -197,7 +203,10 @@ fn every_output_path_in_allowed_set() {
         }
         for p in paths {
             let Some(s) = p.as_str() else {
-                failures.push(format!("agents/{}.md `output-paths` entry is not a string", name));
+                failures.push(format!(
+                    "agents/{}.md `output-paths` entry is not a string",
+                    name
+                ));
                 continue;
             };
             // Path traversal / absolute-path rejection (F-SEC-6).
@@ -209,7 +218,10 @@ fn every_output_path_in_allowed_set() {
                 ));
                 continue;
             }
-            if path_obj.components().any(|c| matches!(c, Component::ParentDir)) {
+            if path_obj
+                .components()
+                .any(|c| matches!(c, Component::ParentDir))
+            {
                 failures.push(format!(
                     "agents/{}.md output-path `{}` contains `..` traversal segment (per F-SEC-6)",
                     name, s
@@ -217,7 +229,9 @@ fn every_output_path_in_allowed_set() {
                 continue;
             }
             // Prefix membership.
-            let in_set = ALLOWED_OUTPUT_PATH_PREFIXES.iter().any(|prefix| s.starts_with(prefix));
+            let in_set = ALLOWED_OUTPUT_PATH_PREFIXES
+                .iter()
+                .any(|prefix| s.starts_with(prefix));
             if !in_set {
                 failures.push(format!(
                     "agents/{}.md output-path `{}` not in allowed prefix set {:?}",
@@ -303,8 +317,8 @@ fn agent_file_under_line_cap() {
 #[test]
 fn slo_critique_skill_md_unchanged() {
     let path = workspace_root().join("skills/slo-critique/SKILL.md");
-    let bytes = std::fs::read(&path)
-        .unwrap_or_else(|e| panic!("failed to read {}: {}", path.display(), e));
+    let bytes =
+        std::fs::read(&path).unwrap_or_else(|e| panic!("failed to read {}: {}", path.display(), e));
     let mut hasher = Sha256::new();
     hasher.update(&bytes);
     let hash = hasher.finalize();


### PR DESCRIPTION
## Summary

- Applies the diff that `cargo fmt --all` already produces against main today, across 13 test files.
- Pure formatting cleanup — no behavioral changes, no source-code (non-test) edits.

## Why

Workspace-wide `cargo fmt --all -- --check` was failing on main due to accumulated drift. Surfaced during ticket-92's verification ([PR #93](https://github.com/kerberosmansour/SunLitOrchestra/pull/93)), where I deliberately did NOT carry the unrelated fmt-fixes into that ticket so the diff stayed inside the ticket's allow-list. This is the standalone hygiene PR that lands them properly.

## Scope

Test files only:

- `crates/sldo-install/tests/e2e_biz_imp_m1.rs`
- `crates/sldo-install/tests/e2e_biz_imp_m2.rs`
- `crates/sldo-install/tests/e2e_cloud_threat_model_m1.rs`
- `crates/sldo-install/tests/e2e_sec_exec_m1.rs` through `_m5.rs`
- `crates/sldo-install/tests/e2e_sec_libs_m1.rs`
- `xtasks/sast-verify/tests/sap_imp_m2_examples.rs`
- `xtasks/sast-verify/tests/sap_imp_m3_standards.rs`
- `xtasks/sast-verify/tests/sap_imp_m4_workflow_pinning.rs`
- `xtasks/sast-verify/tests/sap_imp_m5_agents.rs`

No production code touched.

## Test plan

- [x] `cargo fmt --all -- --check` — clean post-edit (was failing pre-edit).
- [x] `cargo test -p sldo-common -p sldo-install -p sldo-research -p sast-verify` — all suites green; identical pass counts to main.
- [x] Diff inspection confirms only whitespace / line-break changes (no logic edits).

## Out of scope

- `sast-verify` bin dead-code clippy noise on the `Rule` struct's `fix_regex`, `options`, `paths` fields — separate cleanup if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)