### PR TITLE
finops: run sca-emergency twice daily instead of */15 (refs #111)

### DIFF
--- a/.github/workflows/sca-emergency.yml
+++ b/.github/workflows/sca-emergency.yml
@@ -2,7 +2,11 @@ name: sca-emergency
 
 on:
   schedule:
-    - cron: "*/15 * * * *"
+    # Twice daily (00:00 and 12:00 UTC). Reduced from every-15-min (*/15),
+    # which was ~2,900 runs/mo and the single largest GitHub Actions cost
+    # across the SunLit repos (~$186/mo). Use workflow_dispatch for an
+    # on-demand emergency scan between scheduled runs.
+    - cron: "0 0,12 * * *"
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary
Changes the `sca-emergency` schedule from `*/15 * * * *` (every 15 min) to `0 0,12 * * *` (twice daily, 00:00 + 12:00 UTC). This was the largest single GitHub Actions cost across the SunLit repos.

## Cost impact
| | Runs/mo | Minutes/mo | Est. cost |
|---|---|---|---|
| `*/15` (before) | ~2,900 | ~48,000 | ~$186/mo |
| twice daily (after) | ~61 | ~1,000 | ~$0–6/mo (within Pro free allotment) |

~**$180/mo** saving on this line.

## ⚠️ Security trade-off (please weigh)
This is `sca-emergency` — scheduled **detection latency rises from ~15 min to up to ~12h**. `workflow_dispatch` is retained, so an on-demand emergency scan can still be triggered manually at any time. If faster scheduled response is wanted, `0 */4 * * *` (every 4h) or `0 * * * *` (hourly, ~$45/mo) are middle grounds. A more surgical option is to keep a cheap frequent check and only run the heavy `cargo build` + review loop when there's an actual finding.

## Note
This is an **SCA-automation surface**. Opened at the founder's explicit request; **not merged** — left for the SCA owner / founder to review and merge.

Refs #111