### PR TITLE
fix(sca): update vendored brain bundle (triage entry-guard fix)

### DIFF
--- a/tools/sca/VENDOR.md
+++ b/tools/sca/VENDOR.md
@@ -23,7 +23,7 @@ Rust tree. The Rust supply-chain scanners find no npm manifest to parse.
 ## Provenance
 
 - Source repo: `kerberosmansour/AutomoatedSCA`
-- Source commit: `267d35924702f03354137755102a6fa9895ca15b`
+- Source commit: `6e8528121b0b1d3e853d561f87c24c37abd90eca`
 - Bundler: `esbuild --bundle --platform=node --format=esm --target=node20`
 
 ## Regenerate

--- a/tools/sca/dist/triage.mjs
+++ b/tools/sca/dist/triage.mjs
@@ -14807,6 +14807,15 @@ var defaultEnrichments = {
     cvss: 9.8,
     epssScore: 0.2,
     present: true
+  },
+  // Seed for the crates.io (Cargo) review-loop drill: a synthetic emergency
+  // with a fix available, mirroring PYSEC-2010-12 for the PyPI drill.
+  "RUSTSEC-2020-0071": {
+    fixedVersion: "0.2.25",
+    severityClass: "critical",
+    cvss: 9.8,
+    epssScore: 0.5,
+    present: true
   }
 };
 var triage = async (findings, options = {}) => {
@@ -14975,7 +14984,7 @@ async function writeJson(path, value) {
   await writeFile2(path, `${JSON.stringify(value, null, 2)}
 `);
 }
-if (process.argv[1]?.endsWith("triage.ts")) {
+if (import.meta.url === `file://${process.argv[1]}`) {
   main().catch((error51) => {
     const message = error51 instanceof external_exports.ZodError ? error51.message : error51 instanceof Error ? error51.message : String(error51);
     process.stderr.write(`${message}


### PR DESCRIPTION
Re-vendors the bundled brain from AutomoatedSCA @`6e8528121b0b1d3e853d561f87c24c37abd90eca` — fixes the `triage.mjs` entry guard that no-opped the Track A loop. Drill re-run after merge.